### PR TITLE
Update jwt-go lib due to security vulnerability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/creack/pty v1.1.10
 	github.com/davecgh/go-spew v1.1.1
 	github.com/daviddengcn/go-colortext v0.0.0-20171126034257-17e75f6184bc
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/elastic/go-elasticsearch/v7 v7.5.0
 	github.com/go-chef/chef v0.23.1
 	github.com/go-openapi/errors v0.19.7
@@ -92,6 +92,8 @@ require (
 	k8s.io/cli-runtime v0.0.0-20190313123343-44a48934c135
 	k8s.io/client-go v0.17.3
 )
+
+require github.com/golang-jwt/jwt/v4 v4.4.1
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect

--- a/go.sum
+++ b/go.sum
@@ -344,6 +344,8 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang-jwt/jwt/v4 v4.4.1 h1:pC5DB52sCeK48Wlb9oPcdhnjkz1TKt1D/P7WKJ0kUcQ=
+github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=

--- a/pkg/dme-common/authtoken.go
+++ b/pkg/dme-common/authtoken.go
@@ -21,7 +21,7 @@ import (
 	"io/ioutil"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 )
 

--- a/pkg/dme-common/cookie.go
+++ b/pkg/dme-common/cookie.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt/v4"
 	dme "github.com/edgexr/edge-cloud-platform/api/dme-proto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/vault"

--- a/pkg/dme-common/edgeevents-cookie.go
+++ b/pkg/dme-common/edgeevents-cookie.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt/v4"
 	dme "github.com/edgexr/edge-cloud-platform/api/dme-proto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 )

--- a/pkg/mc/orm/emails.go
+++ b/pkg/mc/orm/emails.go
@@ -26,7 +26,7 @@ import (
 	"text/template"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/labstack/echo"
 	"github.com/edgexr/edge-cloud-platform/api/ormapi"
 	"github.com/edgexr/edge-cloud-platform/pkg/mc/ormutil"

--- a/pkg/mc/orm/user.go
+++ b/pkg/mc/orm/user.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
 	"github.com/jinzhu/gorm"
 	"github.com/labstack/echo"

--- a/pkg/mc/orm/userauth.go
+++ b/pkg/mc/orm/userauth.go
@@ -23,7 +23,7 @@ import (
 	"time"
 	"unicode/utf8"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo"
 	"github.com/edgexr/edge-cloud-platform/api/ormapi"

--- a/pkg/vault/jwk.go
+++ b/pkg/vault/jwk.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/mitchellh/mapstructure"
 )

--- a/pkg/vault/jwk_test.go
+++ b/pkg/vault/jwk_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/edgexr/edge-cloud-platform/pkg/process"
 	"github.com/edgexr/edge-cloud-platform/pkg/vault"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Update jwt-go library due to security vulnerability: https://github.com/advisories/GHSA-w73w-5m7g-f7qc

The original dgrijalva/jwt-go library is no longer maintained, and the original owner has transferred ownership to a new set of maintainers and it is now golang-jwt/jwt/v4.

Note that we still have dependencies which are using dgrijalva/jwt, so we need to update our dependencies as well. That will be done separately as it introduces potentially breaking changes to our code.