### PR TITLE
Use e2e-test bind ports below 30000 to avoid conflicts

### DIFF
--- a/test/e2e-tests/data-regional/crm_info.yml
+++ b/test/e2e-tests/data-regional/crm_info.yml
@@ -92,7 +92,7 @@ cloudlets:
   deployment: docker
   trustpolicystate: NotPresent
   defaultresourcealertthreshold: 80
-  hostcontroller: 127.0.0.1:55001
+  hostcontroller: 127.0.0.1:5501
   secondarynotifysrvaddr: 127.0.0.1:0
   dnslabel: dmuus-cloud-1-dmuus
   rootlbfqdn: shared.dmuus-cloud-1-dmuus.local.localtest.net
@@ -113,7 +113,7 @@ cloudlets:
   deployment: docker
   trustpolicystate: NotPresent
   defaultresourcealertthreshold: 80
-  hostcontroller: 127.0.0.1:55001
+  hostcontroller: 127.0.0.1:5501
   secondarynotifysrvaddr: 127.0.0.1:0
   dnslabel: dmuus-cloud-2-dmuus
   rootlbfqdn: shared.dmuus-cloud-2-dmuus.local.localtest.net

--- a/test/e2e-tests/data/federation_init_data_partner1.yml
+++ b/test/e2e-tests/data/federation_init_data_partner1.yml
@@ -14,8 +14,8 @@
 
 controllers:
 - region: PA
-  address: 127.0.0.1:55081
-  notifyaddr: 127.0.0.1:37081
+  address: 127.0.0.1:5581
+  notifyaddr: 127.0.0.1:27081
   dnsregion: pa
 orgs:
 - name: partner1

--- a/test/e2e-tests/data/federation_init_data_partner2.yml
+++ b/test/e2e-tests/data/federation_init_data_partner2.yml
@@ -14,8 +14,8 @@
 
 controllers:
 - region: PS
-  address: 127.0.0.1:55091
-  notifyaddr: 127.0.0.1:37091
+  address: 127.0.0.1:5591
+  notifyaddr: 127.0.0.1:27091
   dnsregion: ps
 orgs:
 - name: partner2

--- a/test/e2e-tests/data/federation_show_partner1.yml
+++ b/test/e2e-tests/data/federation_show_partner1.yml
@@ -14,8 +14,8 @@
 
 controllers:
 - region: PA
-  address: 127.0.0.1:55081
-  notifyaddr: 127.0.0.1:37081
+  address: 127.0.0.1:5581
+  notifyaddr: 127.0.0.1:27081
   dnsregion: pa
 orgs:
 - name: partner1

--- a/test/e2e-tests/data/federation_show_partner2.yml
+++ b/test/e2e-tests/data/federation_show_partner2.yml
@@ -14,8 +14,8 @@
 
 controllers:
 - region: PS
-  address: 127.0.0.1:55091
-  notifyaddr: 127.0.0.1:37091
+  address: 127.0.0.1:5591
+  notifyaddr: 127.0.0.1:27091
   dnsregion: ps
 orgs:
 - name: partner2

--- a/test/e2e-tests/data/kind_user1_data_show.yml
+++ b/test/e2e-tests/data/kind_user1_data_show.yml
@@ -14,14 +14,14 @@
 
 controllers:
 - region: local
-  address: 127.0.0.1:55001
-  notifyaddr: 127.0.0.1:37001
+  address: 127.0.0.1:5501
+  notifyaddr: 127.0.0.1:27001
   influxdb: http://127.0.0.1:8086
   thanosmetrics: http://127.0.0.1:29090
   dnsregion: local
 - region: locala
-  address: 127.0.0.1:55011
-  notifyaddr: 127.0.0.1:37011
+  address: 127.0.0.1:5511
+  notifyaddr: 127.0.0.1:27011
   influxdb: http://127.0.0.1:8087
   dnsregion: locala
 orgs:

--- a/test/e2e-tests/data/kind_user2_data_show.yml
+++ b/test/e2e-tests/data/kind_user2_data_show.yml
@@ -14,14 +14,14 @@
 
 controllers:
 - region: local
-  address: 127.0.0.1:55001
-  notifyaddr: 127.0.0.1:37001
+  address: 127.0.0.1:5501
+  notifyaddr: 127.0.0.1:27001
   influxdb: http://127.0.0.1:8086
   thanosmetrics: http://127.0.0.1:29090
   dnsregion: local
 - region: locala
-  address: 127.0.0.1:55011
-  notifyaddr: 127.0.0.1:37011
+  address: 127.0.0.1:5511
+  notifyaddr: 127.0.0.1:27011
   influxdb: http://127.0.0.1:8087
   dnsregion: locala
 billingorgs:

--- a/test/e2e-tests/data/kind_user3_data_show.yml
+++ b/test/e2e-tests/data/kind_user3_data_show.yml
@@ -14,14 +14,14 @@
 
 controllers:
 - region: local
-  address: 127.0.0.1:55001
-  notifyaddr: 127.0.0.1:37001
+  address: 127.0.0.1:5501
+  notifyaddr: 127.0.0.1:27001
   influxdb: http://127.0.0.1:8086
   thanosmetrics: http://127.0.0.1:29090
   dnsregion: local
 - region: locala
-  address: 127.0.0.1:55011
-  notifyaddr: 127.0.0.1:37011
+  address: 127.0.0.1:5511
+  notifyaddr: 127.0.0.1:27011
   influxdb: http://127.0.0.1:8087
   dnsregion: locala
 billingorgs:

--- a/test/e2e-tests/data/mc_admin_all_data_show.yml
+++ b/test/e2e-tests/data/mc_admin_all_data_show.yml
@@ -14,14 +14,14 @@
 
 controllers:
 - region: local
-  address: 127.0.0.1:55001
-  notifyaddr: 127.0.0.1:37001
+  address: 127.0.0.1:5501
+  notifyaddr: 127.0.0.1:27001
   influxdb: http://127.0.0.1:8086
   thanosmetrics: http://127.0.0.1:29090
   dnsregion: local
 - region: locala
-  address: 127.0.0.1:55011
-  notifyaddr: 127.0.0.1:37011
+  address: 127.0.0.1:5511
+  notifyaddr: 127.0.0.1:27011
   influxdb: http://127.0.0.1:8087
   dnsregion: locala
 billingorgs:

--- a/test/e2e-tests/data/mc_admin_data.yml
+++ b/test/e2e-tests/data/mc_admin_data.yml
@@ -14,14 +14,14 @@
 
 controllers:
 - region: local
