### PR TITLE
backwards compatibility for MobiledgeX org name

### DIFF
--- a/api/edgeproto/objs.go
+++ b/api/edgeproto/objs.go
@@ -1075,7 +1075,19 @@ func CmpSortSlices() []cmp.Option {
 
 var OrganizationPlatos = "platos"
 var OrganizationEdgeCloud = "edgecloudorg"
+var OrganizationEdgeCloudOld = "MobiledgeX"
 var OrganizationEdgeBox = "EdgeBox"
+
+func IsEdgeCloudOrg(s string) bool {
+	// support backwards compatibility for old name
+	return s == OrganizationEdgeCloud || s == OrganizationEdgeCloudOld
+}
+
+func IsEdgeCloudOrgLC(s string) bool {
+	s = strings.ToLower(s)
+	// support backwards compatibility for old name
+	return s == strings.ToLower(OrganizationEdgeCloud) || s == strings.ToLower(OrganizationEdgeCloudOld)
+}
 
 func GetOrg(obj interface{}) string {
 	switch v := obj.(type) {

--- a/cmd/controller/appinst_api.go
+++ b/cmd/controller/appinst_api.go
@@ -721,7 +721,7 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 				if !app.AllowServerless {
 					return fmt.Errorf("Target cloudlet platform only supports serverless Apps")
 				}
-				if in.Key.ClusterInstKey.Organization != edgeproto.OrganizationEdgeCloud {
+				if !edgeproto.IsEdgeCloudOrg(in.Key.ClusterInstKey.Organization) {
 					return fmt.Errorf("ClusterInst organization must be set to %s", edgeproto.OrganizationEdgeCloud)
 				}
 				key := in.ClusterInstKey()
@@ -752,7 +752,7 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 			if autoClusterType != DeprecatedAutoCluster {
 				// reservable and multi-tenant ClusterInsts are
 				// always owned by the system
-				if in.Key.ClusterInstKey.Organization != edgeproto.OrganizationEdgeCloud {
+				if !edgeproto.IsEdgeCloudOrg(in.Key.ClusterInstKey.Organization) {
 					return fmt.Errorf("ClusterInst organization must be %s for autoclusters", edgeproto.OrganizationEdgeCloud)
 				}
 			}

--- a/cmd/controller/cluster_checkpoints.go
+++ b/cmd/controller/cluster_checkpoints.go
@@ -20,10 +20,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/types"
-	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/gogo/protobuf/types"
 )
 
 type ClusterCheckpoint struct {
@@ -41,7 +41,7 @@ func CreateClusterUsageRecord(ctx context.Context, cluster *edgeproto.ClusterIns
 	selectors := []string{"\"event\"", "\"status\""}
 	reservedByOption := ""
 	org := cluster.Key.Organization
-	if cluster.Key.Organization == edgeproto.OrganizationEdgeCloud && cluster.ReservedBy != "" {
+	if edgeproto.IsEdgeCloudOrg(cluster.Key.Organization) && cluster.ReservedBy != "" {
 		reservedByOption = fmt.Sprintf(`AND "reservedBy"='%s' `, cluster.ReservedBy)
 		org = cluster.ReservedBy
 	}
@@ -101,7 +101,7 @@ func createClusterUsageMetric(cluster *edgeproto.ClusterInst, startTime, endTime
 	metric.AddStringVal("start", startUTC.Format(time.RFC3339))
 	metric.AddStringVal("end", endUTC.Format(time.RFC3339))
 	metric.AddDoubleVal("uptime", runTime.Seconds())
-	if cluster.ReservedBy != "" && cluster.Key.Organization == edgeproto.OrganizationEdgeCloud {
+	if cluster.ReservedBy != "" && edgeproto.IsEdgeCloudOrg(cluster.Key.Organization) {
 		metric.AddTag("org", cluster.ReservedBy)
 	} else {
 		metric.AddTag("org", cluster.Key.Organization)

--- a/cmd/controller/clusterinst_api.go
+++ b/cmd/controller/clusterinst_api.go
@@ -856,13 +856,13 @@ func (s *ClusterInstApi) createClusterInstInternal(cctx *CallContext, in *edgepr
 	if in.Key.ClusterKey.Name == "" {
 		return fmt.Errorf("Cluster name cannot be empty")
 	}
-	if in.Reservable && in.Key.Organization != edgeproto.OrganizationEdgeCloud {
+	if in.Reservable && !edgeproto.IsEdgeCloudOrg(in.Key.Organization) {
 		return fmt.Errorf("Only %s ClusterInsts may be reservable", edgeproto.OrganizationEdgeCloud)
 	}
 	if in.Reservable {
 		in.ReservationEndedAt = dme.TimeToTimestamp(time.Now())
 	}
-	if in.MultiTenant && in.Key.Organization != edgeproto.OrganizationEdgeCloud {
+	if in.MultiTenant && !edgeproto.IsEdgeCloudOrg(in.Key.Organization) {
 		return fmt.Errorf("Only %s ClusterInsts may be multi-tenant", edgeproto.OrganizationEdgeCloud)
 	}
 

--- a/pkg/cloudcommon/names.go
+++ b/pkg/cloudcommon/names.go
@@ -297,7 +297,7 @@ func IsClusterInstReqd(app *edgeproto.App) bool {
 }
 
 func IsSideCarApp(app *edgeproto.App) bool {
-	if app.Key.Organization == edgeproto.OrganizationEdgeCloud && app.DelOpt == edgeproto.DeleteType_AUTO_DELETE {
+	if edgeproto.IsEdgeCloudOrg(app.Key.Organization) && app.DelOpt == edgeproto.DeleteType_AUTO_DELETE {
 		return true
 	}
 	return false

--- a/pkg/cloudcommon/node/kafka_bus.go
+++ b/pkg/cloudcommon/node/kafka_bus.go
@@ -113,7 +113,7 @@ func (s *NodeMgr) kafkaSend(ctx context.Context, event EventData, keyTags map[st
 		if eventorg == orgName {
 			allowed = true
 		}
-		if eventorg != orgName && eventorg != edgeproto.OrganizationEdgeCloud {
+		if eventorg != orgName && !edgeproto.IsEdgeCloudOrg(eventorg) {
 			topic = topic_prefix_developer + "-" + cloudletName
 		}
 	}

--- a/pkg/mc/orm/authz_cloudlet.go
+++ b/pkg/mc/orm/authz_cloudlet.go
@@ -330,10 +330,10 @@ func authzCreateAppInst(ctx context.Context, region, username string, obj *edgep
 	// concerned about RBAC permissions, so only ensures that different
 	// organizations are not encroaching on each other.
 	if obj.Key.AppKey.Organization != obj.Key.ClusterInstKey.Organization && obj.Key.ClusterInstKey.Organization != "" {
-		// Sidecar apps may have MobiledgeX organization, or
-		// target ClusterInst may be MobiledgeX reservable/multitenant.
-		// So one of the orgs must be MobiledgeX to pass RBAC.
-		if obj.Key.AppKey.Organization != edgeproto.OrganizationEdgeCloud && obj.Key.ClusterInstKey.Organization != edgeproto.OrganizationEdgeCloud {
+		// Sidecar apps may have EdgeCloud organization, or
+		// target ClusterInst may be EdgeCloud reservable/multitenant.
+		// So one of the orgs must be EdgeCloud to pass RBAC.
+		if !edgeproto.IsEdgeCloudOrg(obj.Key.AppKey.Organization) && !edgeproto.IsEdgeCloudOrg(obj.Key.ClusterInstKey.Organization) {
 			return echo.ErrForbidden
 		}
 	}

--- a/pkg/mc/orm/authz_cloudletpool.go
+++ b/pkg/mc/orm/authz_cloudletpool.go
@@ -112,7 +112,7 @@ func authzCloudletPoolMembers(ctx context.Context, region, username string, pool
 		}
 		invalidOrgs := []string{}
 		err := ctrlclient.GetOrganizationsOnCloudletStream(ctx, &rc, &key, connCache, func(org *edgeproto.Organization) error {
-			if org.Name == edgeproto.OrganizationEdgeCloud {
+			if edgeproto.IsEdgeCloudOrg(org.Name) {
 				return nil
 			}
 			if _, found := allowedOrgs[org.Name]; found {

--- a/pkg/mc/orm/billing_organization.go
+++ b/pkg/mc/orm/billing_organization.go
@@ -844,7 +844,7 @@ func isBillable(ctx context.Context, orgName string) bool {
 	if !billingEnabled(ctx) {
 		return true
 	}
-	if strings.ToLower(orgName) == strings.ToLower(edgeproto.OrganizationEdgeCloud) || strings.ToLower(orgName) == strings.ToLower(edgeproto.OrganizationEdgeBox) {
+	if edgeproto.IsEdgeCloudOrgLC(orgName) || strings.ToLower(orgName) == strings.ToLower(edgeproto.OrganizationEdgeBox) {
 		return true
 	}
 	org, _ := orgExists(ctx, orgName)

--- a/pkg/mc/orm/org.go
+++ b/pkg/mc/orm/org.go
@@ -91,7 +91,7 @@ func CreateOrgObj(ctx context.Context, claims *UserClaims, org *ormapi.Organizat
 	} else {
 		return fmt.Errorf("Organization type must be %s, or %s", OrgTypeDeveloper, OrgTypeOperator)
 	}
-	if strings.ToLower(org.Name) == strings.ToLower(edgeproto.OrganizationEdgeCloud) || strings.ToLower(org.Name) == strings.ToLower(edgeproto.OrganizationEdgeBox) {
+	if edgeproto.IsEdgeCloudOrgLC(org.Name) || strings.ToLower(org.Name) == strings.ToLower(edgeproto.OrganizationEdgeBox) {
 		if err := authorized(ctx, claims.Username, "", ResourceUsers, ActionManage); err != nil {
 			return fmt.Errorf("Not authorized to create reserved org %s", org.Name)
 		}

--- a/pkg/platform/k8s-baremetal/k8sbm-cluster.go
+++ b/pkg/platform/k8s-baremetal/k8sbm-cluster.go
@@ -19,14 +19,14 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 )
 
 func (k *K8sBareMetalPlatform) CreateClusterInst(ctx context.Context, clusterInst *edgeproto.ClusterInst, updateCallback edgeproto.CacheUpdateCallback, timeout time.Duration) error {
 	log.SpanLog(ctx, log.DebugLevelInfra, "CreateClusterInst")
-	if clusterInst.Key.ClusterKey.Name == cloudcommon.DefaultMultiTenantCluster && clusterInst.Key.Organization == edgeproto.OrganizationEdgeCloud {
+	if clusterInst.Key.ClusterKey.Name == cloudcommon.DefaultMultiTenantCluster && edgeproto.IsEdgeCloudOrg(clusterInst.Key.Organization) {
 		// The cluster that represents this Cloudlet's cluster.
 		// This is a no-op as the cluster already exists.
 		return nil


### PR DESCRIPTION
To avoid use of the old company name in the Edge Cloud platform, the built-in org "MobiledgeX" was renamed to "edgecloudorg" via https://github.com/edgexr/edge-cloud-platform/commit/0050f364de5a227c3b7a6c69bb3112856c7a7fae. However, since then the old platform has been resurrected and is running with 3.0 HF5, so is using the old "MobiledgeX" org name. To allow for a seamless upgrade, this change recognizes the old org name as the built-in org name.

It would be very difficult to have an upgrade function to change this as this is a key field, which ends up in things like the names of objects on Openstack. Changing it could require rebuilding Openstack VMs, Stacks, etc. So instead we allow those to continue existing as-is until they are deleted.