### PR TITLE
Fix controller influx database not found regression caused by #15

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -564,13 +564,11 @@ func startServices() error {
 	services.httpServer = httpServer
 
 	// start the checkpointer
-	checkpointer := NewCheckpointer(services.events, allApis.clusterInstApi)
-	err = checkpointer.Init()
+	err = checkInterval()
 	if err != nil {
-		log.SpanLog(ctx, log.DebugLevelInfo, "Error setting up checkpoints", "err", err)
 		return err
 	}
-	services.checkpointer = checkpointer
+	services.checkpointer = NewCheckpointer(services.events, allApis.clusterInstApi)
 	services.checkpointer.Start()
 
 	log.SpanLog(ctx, log.DebugLevelInfo, "Ready")


### PR DESCRIPTION
Change #15 incorrectly moved the influx continuous query init into the controller. Unfortunately it needs to remain in the periodic thread, since the continuous query thread and the thread that set up the events database in influxdb run concurrently and thus it's possible that the events database is not set up by the time the controller init starts setting up the continuous queries.

This results in the following error during controller start-up because the two events are out of order:
```
2022-06-21T14:50:38.335-0700    INFO    6ddaf07ad18897e controller/controller.go:570    Error setting up checkpoints    {"err": "Unable to query influx: database not found: events"}
...
2022-06-21T14:50:38.338-0700    INFO    775bd0c4752dece0        influxq_client/influxq.go:131   initDB done     {"name": "events"}
2022-06-21T14:50:38.338-0700    INFO    775bd0c4752dece0        influxq_client/influxq.go:132   finish InfluxQ initDB   {"lineno": "influxq_client/influxq.go:106"}
```

To fix, I moved the continuous query init back into the periodic thread.