-  address: 127.0.0.1:55001
-  notifyaddr: 127.0.0.1:37001
+  address: 127.0.0.1:5501
+  notifyaddr: 127.0.0.1:27001
   influxdb: http://127.0.0.1:8086
   dnsregion: local
   thanosmetrics: http://127.0.0.1:29090
 - region: locala
-  address: 127.0.0.1:55011
-  notifyaddr: 127.0.0.1:37011
+  address: 127.0.0.1:5511
+  notifyaddr: 127.0.0.1:27011
   influxdb: http://127.0.0.1:8087
   dnsregion: locala
 billingorgs:

--- a/test/e2e-tests/data/mc_admin_data_chef.yml
+++ b/test/e2e-tests/data/mc_admin_data_chef.yml
@@ -21,7 +21,7 @@ orgs:
 
 controllers:
 - region: local
-  address: "127.0.0.1:55001"
+  address: "127.0.0.1:5501"
 
 regiondata:
 - region: local

--- a/test/e2e-tests/data/mc_admin_data_edgebox.yml
+++ b/test/e2e-tests/data/mc_admin_data_edgebox.yml
@@ -21,8 +21,8 @@ orgs:
 
 controllers:
 - region: local
-  address: "127.0.0.1:55001"
-  notifyaddr: "127.0.0.1:37001"
+  address: "127.0.0.1:5501"
+  notifyaddr: "127.0.0.1:27001"
   influxdb: "http://127.0.0.1:8086"
 
 regiondata:

--- a/test/e2e-tests/data/mc_admin_data_show.yml
+++ b/test/e2e-tests/data/mc_admin_data_show.yml
@@ -14,14 +14,14 @@
 
 controllers:
 - region: local
-  address: 127.0.0.1:55001
-  notifyaddr: 127.0.0.1:37001
+  address: 127.0.0.1:5501
+  notifyaddr: 127.0.0.1:27001
   influxdb: http://127.0.0.1:8086
   thanosmetrics: http://127.0.0.1:29090
   dnsregion: local
 - region: locala
-  address: 127.0.0.1:55011
-  notifyaddr: 127.0.0.1:37011
+  address: 127.0.0.1:5511
+  notifyaddr: 127.0.0.1:27011
   influxdb: http://127.0.0.1:8087
   dnsregion: locala
 billingorgs:

--- a/test/e2e-tests/data/mc_admin_show.yml
+++ b/test/e2e-tests/data/mc_admin_show.yml
@@ -14,7 +14,7 @@
 
 controllers:
 - region: local
-  address: 127.0.0.1:55001
+  address: 127.0.0.1:5501
   influxdb: http://127.0.0.1:8086
   thanosmetrics: http://127.0.0.1:29090
   createdat: 2019-11-20T15:21:55.068829-08:00

--- a/test/e2e-tests/data/mc_cloudlets_flavors.yml
+++ b/test/e2e-tests/data/mc_cloudlets_flavors.yml
@@ -14,7 +14,7 @@
 
 controllers:
 - region: local
-  address: 127.0.0.1:55001
+  address: 127.0.0.1:5501
   influxdb: http://127.0.0.1:8086
   thanosmetrics: http://127.0.0.1:29090
 regiondata:

--- a/test/e2e-tests/data/mc_user1_chef_data_show.yml
+++ b/test/e2e-tests/data/mc_user1_chef_data_show.yml
@@ -14,7 +14,7 @@
 
 controllers:
 - region: local
-  address: 127.0.0.1:55001
+  address: 127.0.0.1:5501
 orgs:
 - name: mexdev
   type: operator

--- a/test/e2e-tests/data/mc_user2_chef_data_show.yml
+++ b/test/e2e-tests/data/mc_user2_chef_data_show.yml
@@ -14,7 +14,7 @@
 
 controllers:
 - region: local
-  address: 127.0.0.1:55001
+  address: 127.0.0.1:5501
   dnsregion: local
 orgs:
 - name: DevOrg

--- a/test/e2e-tests/data/undeploy_alerts_show.yml
+++ b/test/e2e-tests/data/undeploy_alerts_show.yml
@@ -28,4 +28,4 @@
     seconds: 1594945144
     nanos: 494892341
   notifyid: 2
-  controller: Jon-Mex@127.0.0.1:55001
+  controller: Jon-Mex@127.0.0.1:5501

--- a/test/e2e-tests/pkg/chef/chefclient1.yml
+++ b/test/e2e-tests/pkg/chef/chefclient1.yml
@@ -44,7 +44,7 @@ jsonattrs: |
         "cloudletKey": "{\"organization\":\"mexdev\",\"name\":\"chef-test-1\"}",
         "d": "api,infra,notify,info",
         "deploymentTag": "local",
-        "notifyAddrs": "127.0.0.1:37001",
+        "notifyAddrs": "127.0.0.1:27001",
         "notifySrvAddr": "127.0.0.1:51099",
         "platform": "PLATFORM_TYPE_FAKEINFRA",
         "region": "local",
@@ -56,7 +56,7 @@ jsonattrs: |
         "VAULT_SECRET_ID=removed"
       ]
     },
-    "notifyAddrs": "127.0.0.1:37001",
+    "notifyAddrs": "127.0.0.1:27001",
     "prometheusImage": "prom/prometheus",
     "prometheusVersion": "latest",
     "shepherd": {

--- a/test/e2e-tests/setups-regional/local.yml
+++ b/test/e2e-tests/setups-regional/local.yml
@@ -61,13 +61,13 @@ controllers:
   etcdaddrs: "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003"
   apiaddr: "0.0.0.0:55001"
   httpaddr: "0.0.0.0:36001"
-  notifyaddr: "127.0.0.1:37001"
+  notifyaddr: "127.0.0.1:27001"
   hostname: "127.0.0.1"
 
 dmes:
 - name: dme1
   apiaddr: "0.0.0.0:50051"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   locverurl: "{{locverurl}}"
   toksrvurl: "{{toksrvurl}}"
   carrier: GDDT
@@ -78,7 +78,7 @@ dmes:
 crms:
 - name: crm1
   apiaddr: "0.0.0.0:55091"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"operator_key":{"name":"dmuus"},"name":"tmocloud-1"}'
   hostname: "127.0.0.1"
 

--- a/test/e2e-tests/setups-regional/local_dind.yml
+++ b/test/e2e-tests/setups-regional/local_dind.yml
@@ -72,7 +72,7 @@ controllers:
   etcdaddrs: "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003"
   apiaddr: "0.0.0.0:55001"
   httpaddr: "0.0.0.0:36001"
-  notifyaddr: "127.0.0.1:37001"
+  notifyaddr: "127.0.0.1:27001"
   influxaddr: "https://127.0.0.1:8086"
   vaultaddr: "http://127.0.0.1:8200"
   redisstandaloneaddr: "127.0.0.1:6379"
