### PR TITLE
Unit-test fixes: httpmock, accesskey, vault addr

### DIFF
--- a/cmd/alertmgr-sidecar/alertmgr-sidecar.go
+++ b/cmd/alertmgr-sidecar/alertmgr-sidecar.go
@@ -20,8 +20,8 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/edgexr/edge-cloud-platform/pkg/mc/orm/alertmgr"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/mc/orm/alertmgr"
 )
 
 var debugLevels = flag.String("d", "", fmt.Sprintf("comma separated list of %v", log.DebugLevelStrings))
@@ -79,7 +79,7 @@ func main() {
 	}
 
 	SidecarServer, err := alertmgr.NewSidecarServer(*alertmanagerAddr, *alertmanagerConfigFile,
-		*httpAddr, config, *clientCert, *tlsCert, *tlsCertKey, *localTest)
+		*httpAddr, config, *clientCert, *tlsCert, *tlsCertKey, *localTest, nil)
 	if err != nil {
 		log.FatalLog("Unable to init alertmgr sidecar", "err", err)
 	}

--- a/cmd/frm/notify_test.go
+++ b/cmd/frm/notify_test.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/edgexr/edge-cloud-platform/pkg/redundancy"
-	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
-	"github.com/edgexr/edge-cloud-platform/pkg/process"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/notify"
+	"github.com/edgexr/edge-cloud-platform/pkg/process"
+	"github.com/edgexr/edge-cloud-platform/pkg/redundancy"
 	"github.com/stretchr/testify/require"
 )
 
@@ -143,7 +143,7 @@ func TestFRMNotify(t *testing.T) {
 	ctrlHandler := notify.NewDummyHandler()
 	ctrlMgr := notify.ServerMgr{}
 	ctrlHandler.RegisterServer(&ctrlMgr)
-	notifyAddr := "127.0.0.1:61245"
+	notifyAddr := "127.0.0.1:21245"
 	ctrlMgr.Start("ctrl", notifyAddr, nil)
 
 	var nodeMgr node.NodeMgr

--- a/pkg/cloudcommon/node/events.go
+++ b/pkg/cloudcommon/node/events.go
@@ -27,11 +27,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/mitchellh/mapstructure"
-	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
-	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -253,6 +253,9 @@ func (s *NodeMgr) initEvents(ctx context.Context, opts *NodeOptions) error {
 			TLSClientConfig: tlsConfig,
 		}
 		config.Transport = &transport
+	}
+	if s.testTransport != nil {
+		config.Transport = s.testTransport
 	}
 
 	s.ESClient, err = elasticsearch.NewClient(config)

--- a/pkg/cloudcommon/node/pki_test.go
+++ b/pkg/cloudcommon/node/pki_test.go
@@ -29,14 +29,14 @@ import (
 	"testing"
 	"time"
 
-	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
-	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
-	"github.com/edgexr/edge-cloud-platform/pkg/process"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/process"
 	edgetls "github.com/edgexr/edge-cloud-platform/pkg/tls"
 	"github.com/edgexr/edge-cloud-platform/pkg/vault"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/examples/features/proto/echo"
@@ -70,7 +70,7 @@ func TestInternalPki(t *testing.T) {
 			Name: "vault",
 		},
 		Regions:    "us,eu",
-		ListenAddr: "http://127.0.0.1:8200",
+		ListenAddr: "http://127.0.0.1:8201",
 	}
 	vroles, err := vp.StartLocalRoles()
 	require.Nil(t, err, "start local vault")

--- a/pkg/cloudcommon/nodetest/dummy_events_es.go
+++ b/pkg/cloudcommon/nodetest/dummy_events_es.go
@@ -23,8 +23,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jarcoal/httpmock"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
+	"github.com/jarcoal/httpmock"
 )
 
 // This captures events meant to be sent to elastic search.
