### PR TITLE
e2e-tests start processes in parallel

### DIFF
--- a/pkg/process/process_locapisim.go
+++ b/pkg/process/process_locapisim.go
@@ -29,10 +29,6 @@ type LocApiSim struct {
 }
 
 func (p *LocApiSim) StartLocal(logfile string, opts ...StartOp) error {
-	if p.Locfile != "" {
-
-	}
-
 	args := []string{"-port", fmt.Sprintf("%d", p.Port), "-file", p.Locfile}
 	if p.Geofile != "" {
 		args = append(args, "-geo", p.Geofile)


### PR DESCRIPTION
Start e2e-test processes in parallel to reduce time spent for e2e tests. Processes are started in two sets, first all the databases are started in parallel. Once those are up, the rest of the processes are started in parallel.

On my Intel 16 core i9-1050K on WSL in Windows 11, this reduces the start up time by ~28s.
Serial:
```
 - deploy_start.yml            deploy and start services                                    PASS  52.5936406s
...
Total Run: 322, passed: 322, failed: 0, took: 3m48.7274425s
```
Parallel:
```
 - deploy_start.yml            deploy and start services                                    PASS  24.4187563s
...
Total Run: 322, passed: 322, failed: 0, took: 3m20.7903032s
```
Depending on how many cores your machine has, you may not see such a speedup.

Note that processes are already stopped in parallel.