@@ -91,7 +91,7 @@ dmes:
 - name: dme1
   apiaddr: "0.0.0.0:50051"
   httpaddr: "0.0.0.0:38001"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   locverurl: "{{locverurl}}"
   toksrvurl: "{{toksrvurl}}"
   carrier: GDDT
@@ -109,8 +109,8 @@ dmes:
 
 clustersvcs:
 - name: cluster-svc1
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
-  ctrladdrs: "127.0.0.1:55001"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
+  ctrladdrs: "127.0.0.1:5501"
   vaultaddr: "http://127.0.0.1:8200"
   usevaultcerts: true
   tls:

--- a/test/e2e-tests/setups-regional/local_multi.yml
+++ b/test/e2e-tests/setups-regional/local_multi.yml
@@ -58,9 +58,9 @@ etcds:
 controllers:
 - name: ctrl1
   etcdaddrs: "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003"
-  apiaddr: "127.0.0.1:55001"
+  apiaddr: "127.0.0.1:5501"
   httpaddr: "0.0.0.0:36001"
-  notifyaddr: "127.0.0.1:37001"
+  notifyaddr: "127.0.0.1:27001"
   vaultaddr: "http://127.0.0.1:8200"
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
@@ -84,7 +84,7 @@ controllers:
   etcdaddrs: "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003"
   apiaddr: "127.0.0.1:55002"
   httpaddr: "0.0.0.0:36002"
-  notifyaddr: "127.0.0.1:37002"
+  notifyaddr: "127.0.0.1:27002"
   vaultaddr: "http://127.0.0.1:8200"
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
@@ -106,8 +106,8 @@ controllers:
 
 clustersvcs:
 - name: cluster-svc1
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
-  ctrladdrs: "127.0.0.1:55001"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
+  ctrladdrs: "127.0.0.1:5501"
   vaultaddr: "http://127.0.0.1:8200"
   usevaultpki: true
   tls:
@@ -120,7 +120,7 @@ clustersvcs:
     E2ETEST_TLS: true
 
 - name: cluster-svc2
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   ctrladdrs: "127.0.0.1:55002"
   vaultaddr: "http://127.0.0.1:8200"
   usevaultpki: true
@@ -137,7 +137,7 @@ dmes:
 - name: dme1
   apiaddr: "0.0.0.0:50051"
   httpaddr: "0.0.0.0:38001"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"organization":"dmuus","name":"dmuus-cloud-1"}'
   vaultaddr: "http://127.0.0.1:8200"
   usevaultpki: true
@@ -153,7 +153,7 @@ dmes:
 - name: dme2
   apiaddr: "0.0.0.0:50052"
   httpaddr: "0.0.0.0:38002"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"organization":"dmuus","name":"dmuus-cloud-2"}'
   vaultaddr: "http://127.0.0.1:8200"
   usevaultpki: true

--- a/test/e2e-tests/setups-regional/local_multi_notls.yml
+++ b/test/e2e-tests/setups-regional/local_multi_notls.yml
@@ -56,7 +56,7 @@ controllers:
   etcdaddrs: "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003"
   apiaddr: "0.0.0.0:55001"
   httpaddr: "0.0.0.0:36001"
-  notifyaddr: "127.0.0.1:37001"
+  notifyaddr: "127.0.0.1:27001"
   shorttimeouts: true
   hostname: "127.0.0.1"
 
@@ -64,7 +64,7 @@ controllers:
   etcdaddrs: "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003"
   apiaddr: "0.0.0.0:55002"
   httpaddr: "0.0.0.0:36002"
-  notifyaddr: "127.0.0.1:37002"
+  notifyaddr: "127.0.0.1:27002"
   shorttimeouts: true
   hostname: "127.0.0.1"
 
@@ -72,7 +72,7 @@ controllers:
 dmes:
 - name: dme1
   apiaddr: "0.0.0.0:50051"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   locverurl: "{{locverurl}}"
   toksrvurl: "{{toksrvurl}}"
   carrier: GDDT
@@ -81,7 +81,7 @@ dmes:
 
 - name: dme2
   apiaddr: "0.0.0.0:50052"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   locverurl: "{{locverurl}}"
   toksrvurl: "{{toksrvurl}}"
   carrier: GDDT
@@ -92,61 +92,61 @@ dmes:
 crms:
 - name: crm1
   apiaddr: "0.0.0.0:55091"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"operator_key":{"name":"dmuus"},"name":"tmocloud-1"}'
   hostname: "127.0.0.1"
 
 - name: crm2
   apiaddr: "0.0.0.0:55092"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"operator_key":{"name":"dmuus"},"name":"tmocloud-2"}'
   hostname: "127.0.0.1"
 
 - name: crm3
   apiaddr: "0.0.0.0:55093"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"operator_key":{"name":"dmuus"},"name":"tmocloud-3"}'
   hostname: "127.0.0.1"
 
 - name: crm4
   apiaddr: "0.0.0.0:55094"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"operator_key":{"name":"dmuus"},"name":"tmocloud-4"}'
   hostname: "127.0.0.1"
 
 - name: crm5
   apiaddr: "0.0.0.0:55095"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"operator_key":{"name":"dmuus"},"name":"tmocloud-5"}'
   hostname: "127.0.0.1"
 
 - name: crm6
   apiaddr: "0.0.0.0:55096"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"operator_key":{"name":"dmuus"},"name":"tmocloud-6"}'
   hostname: "127.0.0.1"
 
 - name: crm7
   apiaddr: "0.0.0.0:55097"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"operator_key":{"name":"dmuus"},"name":"tmocloud-7"}'
   hostname: "127.0.0.1"
 
 - name: crm8
   apiaddr: "0.0.0.0:55098"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"operator_key":{"name":"dmuus"},"name":"tmocloud-8"}'
   hostname: "127.0.0.1"
 
 - name: crm9
   apiaddr: "0.0.0.0:55099"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"operator_key":{"name":"dmuus"},"name":"tmocloud-9"}'
   hostname: "127.0.0.1"
 
 - name: crm10
   apiaddr: "0.0.0.0:55100"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"operator_key":{"name":"dmuus"},"name":"tmocloud-10"}'
   hostname: "127.0.0.1"
 

--- a/test/e2e-tests/setups/local_chef.yml
+++ b/test/e2e-tests/setups/local_chef.yml
@@ -54,7 +54,7 @@ controllers:
   etcdaddrs: "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003"
   apiaddr: "0.0.0.0:55001"
   httpaddr: "0.0.0.0:36001"