@@ -39,16 +39,16 @@ type DummyEventsES struct {
 // This assumes httpmock has already been initialized via:
 // httpmock.Activate()
 // defer httpmock.DeactiveAndReset()
-func (s *DummyEventsES) InitHttpMock(addr string) {
+func (s *DummyEventsES) InitHttpMock(addr string, mockTransport *httpmock.MockTransport) {
 	s.Events = make([]*node.EventData, 0)
 
 	matchAll := "=~" + addr + `/.*\z`
 	// regexp match POST events
-	httpmock.RegisterResponder("POST", matchAll, s.Handle)
+	mockTransport.RegisterResponder("POST", matchAll, s.Handle)
 	// ignore searches
-	httpmock.RegisterResponder("GET", matchAll, s.HandleIgnore)
+	mockTransport.RegisterResponder("GET", matchAll, s.HandleIgnore)
 	// ignore PUT index template
-	httpmock.RegisterResponder("PUT", matchAll, s.HandleIgnore)
+	mockTransport.RegisterResponder("PUT", matchAll, s.HandleIgnore)
 }
 
 func (s *DummyEventsES) Handle(req *http.Request) (*http.Response, error) {

--- a/pkg/mc/federation/client.go
+++ b/pkg/mc/federation/client.go
@@ -20,9 +20,9 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/mc/ormclient"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform"
-	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/tls"
 )
 
@@ -31,8 +31,8 @@ const (
 )
 
 type FederationClient struct {
-	AccessApi platform.AccessApi
-	UnitTest  bool
+	AccessApi     platform.AccessApi
+	TestTransport http.RoundTripper
 }
 
 func NewClient(accessApi platform.AccessApi) (*FederationClient, error) {
@@ -62,8 +62,8 @@ func (c *FederationClient) SendRequest(ctx context.Context, method, fedAddr, fed
 	}
 
 	restClient := &ormclient.Client{}
-	if c.UnitTest {
-		restClient.ForceDefaultTransport = true
+	if c.TestTransport != nil {
+		restClient.TestTransport = c.TestTransport
 	}
 	if tls.IsTestTls() {
 		restClient.SkipVerify = true

--- a/pkg/mc/orm/alertmgr_api_test.go
+++ b/pkg/mc/orm/alertmgr_api_test.go
@@ -20,27 +20,28 @@ import (
 	"os"
 	"testing"
 
-	"github.com/edgexr/edge-cloud-platform/pkg/mcctl/mctestclient"
-	"github.com/edgexr/edge-cloud-platform/pkg/mc/orm/alertmgr"
-	"github.com/edgexr/edge-cloud-platform/api/ormapi"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/api/ormapi"
+	"github.com/edgexr/edge-cloud-platform/pkg/mc/orm/alertmgr"
+	"github.com/edgexr/edge-cloud-platform/pkg/mcctl/mctestclient"
+	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/require"
 )
 
-func InitAlertmgrMock() (string, error) {
-	testAlertMgrAddr := "http://dummyalertmgr.mobiledgex.net:9093"
+func InitAlertmgrMock(mockTransport *httpmock.MockTransport) (string, error) {
+	testAlertMgrAddr := "http://dummyalertmgr.edgecloud.net:9093"
 	testAlertMgrConfig := "testAlertMgrConfig.yml"
 	// start with clean configFile
 	err := os.Remove(testAlertMgrConfig)
 	if err != nil && !os.IsNotExist(err) {
 		return "", err
 	}
-	if fakeAlertmanager := alertmgr.NewAlertmanagerMock(testAlertMgrAddr, testAlertMgrConfig); fakeAlertmanager == nil {
+	if fakeAlertmanager := alertmgr.NewAlertmanagerMock(testAlertMgrAddr, testAlertMgrConfig, mockTransport); fakeAlertmanager == nil {
 		return "", fmt.Errorf("Failed to start alertmanager")
 	}
 
 	// Start up a sidecar server on an available port
-	sidecarServer, err := alertmgr.NewSidecarServer(testAlertMgrAddr, testAlertMgrConfig, ":0", &alertmgr.TestInitInfo, "", "", "", false)
+	sidecarServer, err := alertmgr.NewSidecarServer(testAlertMgrAddr, testAlertMgrConfig, ":0", &alertmgr.TestInitInfo, "", "", "", false, mockTransport)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/mc/orm/artifactory.go
+++ b/pkg/mc/orm/artifactory.go
@@ -68,6 +68,9 @@ func artifactoryClient(ctx context.Context) (*artifactory.Artifactory, error) {
 	tp := transport.ApiKeyAuth{
 		ApiKey: rtfAuth.ApiKey,
 	}
+	if serverConfig != nil {
+		tp.Transport = serverConfig.testTransport
+	}
 	client, err := artifactory.NewClient(serverConfig.ArtifactoryAddr, tp.Client())
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelInfo, "Failed to connect to artifactory", "addr",

--- a/pkg/mc/orm/server_test.go
+++ b/pkg/mc/orm/server_test.go
@@ -83,7 +83,7 @@ func TestServer(t *testing.T) {
 	err = server.WaitUntilReady()
 	require.Nil(t, err, "server online")
 
-	for _, clientRun := range getUnitTestClientRuns() {
+	for _, clientRun := range getUnitTestClientRuns(nil) {
 		testServerClientRun(t, ctx, clientRun, uri)
 	}
 }
@@ -1301,15 +1301,17 @@ func testEdgeboxOnlyOrgs(t *testing.T, uri string, mcClient *mctestclient.Client
 	testDeleteUser(t, mcClient, uri, userTok, user.Name)
 }
 
-func getUnitTestClientRuns() []mctestclient.ClientRun {
-	restClient := &ormclient.Client{
-		ForceDefaultTransport: true,
-	}
+func getUnitTestClientRuns(trans http.RoundTripper) []mctestclient.ClientRun {
+	restClient := &ormclient.Client{}
 	cliClient := cliwrapper.NewClient()
 	cliClient.DebugLog = true
 	cliClient.SilenceUsage = true
 	cliClient.RunInline = true
 	cliClient.InjectRequiredArgs = true
+	if trans != nil {
+		restClient.TestTransport = trans
+		cliClient.SetTestTransport(trans)
+	}
 	return []mctestclient.ClientRun{restClient, cliClient}
 }
 

--- a/pkg/mc/ormclient/rest_client.go
+++ b/pkg/mc/ormclient/rest_client.go
@@ -28,14 +28,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/websocket"
-	"github.com/mitchellh/mapstructure"
-	"github.com/edgexr/edge-cloud-platform/pkg/mcctl/mctestclient"
-	"github.com/edgexr/edge-cloud-platform/pkg/mcctl/ormctl"
+	edgeproto "github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/api/ormapi"
 	"github.com/edgexr/edge-cloud-platform/pkg/cli"
-	edgeproto "github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/mcctl/mctestclient"
+	"github.com/edgexr/edge-cloud-platform/pkg/mcctl/ormctl"
+	"github.com/gorilla/websocket"
+	"github.com/mitchellh/mapstructure"
 )
 
 type Client struct {
@@ -45,8 +45,8 @@ type Client struct {
 	// some stream messages have been received before signaling to the
 	// sender that it's ok to generate an error.
 	MidstreamFailChs map[string]chan bool
-	// Force default transport (allows for http mocking for unit tests)
-	ForceDefaultTransport bool
+	// Test transport for mocking unit tests
+	TestTransport http.RoundTripper
 	// Print input data transformations
 	PrintTransformations bool
 }
@@ -161,8 +161,8 @@ func (s *Client) HttpJsonSendReq(method, uri, token string, reqData interface{})
 		TLSClientConfig: tlsConfig,
 		Proxy:           http.ProxyFromEnvironment,
 	}
-	if s.ForceDefaultTransport {
-		tr = http.DefaultTransport
+	if s.TestTransport != nil {
+		tr = s.TestTransport
 	}
 	if s.Debug {
 		curlcmd := fmt.Sprintf(`curl -X %s "%s" -H "Content-Type: application/json"`, method, uri)

--- a/pkg/mcctl/cliwrapper/wrapcli.go
+++ b/pkg/mcctl/cliwrapper/wrapcli.go
@@ -27,11 +27,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/edgexr/edge-cloud-platform/pkg/cli"
+	edgelog "github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/mcctl/mccli"
 	"github.com/edgexr/edge-cloud-platform/pkg/mcctl/mctestclient"
 	"github.com/edgexr/edge-cloud-platform/pkg/mcctl/ormctl"
-	"github.com/edgexr/edge-cloud-platform/pkg/cli"
-	edgelog "github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/spf13/cobra"
 )
 
@@ -58,8 +58,8 @@ func NewClient() *Client {
 	return s
 }
 
-func (s *Client) ForceDefaultTransport(enable bool) {
-	s.rootCmd.ForceDefaultTransport(enable)
+func (s *Client) SetTestTransport(tr http.RoundTripper) {
+	s.rootCmd.SetTestTransport(tr)
 }
 
 func (s *Client) EnablePrintTransformations() {

--- a/pkg/mcctl/mccli/rootcmd.go
+++ b/pkg/mcctl/mccli/rootcmd.go
@@ -17,11 +17,12 @@ package mccli
 import (
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 
-	"github.com/edgexr/edge-cloud-platform/pkg/mcctl/ormctl"
-	"github.com/edgexr/edge-cloud-platform/pkg/mc/ormclient"
 	"github.com/edgexr/edge-cloud-platform/pkg/cli"
+	"github.com/edgexr/edge-cloud-platform/pkg/mc/ormclient"
+	"github.com/edgexr/edge-cloud-platform/pkg/mcctl/ormctl"
 	"github.com/spf13/cobra"
 )
 
@@ -207,9 +208,9 @@ func printCommandGroup(out io.Writer, desc string, pad int, cmds []*cobra.Comman
 	}
 }
 
-// For unit-testing, force default transport to allow http requests to be mocked
-func (s *RootCommand) ForceDefaultTransport(enable bool) {
-	s.client.ForceDefaultTransport = enable
+// For unit-testing, set transport to allow http requests to be mocked
+func (s *RootCommand) SetTestTransport(tr http.RoundTripper) {
+	s.client.TestTransport = tr
 }
 
 func (s *RootCommand) EnablePrintTransformations() {


### PR DESCRIPTION
A bunch of changes to avoid intermittent unit test failures.
- Change usage of httpmock. Using the global httpmock Register/Active/Deactivate functions changes a global Transport which is shared across unit-tests from different packges running in parallel. This means different unit-tests can modify each other's global Transport object, causing intermittent failures. The fix is to define a local MockTransport and use that where needed, instead of modifying the global one.
- Change the way we detect grpc reconnect in the access client-server key test, the previous method was not reliable
- Change port for notify binding to below 30000 to avoid bind conflicts in WSL.
- Change Vault listen addr in unit-test to avoid conflicts with multiple Vaults running in parallel from unit-tests in different packages. I'm not sure this is sufficient, if we continue to see tests failing to due Vault setup errors, we may need to transition to vault.NewTestCluster() which is an in-memory test Vault that Hashicorp uses for its own testing.