### PR TITLE
allow e2e-tests to run inline instead of external program

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -29,14 +29,27 @@ var mux sync.Mutex
 var spanlogger *zap.Logger
 
 func init() {
-	logger, _ := zap.NewDevelopment(zap.AddCallerSkip(1))
+	SetupLoggers("")
+}
+
+// SetupLoggers allows for overriding default loggers, primarily for e2e tests.
+// Must be called before InitTracer().
+func SetupLoggers(logFile string) {
+	cfg := zap.NewDevelopmentConfig()
+	if logFile != "" {
+		cfg.OutputPaths = []string{logFile}
+	}
+	logger, _ := cfg.Build(zap.AddCallerSkip(1))
 	defer logger.Sync()
 	slogger = logger.Sugar()
 
 	// logger that does not log caller, optimization for
 	// span logging to local disk since caller is derived by spanlog.
-	cfg := zap.NewDevelopmentConfig()
+	cfg = zap.NewDevelopmentConfig()
 	cfg.DisableCaller = true
+	if logFile != "" {
+		cfg.OutputPaths = []string{logFile}
+	}
 	spanlogger, _ = cfg.Build()
 	defer spanlogger.Sync()
 }
@@ -144,7 +157,7 @@ func SetDebugLevelStrs(list string) {
 		val, ok := stringToDebugLevel(str)
 		if ok {
 			SetDebugLevelEnum(val)
-		} 
+		}
 	}
 }
 

--- a/test/e2e-tests/cmd/test-mex/test-mex.go
+++ b/test/e2e-tests/cmd/test-mex/test-mex.go
@@ -152,8 +152,10 @@ func main() {
 	validateArgs(&config, &spec)
 
 	errors := []string{}
+	var logFile *os.File
 	if outputDir != "" {
-		outputDir = e2e.CreateOutputDir(false, outputDir, commandName+".log")
+		outputDir, logFile = e2e.CreateOutputDir(false, outputDir, commandName+".log")
+		defer logFile.Close()
 	}
 
 	if config.SetupFile != "" {

--- a/test/e2e-tests/vars.yml
+++ b/test/e2e-tests/vars.yml
@@ -16,5 +16,6 @@ datadir: $GOPATH/src/github.com/edgexr/edge-cloud-platform/test/e2e-tests/data-r
 datadir2: $GOPATH/src/github.com/edgexr/edge-cloud-platform/test/e2e-tests/data
 edge-cloud-testfiles: $GOPATH/src/github.com/edgexr/edge-cloud-platform/test/e2e-tests/testfiles
 chefdir: $GOPATH/src/github.com/edgexr/edge-cloud-platform/test/e2e-tests/chef
-default-program: test-mex-infra
 staticdir: $GOPATH/src/github.com/edgexr/edge-cloud-infra/static
+# set default-program to an external program to run customized tests
+#default-program: test-mex-infra


### PR DESCRIPTION
To improve e2e test time taken, the e2e-tests now by default run tests inline in the same process, rather than spawning an externa process to run each test. An external process can still be used if needed. An external process is mainly for users outside of our project to extend the tests in a custom way without having to modify the e2e-test program (which no one is doing now).

For tests that are simple, the overhead of spawning an external process is quite high:
External process:
```
 - qos_priority_sessions.yml   Create and verify QOS priority session QOS_THROUGHPUT_DOWN_M PASS  130.2228ms
 - qos_priority_sessions.yml   Create and verify QOS priority session QOS_THROUGHPUT_DOWN_L PASS  138.8037ms
 - qos_priority_sessions.yml   Create QOS session same profile, SessionId is reused         PASS  128.5041ms
 - qos_priority_sessions.yml   Create QOS session diff profile, new SessionId is created    PASS  127.4884ms
 - qos_priority_sessions.yml   Delete previously created QOS session                        PASS  125.6065ms
 - qos_priority_sessions.yml   Delete unknown QOS session                                   PASS  125.2621ms
 - qos_priority_sessions.yml   Remove qosapplication app and appinst                        PASS  360.585ms
 - qos_priority_sessions.yml   done                                                               3.4069657s
```
Inline process:
```
 - qos_priority_sessions.yml   Create and verify QOS priority session QOS_THROUGHPUT_DOWN_M PASS  8.1877ms
 - qos_priority_sessions.yml   Create and verify QOS priority session QOS_THROUGHPUT_DOWN_L PASS  6.4257ms
 - qos_priority_sessions.yml   Create QOS session same profile, SessionId is reused         PASS  6.3552ms
 - qos_priority_sessions.yml   Create QOS session diff profile, new SessionId is created    PASS  7.0486ms
 - qos_priority_sessions.yml   Delete previously created QOS session                        PASS  5.7536ms
 - qos_priority_sessions.yml   Delete unknown QOS session                                   PASS  5.4659ms
 - qos_priority_sessions.yml   Remove qosapplication app and appinst                        PASS  248.4755ms
 - qos_priority_sessions.yml   done                                                               1.5282932s
```
However, longer tests that are doing a bunch of API calls or waiting for stuff to happen or doing a sleep obviously don't benefit that much. So overall the savings is somewhat limited for the whole e2e-tests, only about 12 seconds:
External process:
```
Total Run: 322, passed: 322, failed: 0, took: 4m1.1587614s
```
Internal process:
```
Total Run: 322, passed: 322, failed: 0, took: 3m48.7274425s
```
But in general reducing the amount of wasted time and cpu is a good thing.