-  notifyaddr: "127.0.0.1:37001"
+  notifyaddr: "127.0.0.1:27001"
   usevaultpki: true
   notifyparentaddrs: "127.0.0.1:52001"
   notifyrootaddrs: "127.0.0.1:53001"

--- a/test/e2e-tests/setups/local_edgebox.yml
+++ b/test/e2e-tests/setups/local_edgebox.yml
@@ -75,7 +75,7 @@ controllers:
   etcdaddrs: "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003"
   apiaddr: "0.0.0.0:55001"
   httpaddr: "0.0.0.0:36001"
-  notifyaddr: "127.0.0.1:37001"
+  notifyaddr: "127.0.0.1:27001"
   usevaultpki: true
   notifyparentaddrs: "127.0.0.1:52001"
   notifyrootaddrs: "127.0.0.1:53001"
@@ -95,7 +95,7 @@ dmes:
 - name: dme1
   apiaddr: "0.0.0.0:50051"
   httpaddr: "0.0.0.0:38001"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   usevaultpki: true
   locverurl: "{{locverurl}}"
   toksrvurl: "{{toksrvurl}}"
@@ -110,10 +110,10 @@ dmes:
 
 clustersvcs:
 - name: cluster-svc1
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   usevaultpki: true
   vaultaddr: "http://127.0.0.1:8200"
-  ctrladdrs: "127.0.0.1:55001"
+  ctrladdrs: "127.0.0.1:5501"
   pluginrequired: true
   promports: "tcp:9090"
   interval: "5s"
@@ -171,10 +171,10 @@ jaegers:
 
 autoprovs:
 - name: autoprov1
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   usevaultpki: true
   vaultaddr: "http://127.0.0.1:8200"
-  ctrladdrs: "127.0.0.1:55001"
+  ctrladdrs: "127.0.0.1:5501"
   hostname: "127.0.0.1"
   envvars:
     E2ETEST_TLS: true

--- a/test/e2e-tests/setups/local_multi.yml
+++ b/test/e2e-tests/setups/local_multi.yml
@@ -66,58 +66,58 @@ influxs:
 etcds:
 - name: etcd1
   datadir: /var/tmp/edge-cloud-local-etcd/etcd1
-  peeraddrs: "http://127.0.0.1:30011"
-  clientaddrs: "http://127.0.0.1:30001"
-  initialcluster: "etcd1=http://127.0.0.1:30011,etcd2=http://127.0.0.1:30012,etcd3=http://127.0.0.1:30013"
+  peeraddrs: "http://127.0.0.1:3011"
+  clientaddrs: "http://127.0.0.1:3001"
+  initialcluster: "etcd1=http://127.0.0.1:3011,etcd2=http://127.0.0.1:3012,etcd3=http://127.0.0.1:3013"
   hostname: "127.0.0.1"
 
 - name: etcd2
   datadir: /var/tmp/edge-cloud-local-etcd/etcd2
-  peeraddrs: "http://127.0.0.1:30012"
-  clientaddrs: "http://127.0.0.1:30002"
-  initialcluster: "etcd1=http://127.0.0.1:30011,etcd2=http://127.0.0.1:30012,etcd3=http://127.0.0.1:30013"
+  peeraddrs: "http://127.0.0.1:3012"
+  clientaddrs: "http://127.0.0.1:3002"
+  initialcluster: "etcd1=http://127.0.0.1:3011,etcd2=http://127.0.0.1:3012,etcd3=http://127.0.0.1:3013"
   hostname: "127.0.0.1"
 
 - name: etcd3
   datadir: /var/tmp/edge-cloud-local-etcd/etcd3
-  peeraddrs: "http://127.0.0.1:30013"
-  clientaddrs: "http://127.0.0.1:30003"
-  initialcluster: "etcd1=http://127.0.0.1:30011,etcd2=http://127.0.0.1:30012,etcd3=http://127.0.0.1:30013"
+  peeraddrs: "http://127.0.0.1:3013"
+  clientaddrs: "http://127.0.0.1:3003"
+  initialcluster: "etcd1=http://127.0.0.1:3011,etcd2=http://127.0.0.1:3012,etcd3=http://127.0.0.1:3013"
   hostname: "127.0.0.1"
 
 - name: etcda1
   datadir: /var/tmp/edge-cloud-local-etcd/etcda1
-  peeraddrs: "http://127.0.0.1:30021"
-  clientaddrs: "http://127.0.0.1:30031"
-  initialcluster: "etcda1=http://127.0.0.1:30021,etcda2=http://127.0.0.1:30022,etcda3=http://127.0.0.1:30023"
+  peeraddrs: "http://127.0.0.1:3021"
+  clientaddrs: "http://127.0.0.1:3031"
+  initialcluster: "etcda1=http://127.0.0.1:3021,etcda2=http://127.0.0.1:3022,etcda3=http://127.0.0.1:3023"
   hostname: "127.0.0.1"
 
 - name: etcda2
   datadir: /var/tmp/edge-cloud-local-etcd/etcda2
-  peeraddrs: "http://127.0.0.1:30022"
-  clientaddrs: "http://127.0.0.1:30032"
-  initialcluster: "etcda1=http://127.0.0.1:30021,etcda2=http://127.0.0.1:30022,etcda3=http://127.0.0.1:30023"
+  peeraddrs: "http://127.0.0.1:3022"
+  clientaddrs: "http://127.0.0.1:3032"
+  initialcluster: "etcda1=http://127.0.0.1:3021,etcda2=http://127.0.0.1:3022,etcda3=http://127.0.0.1:3023"
   hostname: "127.0.0.1"
 
 - name: etcda3
   datadir: /var/tmp/edge-cloud-local-etcd/etcda3
-  peeraddrs: "http://127.0.0.1:30023"
-  clientaddrs: "http://127.0.0.1:30033"
-  initialcluster: "etcda1=http://127.0.0.1:30021,etcda2=http://127.0.0.1:30022,etcda3=http://127.0.0.1:30023"
+  peeraddrs: "http://127.0.0.1:3023"
+  clientaddrs: "http://127.0.0.1:3033"
+  initialcluster: "etcda1=http://127.0.0.1:3021,etcda2=http://127.0.0.1:3022,etcda3=http://127.0.0.1:3023"
   hostname: "127.0.0.1"
 
 - name: etcd-partner1
   datadir: /var/tmp/edge-cloud-local-etcd/etcd-partner1
