### PR TITLE
Edgeturn proxy start bind error ignored

### DIFF
--- a/cmd/edgeturn/server.go
+++ b/cmd/edgeturn/server.go
@@ -34,11 +34,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	edgetls "github.com/edgexr/edge-cloud-platform/pkg/tls"
+	"github.com/gorilla/websocket"
 	"github.com/segmentio/ksuid"
 	"github.com/xtaci/smux"
 )
@@ -553,7 +553,8 @@ func setupProxyServer(started chan bool) error {
 	var err error
 	if *testMode {
 		// In test mode, setup HTTP server with TLS
-		tlsConfig, err := edgetls.GetLocalTLSConfig()
+		var tlsConfig *tls.Config
+		tlsConfig, err = edgetls.GetLocalTLSConfig()
 		if err != nil {
 			return fmt.Errorf("unable to fetch tls local server config, %v", err)
 		}


### PR DESCRIPTION
Err was being redefined inside the if-stmt scoped, but the check for if ListenAndServeTLS() failed was outside of the if-stmt scope. This meant that a bind failure was not actually caught, as the err outside the if-stmt remained nil. Obviously from the existing code it was intended that error was not to be redefined inside the if-stmt, so made that change.