-  peeraddrs: "http://127.0.0.1:30081"
-  clientaddrs: "http://127.0.0.1:30008"
-  initialcluster: "etcd-partner1=http://127.0.0.1:30081"
+  peeraddrs: "http://127.0.0.1:3081"
+  clientaddrs: "http://127.0.0.1:3008"
+  initialcluster: "etcd-partner1=http://127.0.0.1:3081"
   hostname: "127.0.0.1"
 
 - name: etcd-partner2
   datadir: /var/tmp/edge-cloud-local-etcd/etcd-partner2
-  peeraddrs: "http://127.0.0.1:30091"
-  clientaddrs: "http://127.0.0.1:30009"
-  initialcluster: "etcd-partner2=http://127.0.0.1:30091"
+  peeraddrs: "http://127.0.0.1:3091"
+  clientaddrs: "http://127.0.0.1:3009"
+  initialcluster: "etcd-partner2=http://127.0.0.1:3091"
   hostname: "127.0.0.1"
 
 rediscaches:
@@ -139,32 +139,32 @@ rediscaches:
 - name: redis-sentinel1
   type: sentinel
   masterport: 16379
-  port: 36379
+  port: 26379
   hostname: "127.0.0.1"
 - name: redis-sentinel2
   type: sentinel
   masterport: 16379
-  port: 36380
+  port: 26380
   hostname: "127.0.0.1"
 - name: redis-sentinel3
   type: sentinel
   masterport: 16379
-  port: 36381
+  port: 26381
   hostname: "127.0.0.1"
 # standalone redis for ctrla1/ctrla2
 - name: redisa1
   type: master
-  port: 36382
+  port: 26382
   hostname: "127.0.0.1"
 # standalone redis for ctrl-partner1
 - name: redis-partner1
   type: master
-  port: 36383
+  port: 26383
   hostname: "127.0.0.1"
 # standalone redis for ctrl-partner2
 - name: redis-partner2
   type: master
-  port: 36384
+  port: 26384
   hostname: "127.0.0.1"
 # redis standalone for crm
 - name: redis-standalone
@@ -174,101 +174,101 @@ rediscaches:
 
 controllers:
 - name: ctrl1
-  etcdaddrs: "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003"
-  apiaddr: "127.0.0.1:55001"
-  httpaddr: "127.0.0.1:36001"
-  notifyaddr: "127.0.0.1:37001"
+  etcdaddrs: "http://127.0.0.1:3001,http://127.0.0.1:3002,http://127.0.0.1:3003"
+  apiaddr: "127.0.0.1:5501"
+  httpaddr: "127.0.0.1:26001"
+  notifyaddr: "127.0.0.1:27001"
   vaultaddr: "http://127.0.0.1:8200"
-  redissentineladdrs: "127.0.0.1:36379,127.0.0.1:36380,127.0.0.1:36381"
+  redissentineladdrs: "127.0.0.1:26379,127.0.0.1:26380,127.0.0.1:26381"
   hostname: "127.0.0.1"
   versiontag: "2019-10-24"
   testmode: true
-  notifyparentaddrs: "127.0.0.1:52001"
-  notifyrootaddrs: "127.0.0.1:53001"
+  notifyparentaddrs: "127.0.0.1:5201"
+  notifyrootaddrs: "127.0.0.1:5301"
   usevaultpki: true
   edgeturnaddr: "127.0.0.1:8081"
   appdnsroot: mobiledgex.net
   deploymenttag: dev
-  accessapiaddr: "127.0.0.1:41001"
+  accessapiaddr: "127.0.0.1:21001"
   thanosrecvaddr: "http://host.docker.internal:10908"
   envvars:
     ES_SERVER_URLS: https://localhost:9201
     E2ETEST_TLS: true
 
 - name: ctrl2
-  etcdaddrs: "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003"
-  apiaddr: "127.0.0.1:55002"
-  httpaddr: "127.0.0.1:36002"
-  notifyaddr: "127.0.0.1:37002"
+  etcdaddrs: "http://127.0.0.1:3001,http://127.0.0.1:3002,http://127.0.0.1:3003"
+  apiaddr: "127.0.0.1:5502"
+  httpaddr: "127.0.0.1:26002"
+  notifyaddr: "127.0.0.1:27002"
   vaultaddr: "http://127.0.0.1:8200"
-  redissentineladdrs: "127.0.0.1:36379,127.0.0.1:36380,127.0.0.1:36381"
+  redissentineladdrs: "127.0.0.1:26379,127.0.0.1:26380,127.0.0.1:26381"
   hostname: "127.0.0.1"
   versiontag: "2019-10-24"
   testmode: true
-  notifyparentaddrs: "127.0.0.1:52002"
-  notifyrootaddrs: "127.0.0.1:53001"
+  notifyparentaddrs: "127.0.0.1:5202"
+  notifyrootaddrs: "127.0.0.1:5301"
   usevaultpki: true
   edgeturnaddr: "127.0.0.1:8081"
   appdnsroot: mobiledgex.net
   deploymenttag: dev
-  accessapiaddr: "127.0.0.1:41002"
+  accessapiaddr: "127.0.0.1:21002"
   envvars:
     ES_SERVER_URLS: https://localhost:9201
     E2ETEST_TLS: true
 
 - name: ctrla1
-  etcdaddrs: "http://127.0.0.1:30031,http://127.0.0.1:30032,http://127.0.0.1:30033"
-  apiaddr: "127.0.0.1:55011"
-  httpaddr: "127.0.0.1:36011"
-  notifyaddr: "127.0.0.1:37011"
+  etcdaddrs: "http://127.0.0.1:3031,http://127.0.0.1:3032,http://127.0.0.1:3033"
+  apiaddr: "127.0.0.1:5511"
+  httpaddr: "127.0.0.1:26011"
+  notifyaddr: "127.0.0.1:27011"
   vaultaddr: "http://127.0.0.1:8200"
-  redisstandaloneaddr: "127.0.0.1:36382"
+  redisstandaloneaddr: "127.0.0.1:26382"
   hostname: "127.0.0.1"
   versiontag: "2019-10-24"
   testmode: true
-  notifyparentaddrs: "127.0.0.1:52001"
-  notifyrootaddrs: "127.0.0.1:53001"
+  notifyparentaddrs: "127.0.0.1:5201"
+  notifyrootaddrs: "127.0.0.1:5301"
   region: locala
   usevaultpki: true
   edgeturnaddr: "127.0.0.1:8082"
   appdnsroot: mobiledgex.net
   deploymenttag: dev
   influxaddr: "http://127.0.0.1:8087"
-  accessapiaddr: "127.0.0.1:41011"
+  accessapiaddr: "127.0.0.1:21011"
   envvars:
     ES_SERVER_URLS: https://localhost:9201
     E2ETEST_TLS: true
 
 - name: ctrla2
-  etcdaddrs: "http://127.0.0.1:30031,http://127.0.0.1:30032,http://127.0.0.1:30033"
-  apiaddr: "127.0.0.1:55012"
-  httpaddr: "127.0.0.1:36012"
-  notifyaddr: "127.0.0.1:37012"
+  etcdaddrs: "http://127.0.0.1:3031,http://127.0.0.1:3032,http://127.0.0.1:3033"
+  apiaddr: "127.0.0.1:5512"
+  httpaddr: "127.0.0.1:26012"
+  notifyaddr: "127.0.0.1:27012"
   vaultaddr: "http://127.0.0.1:8200"
-  redisstandaloneaddr: "127.0.0.1:36382"
+  redisstandaloneaddr: "127.0.0.1:26382"
   hostname: "127.0.0.1"
   versiontag: "2019-10-24"
   testmode: true
-  notifyparentaddrs: "127.0.0.1:52002"
-  notifyrootaddrs: "127.0.0.1:53001"
+  notifyparentaddrs: "127.0.0.1:5202"
+  notifyrootaddrs: "127.0.0.1:5301"
   region: locala
   usevaultpki: true
   edgeturnaddr: "127.0.0.1:8082"
   appdnsroot: mobiledgex.net
   deploymenttag: dev
   influxaddr: "http://127.0.0.1:8087"
-  accessapiaddr: "127.0.0.1:41012"
+  accessapiaddr: "127.0.0.1:21012"
   envvars:
     ES_SERVER_URLS: https://localhost:9201
     E2ETEST_TLS: true
 
 - name: ctrl-partner1
-  etcdaddrs: "http://127.0.0.1:30008"
-  apiaddr: "127.0.0.1:55081"
-  httpaddr: "127.0.0.1:36081"
-  notifyaddr: "127.0.0.1:37081"
+  etcdaddrs: "http://127.0.0.1:3008"
+  apiaddr: "127.0.0.1:5581"
+  httpaddr: "127.0.0.1:26081"
+  notifyaddr: "127.0.0.1:27081"
   vaultaddr: "http://127.0.0.1:8200"
-  redisstandaloneaddr: "127.0.0.1:36383"
+  redisstandaloneaddr: "127.0.0.1:26383"
   hostname: "127.0.0.1"
   versiontag: "2019-10-24"
   testmode: true
@@ -276,18 +276,18 @@ controllers:
   usevaultpki: true
   appdnsroot: mobiledgex.net
   deploymenttag: dev
-  accessapiaddr: "127.0.0.1:41081"
+  accessapiaddr: "127.0.0.1:21081"
   envvars:
     ES_SERVER_URLS: https://localhost:9201
     E2ETEST_TLS: true
 
 - name: ctrl-partner2
-  etcdaddrs: "http://127.0.0.1:30009"
-  apiaddr: "127.0.0.1:55091"
-  httpaddr: "127.0.0.1:36091"
-  notifyaddr: "127.0.0.1:37091"
+  etcdaddrs: "http://127.0.0.1:3009"
+  apiaddr: "127.0.0.1:5591"
+  httpaddr: "127.0.0.1:26091"
+  notifyaddr: "127.0.0.1:27091"
   vaultaddr: "http://127.0.0.1:8200"
-  redisstandaloneaddr: "127.0.0.1:36384"
+  redisstandaloneaddr: "127.0.0.1:26384"
   hostname: "127.0.0.1"
   versiontag: "2019-10-24"
   testmode: true
@@ -295,14 +295,14 @@ controllers:
   usevaultpki: true
   appdnsroot: mobiledgex.net
   deploymenttag: dev
-  accessapiaddr: "127.0.0.1:41091"
+  accessapiaddr: "127.0.0.1:21091"
   envvars:
     ES_SERVER_URLS: https://localhost:9201
     E2ETEST_TLS: true
 
 frms:
 - name: frm1
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   hostname: "127.0.0.1"
   deploymenttag: dev
   region: local
@@ -313,7 +313,7 @@ frms:
     E2ETEST_TLS: true
 
 - name: frma1
-  notifyaddrs: "127.0.0.1:37011,127.0.0.1:37012"
+  notifyaddrs: "127.0.0.1:27011,127.0.0.1:27012"
   hostname: "127.0.0.1"
   deploymenttag: dev
   region: locala
@@ -325,8 +325,8 @@ frms:
 
 clustersvcs:
 - name: cluster-svc1
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
-  ctrladdrs: "127.0.0.1:55001"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
+  ctrladdrs: "127.0.0.1:5501"
   vaultaddr: "http://127.0.0.1:8200"
   pluginrequired: true
   usevaultpki: true
@@ -337,8 +337,8 @@ clustersvcs:
     E2ETEST_TLS: true
 
 - name: cluster-svc2
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
-  ctrladdrs: "127.0.0.1:55002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
+  ctrladdrs: "127.0.0.1:5502"
   vaultaddr: "http://127.0.0.1:8200"
   usevaultpki: true
   hostname: "127.0.0.1"
@@ -348,8 +348,8 @@ clustersvcs:
     E2ETEST_TLS: true
 
 - name: cluster-svca1
-  notifyaddrs: "127.0.0.1:37011,127.0.0.1:37012"
-  ctrladdrs: "127.0.0.1:55011"
+  notifyaddrs: "127.0.0.1:27011,127.0.0.1:27012"
+  ctrladdrs: "127.0.0.1:5511"
   vaultaddr: "http://127.0.0.1:8200"
   pluginrequired: true
   usevaultpki: true
@@ -361,8 +361,8 @@ clustersvcs:
     E2ETEST_TLS: true
 
 - name: cluster-svca2
-  notifyaddrs: "127.0.0.1:37011,127.0.0.1:37012"
-  ctrladdrs: "127.0.0.1:55012"
+  notifyaddrs: "127.0.0.1:27011,127.0.0.1:27012"
+  ctrladdrs: "127.0.0.1:5512"
   vaultaddr: "http://127.0.0.1:8200"
   usevaultpki: true
   region: locala
@@ -374,9 +374,9 @@ clustersvcs:
 
 dmes:
 - name: dme1
-  apiaddr: "127.0.0.1:50051"
-  httpaddr: "127.0.0.1:38001"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  apiaddr: "127.0.0.1:5051"
+  httpaddr: "127.0.0.1:28001"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   locverurl: "{{locverurl}}"
   toksrvurl: "{{toksrvurl}}"
   qossesaddr: "http://localhost:8083"
@@ -395,9 +395,9 @@ dmes:
     E2ETEST_QOS_SIM: true
 
 - name: dme2
-  apiaddr: "127.0.0.1:50052"
-  httpaddr: "127.0.0.1:38002"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  apiaddr: "127.0.0.1:5052"
+  httpaddr: "127.0.0.1:28002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   locverurl: "{{locverurl}}"
   toksrvurl: "{{toksrvurl}}"
   carrier: GDDT
@@ -414,9 +414,9 @@ dmes:
     E2ETEST_NORANDOM: true
 
 - name: dmea1
-  apiaddr: "127.0.0.1:50061"
-  httpaddr: "127.0.0.1:38011"
-  notifyaddrs: "127.0.0.1:37011,127.0.0.1:37012"
+  apiaddr: "127.0.0.1:5061"
+  httpaddr: "127.0.0.1:28011"
+  notifyaddrs: "127.0.0.1:27011,127.0.0.1:27012"
   locverurl: "{{locverurl}}"
   toksrvurl: "{{toksrvurl}}"
   carrier: GDDT
@@ -434,9 +434,9 @@ dmes:
     E2ETEST_NORANDOM: true
 
 - name: dmea2
-  apiaddr: "127.0.0.1:50062"
-  httpaddr: "127.0.0.1:38012"
-  notifyaddrs: "127.0.0.1:37011,127.0.0.1:37012"
+  apiaddr: "127.0.0.1:5062"
+  httpaddr: "127.0.0.1:28012"
+  notifyaddrs: "127.0.0.1:27011,127.0.0.1:27012"
   locverurl: "{{locverurl}}"
   toksrvurl: "{{toksrvurl}}"
   carrier: GDDT
@@ -458,12 +458,12 @@ mcs:
   addr: "127.0.0.1:9900"
   sqladdr: "127.0.0.1:5432"
   vaultaddr: "http://127.0.0.1:8200"
-  notifyaddrs: "127.0.0.1:53001"
+  notifyaddrs: "127.0.0.1:5301"
   usevaultpki: true
   hostname: "127.0.0.1"
   ldapaddr: "127.0.0.1:9389"
   federationaddr: "127.0.0.1:9801"
-  notifysrvaddr: "127.0.0.1:52001"
+  notifysrvaddr: "127.0.0.1:5201"
   consoleproxyaddr: "127.0.0.1:6080"
   alertresolvetimeout: "{{alertmgrresolvetimeout}}"
   alertmgrapiaddr: "https://127.0.0.1:9094"
@@ -479,12 +479,12 @@ mcs:
   addr: "127.0.0.1:9901"
   sqladdr: "127.0.0.1:5432"
   vaultaddr: "http://127.0.0.1:8200"
-  notifyaddrs: "127.0.0.1:53001"
+  notifyaddrs: "127.0.0.1:5301"
   usevaultpki: true
   hostname: "127.0.0.1"
   ldapaddr: "127.0.0.1:9390"
   federationaddr: "127.0.0.1:9802"
-  notifysrvaddr: "127.0.0.1:52002"
+  notifysrvaddr: "127.0.0.1:5202"
   consoleproxyaddr: "127.0.0.1:6081"
   alertmgrapiaddr: "https://127.0.0.1:9094"
   alertresolvetimeout: "{{alertmgrresolvetimeout}}"
@@ -504,7 +504,7 @@ mcs:
   hostname: "127.0.0.1"
   ldapaddr: "127.0.0.1:9889"
   federationaddr: "127.0.0.1:9808"
-  notifysrvaddr: "127.0.0.1:52081"
+  notifysrvaddr: "127.0.0.1:5281"
   apitlscert: "{{tlsoutdir}}/test-server.crt"
   apitlskey: "{{tlsoutdir}}/test-server.key"
   deploymenttag: dev
@@ -521,7 +521,7 @@ mcs:
   hostname: "127.0.0.1"
   ldapaddr: "127.0.0.1:9989"
   federationaddr: "127.0.0.1:9809"
-  notifysrvaddr: "127.0.0.1:52091"
+  notifysrvaddr: "127.0.0.1:5291"
   apitlscert: "{{tlsoutdir}}/test-server.crt"
   apitlskey: "{{tlsoutdir}}/test-server.key"
   deploymenttag: dev
@@ -597,8 +597,8 @@ jaegers:
 
 autoprovs:
 - name: autoprov1
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
-  ctrladdrs: "127.0.0.1:55001"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
+  ctrladdrs: "127.0.0.1:5501"
   vaultaddr: "http://127.0.0.1:8200"
   influxaddr: "http://127.0.0.1:8086"
   usevaultpki: true
@@ -609,8 +609,8 @@ autoprovs:
     E2ETEST_TLS: true
 
 - name: autoprova1
-  notifyaddrs: "127.0.0.1:37011,127.0.0.1:37012"
-  ctrladdrs: "127.0.0.1:55011"
+  notifyaddrs: "127.0.0.1:27011,127.0.0.1:27012"
+  ctrladdrs: "127.0.0.1:5511"
   vaultaddr: "http://127.0.0.1:8200"
   influxaddr: "http://127.0.0.1:8087"
   region: locala
@@ -635,7 +635,7 @@ httpservers:
 notifyroots:
 - name: notifyroot
   hostname: "127.0.0.1"
-  notifyaddr: "127.0.0.1:53001"
+  notifyaddr: "127.0.0.1:5301"
   vaultaddr: "http://127.0.0.1:8200"
   usevaultpki: true
   deploymenttag: dev

--- a/test/e2e-tests/setups/local_multi_automation.yml
+++ b/test/e2e-tests/setups/local_multi_automation.yml
@@ -72,7 +72,7 @@ controllers:
   etcdaddrs: "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003"
   apiaddr: "0.0.0.0:55001"
   httpaddr: "0.0.0.0:36001"
-  notifyaddr: "127.0.0.1:37001"
+  notifyaddr: "127.0.0.1:27001"
   tls:
      servercert: "{{tlsoutdir}}/mex-server.crt"
      clientcert: "{{tlsoutdir}}/mex-client.crt"
@@ -84,7 +84,7 @@ controllers:
   etcdaddrs: "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003"
   apiaddr: "0.0.0.0:55002"
   httpaddr: "0.0.0.0:36002"
-  notifyaddr: "127.0.0.1:37002"
+  notifyaddr: "127.0.0.1:27002"
   tls:
      servercert: "{{tlsoutdir}}/mex-server.crt"
      clientcert: "{{tlsoutdir}}/mex-client.crt"
@@ -97,7 +97,7 @@ dmes:
 - name: dme1
   apiaddr: "0.0.0.0:50051"
   httpaddr: "0.0.0.0:38001"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   locverurl: "{{locverurl}}"
   toksrvurl: "{{toksrvurl}}"
   carrier: GDDT
@@ -113,7 +113,7 @@ dmes:
 crms:
 - name: crm1
   apiaddr: "0.0.0.0:55091"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"organization":"dmuus","name":"tmocloud-1"}'
   platform: fakecloudlet
   tls:
@@ -123,7 +123,7 @@ crms:
 
 - name: crm2
   apiaddr: "0.0.0.0:55092"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"organization":"dmuus","name":"tmocloud-2"}'
   platform: fakecloudlet
   tls:
@@ -133,7 +133,7 @@ crms:
 
 - name: crm3
   apiaddr: "0.0.0.0:55093"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"organization":"dmuus","name":"tmocloud-3"}'
   platform: fakecloudlet
   tls:
@@ -143,7 +143,7 @@ crms:
 
 - name: crm4
   apiaddr: "0.0.0.0:55094"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"organization":"dmuus","name":"tmocloud-4"}'
   platform: fakecloudlet
   tls:
@@ -153,7 +153,7 @@ crms:
 
 - name: crm5
   apiaddr: "0.0.0.0:55095"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"organization":"dmuus","name":"tmocloud-5"}'
   platform: fakecloudlet
   tls:
@@ -163,7 +163,7 @@ crms:
 
 - name: crm6
   apiaddr: "0.0.0.0:55096"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"organization":"dmuus","name":"tmocloud-6"}'
   platform: fakecloudlet
   tls:
@@ -173,7 +173,7 @@ crms:
 
 - name: crm7
   apiaddr: "0.0.0.0:55097"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"organization":"dmuus","name":"tmocloud-7"}'
   platform: fakecloudlet
   tls:
@@ -183,7 +183,7 @@ crms:
 
 - name: crm8
   apiaddr: "0.0.0.0:55098"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"organization":"dmuus","name":"tmocloud-8"}'
   platform: fakecloudlet
   tls:
@@ -193,7 +193,7 @@ crms:
 
 - name: crm9
   apiaddr: "0.0.0.0:55099"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"organization":"dmuus","name":"tmocloud-9"}'
   platform: fakecloudlet
   tls:
@@ -203,7 +203,7 @@ crms:
 
 - name: crm10
   apiaddr: "0.0.0.0:55100"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"organization":"dmuus","name":"tmocloud-10"}'
   platform: fakecloudlet
   tls:
@@ -213,7 +213,7 @@ crms:
 
 - name: crm11
   apiaddr: "0.0.0.0:55101"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"organization":"azure","name":"azurecloud-1"}'
   platform: fakecloudlet
   tls:
@@ -223,7 +223,7 @@ crms:
 
 - name: crm12
   apiaddr: "0.0.0.0:55102"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"organization":"gcp","name":"gcpcloud-1"}'
   platform: fakecloudlet
   tls:
@@ -233,7 +233,7 @@ crms:
 
 - name: crm13
   apiaddr: "0.0.0.0:55103"
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   cloudletkey: '{"organization":"att","name":"attcloud-1"}'
   platform: fakecloudlet
   tls:
@@ -266,15 +266,15 @@ sqls:
 
 clustersvcs:
 - name: cluster-svc1
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
-  ctrladdrs: "127.0.0.1:55001"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
+  ctrladdrs: "127.0.0.1:5501"
   tls:
      servercert: "{{tlsoutdir}}/mex-server.crt"
      clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
 
 - name: cluster-svc2
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
   ctrladdrs: "127.0.0.1:55002"
   tls:
      servercert: "{{tlsoutdir}}/mex-server.crt"
@@ -295,8 +295,8 @@ jaegers:
 
 autoprovs:
 - name: autoprov1
-  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
-  ctrladdrs: "127.0.0.1:55001"
+  notifyaddrs: "127.0.0.1:27001,127.0.0.1:27002"
+  ctrladdrs: "127.0.0.1:5501"
   vaultaddr: "http://127.0.0.1:8200"
   influxaddr: "http://127.0.0.1:8086"
   shorttimeouts: true

--- a/test/e2e-tests/testfiles/federationtest.yml
+++ b/test/e2e-tests/testfiles/federationtest.yml
@@ -74,8 +74,8 @@ tests:
     partnertag: "partner1"
     region: "PA"
     dnsregion: "pa"
-    ctrlapiaddr: "127.0.0.1:55081"
-    ctrlnotifyaddr: "127.0.0.1:37081"
+    ctrlapiaddr: "127.0.0.1:5581"
+    ctrlnotifyaddr: "127.0.0.1:27081"
   curuserfile: '{{datadir2}}/mc_admin.yml'
   compareyaml:
     yaml1: '{{outputdir}}/show-commands.yml'
@@ -108,8 +108,8 @@ tests:
     partnertag: "partner2"
     region: "PS"
     dnsregion: "ps"
-    ctrlapiaddr: "127.0.0.1:55091"
-    ctrlnotifyaddr: "127.0.0.1:37091"
+    ctrlapiaddr: "127.0.0.1:5591"
+    ctrlnotifyaddr: "127.0.0.1:27091"
   curuserfile: '{{datadir2}}/mc_admin.yml'
   compareyaml:
     yaml1: '{{outputdir}}/show-commands.yml'
@@ -674,8 +674,8 @@ tests:
     partnertag: "partner1"
     region: "PA"
     dnsregion: "pa"
-    ctrlapiaddr: "127.0.0.1:55081"
-    ctrlnotifyaddr: "127.0.0.1:37081"
+    ctrlapiaddr: "127.0.0.1:5581"
+    ctrlnotifyaddr: "127.0.0.1:27081"
   curuserfile: '{{datadir2}}/mc_admin.yml'
   compareyaml:
     yaml1: '{{outputdir}}/show-commands.yml'
@@ -697,8 +697,8 @@ tests:
     partnertag: "partner2"
     region: "PS"
     dnsregion: "ps"
-    ctrlapiaddr: "127.0.0.1:55081"
-    ctrlnotifyaddr: "127.0.0.1:37081"
+    ctrlapiaddr: "127.0.0.1:5581"
+    ctrlnotifyaddr: "127.0.0.1:27081"
   curuserfile: '{{datadir2}}/mc_admin.yml'
   compareyaml:
     yaml1: '{{outputdir}}/show-commands.yml'


### PR DESCRIPTION
On WSL2 (Windows subsystem linux), e2e-tests start-up would often fail due to random port bind failures for listener ports because "the ports were in use", but there were never any persistent services using them. It appears ephemeral usage of random ports occasionally caused conflicts. This change moves all the bind ports to below 30000 to avoid conflicts with randomly assigned ports used by the OS.