### PR TITLE
make testutil test data immutable

### DIFF
--- a/cmd/autoprov/autoprov_minmax_test.go
+++ b/cmd/autoprov/autoprov_minmax_test.go
@@ -45,7 +45,7 @@ func TestChoose(t *testing.T) {
 	// set up object data
 	app := edgeproto.App{}
 	app.Key.Name = "app"
-	policy := testutil.AutoProvPolicyData[0]
+	policy := testutil.AutoProvPolicyData()[0]
 	cloudlets := make([]edgeproto.Cloudlet, 3, 3)
 	cloudlets[0].Key.Name = "A"
 	cloudlets[1].Key.Name = "B"

--- a/cmd/autoprov/autoprov_retry_test.go
+++ b/cmd/autoprov/autoprov_retry_test.go
@@ -32,7 +32,7 @@ func TestRetry(t *testing.T) {
 	ctx := log.StartTestSpan(context.Background())
 
 	retry := newRetryTracker()
-	key := testutil.AppInstData[0].Key
+	key := testutil.AppInstData()[0].Key
 
 	// no error should not register a retry
 	retry.registerDeployResult(ctx, key, nil)

--- a/cmd/autoprov/autoprov_test.go
+++ b/cmd/autoprov/autoprov_test.go
@@ -80,8 +80,8 @@ func TestAutoProv(t *testing.T) {
 
 func testAutoScale(t *testing.T, ctx context.Context, ds *testutil.DummyServer, dn *notify.DummyHandler) {
 	// initial state of ClusterInst
-	cinst := testutil.ClusterInstData[2]
-	numnodes := int(testutil.ClusterInstData[2].NumNodes)
+	cinst := testutil.ClusterInstData()[2]
+	numnodes := int(testutil.ClusterInstData()[2].NumNodes)
 	ds.ClusterInstCache.Update(ctx, &cinst, 0)
 
 	// alert labels for ClusterInst
@@ -148,12 +148,12 @@ func testAutoProv(t *testing.T, ctx context.Context, ds *testutil.DummyServer, d
 	autoProvAggr.UpdateSettings(ctx, 300, 0)
 
 	// add reservable ClusterInst
-	rcinst := testutil.ClusterInstData[7]
+	rcinst := testutil.ClusterInstData()[7]
 	dn.ClusterInstCache.Update(ctx, &rcinst, 0)
 	cloudletKey := rcinst.Key.CloudletKey
 
 	// add policies
-	policy := testutil.AutoProvPolicyData[0]
+	policy := testutil.AutoProvPolicyData()[0]
 	policy.Cloudlets = []*edgeproto.AutoProvCloudlet{
 		&edgeproto.AutoProvCloudlet{
 			Key: rcinst.Key.CloudletKey,
@@ -161,7 +161,7 @@ func testAutoProv(t *testing.T, ctx context.Context, ds *testutil.DummyServer, d
 	}
 	dn.AutoProvPolicyCache.Update(ctx, &policy, 0)
 
-	policy2 := testutil.AutoProvPolicyData[3]
+	policy2 := testutil.AutoProvPolicyData()[3]
 	policy2.Cloudlets = []*edgeproto.AutoProvCloudlet{
 		&edgeproto.AutoProvCloudlet{
 			Key: rcinst.Key.CloudletKey,
@@ -175,7 +175,7 @@ func testAutoProv(t *testing.T, ctx context.Context, ds *testutil.DummyServer, d
 	require.True(t, policy2.DeployIntervalCount > scale*policy.DeployIntervalCount)
 
 	// add app that uses above policy
-	app := testutil.AppData[11]
+	app := testutil.AppData()[11]
 	dn.AppCache.Update(ctx, &app, 0)
 
 	notify.WaitFor(&cacheData.appCache, 1)

--- a/cmd/controller/addrefs_test.go
+++ b/cmd/controller/addrefs_test.go
@@ -47,9 +47,9 @@ func TestAddRefsChecks(t *testing.T) {
 type AddRefsDataGen struct{}
 
 func (s *AddRefsDataGen) GetAddAppAlertPolicyTestObj() (*edgeproto.AppAlertPolicy, *testSupportData) {
-	app := testutil.AppData[0]
+	app := testutil.AppData()[0]
 	app.AlertPolicies = nil
-	alertPolicy := testutil.AlertPolicyData[0]
+	alertPolicy := testutil.AlertPolicyData()[0]
 
 	testObj := edgeproto.AppAlertPolicy{
 		AppKey:      app.Key,
@@ -62,10 +62,10 @@ func (s *AddRefsDataGen) GetAddAppAlertPolicyTestObj() (*edgeproto.AppAlertPolic
 }
 
 func (s *AddRefsDataGen) GetAddAppAutoProvPolicyTestObj() (*edgeproto.AppAutoProvPolicy, *testSupportData) {
-	app := testutil.AppData[0]
+	app := testutil.AppData()[0]
 	app.Deployment = cloudcommon.DeploymentTypeKubernetes
 	app.AutoProvPolicies = nil
-	autoProvPolicy := testutil.AutoProvPolicyData[0]
+	autoProvPolicy := testutil.AutoProvPolicyData()[0]
 
 	testObj := edgeproto.AppAutoProvPolicy{
 		AppKey:         app.Key,
@@ -79,7 +79,7 @@ func (s *AddRefsDataGen) GetAddAppAutoProvPolicyTestObj() (*edgeproto.AppAutoPro
 
 func (s *AddRefsDataGen) GetAddAutoProvPolicyCloudletTestObj() (*edgeproto.AutoProvPolicyCloudlet, *testSupportData) {
 	cloudlet := testutil.CloudletData()[0]
-	autoProvPolicy := testutil.AutoProvPolicyData[0]
+	autoProvPolicy := testutil.AutoProvPolicyData()[0]
 	autoProvPolicy.Cloudlets = nil
 
 	testObj := edgeproto.AutoProvPolicyCloudlet{
@@ -94,7 +94,7 @@ func (s *AddRefsDataGen) GetAddAutoProvPolicyCloudletTestObj() (*edgeproto.AutoP
 
 func (s *AddRefsDataGen) GetAddCloudletPoolMemberTestObj() (*edgeproto.CloudletPoolMember, *testSupportData) {
 	cloudlet := testutil.CloudletData()[0]
-	cloudletPool := testutil.CloudletPoolData[0]
+	cloudletPool := testutil.CloudletPoolData()[0]
 	cloudletPool.Key.Organization = cloudlet.Key.Organization
 	cloudletPool.Cloudlets = nil
 
@@ -111,7 +111,7 @@ func (s *AddRefsDataGen) GetAddCloudletPoolMemberTestObj() (*edgeproto.CloudletP
 func (s *AddRefsDataGen) GetAddCloudletResMappingTestObj() (*edgeproto.CloudletResMap, *testSupportData) {
 	cloudlet := testutil.CloudletData()[0]
 	cloudlet.ResTagMap = nil
-	resTagTable := testutil.ResTagTableData[0]
+	resTagTable := testutil.ResTagTableData()[0]
 
 	testObj := edgeproto.CloudletResMap{
 		Key: cloudlet.Key,
@@ -126,11 +126,11 @@ func (s *AddRefsDataGen) GetAddCloudletResMappingTestObj() (*edgeproto.CloudletR
 }
 
 func (s *AddRefsDataGen) GetCreateAppTestObj() (*edgeproto.App, *testSupportData) {
-	flavor := testutil.FlavorData[0]
-	autoProvPolicy := testutil.AutoProvPolicyData[0]
-	alertPolicy := testutil.AlertPolicyData[0]
+	flavor := testutil.FlavorData()[0]
+	autoProvPolicy := testutil.AutoProvPolicyData()[0]
+	alertPolicy := testutil.AlertPolicyData()[0]
 
-	app := testutil.AppData[0]
+	app := testutil.AppData()[0]
 	app.DefaultFlavor = flavor.Key
 	app.AutoProvPolicies = []string{autoProvPolicy.Key.Name}
 	app.AlertPolicies = []string{alertPolicy.Key.Name}
@@ -143,15 +143,15 @@ func (s *AddRefsDataGen) GetCreateAppTestObj() (*edgeproto.App, *testSupportData
 }
 
 func (s *AddRefsDataGen) GetCreateAppInstTestObj() (*edgeproto.AppInst, *testSupportData) {
-	app := testutil.AppData[0]
+	app := testutil.AppData()[0]
 	cloudlet := testutil.CloudletData()[0]
-	cloudletInfo := testutil.CloudletInfoData[0]
-	clusterInst := testutil.ClusterInstData[0]
+	cloudletInfo := testutil.CloudletInfoData()[0]
+	clusterInst := testutil.ClusterInstData()[0]
 	clusterInst.Key.CloudletKey = cloudlet.Key
 	clusterInst.State = edgeproto.TrackedState_READY
-	flavor := testutil.FlavorData[0]
+	flavor := testutil.FlavorData()[0]
 
-	appInst := testutil.AppInstData[0]
+	appInst := testutil.AppInstData()[0]
 	appInst.Key.AppKey = app.Key
 	appInst.Key.ClusterInstKey = *clusterInst.Key.Virtual("")
 	appInst.Flavor = flavor.Key
@@ -169,7 +169,7 @@ func (s *AddRefsDataGen) GetCreateAppInstTestObj() (*edgeproto.AppInst, *testSup
 func (s *AddRefsDataGen) GetCreateAutoProvPolicyTestObj() (*edgeproto.AutoProvPolicy, *testSupportData) {
 	cloudlet := testutil.CloudletData()[0]
 
-	autoProvPolicy := testutil.AutoProvPolicyData[0]
+	autoProvPolicy := testutil.AutoProvPolicyData()[0]
 	autoProvPolicy.Cloudlets = []*edgeproto.AutoProvCloudlet{
 		&edgeproto.AutoProvCloudlet{
 			Key: cloudlet.Key,
@@ -186,14 +186,14 @@ func (s *AddRefsDataGen) GetCreateCloudletTestObj() (*edgeproto.Cloudlet, *testS
 	// allow special characters in org name.
 	cloudlet := testutil.CloudletData()[2]
 
-	flavor := testutil.FlavorData[0]
-	resTagTable := testutil.ResTagTableData[0]
+	flavor := testutil.FlavorData()[0]
+	resTagTable := testutil.ResTagTableData()[0]
 	resTagTable.Key.Organization = cloudlet.Key.Organization
-	trustPolicy := testutil.TrustPolicyData[0]
+	trustPolicy := testutil.TrustPolicyData()[0]
 	trustPolicy.Key.Organization = cloudlet.Key.Organization
-	gpuDriver := testutil.GPUDriverData[0]
+	gpuDriver := testutil.GPUDriverData()[0]
 	gpuDriver.Key.Organization = cloudlet.Key.Organization
-	vmpool := testutil.VMPoolData[0]
+	vmpool := testutil.VMPoolData()[0]
 	vmpool.Key.Organization = cloudlet.Key.Organization
 
 	cloudlet.Flavor = flavor.Key
@@ -216,7 +216,7 @@ func (s *AddRefsDataGen) GetCreateCloudletTestObj() (*edgeproto.Cloudlet, *testS
 func (s *AddRefsDataGen) GetCreateCloudletPoolTestObj() (*edgeproto.CloudletPool, *testSupportData) {
 	cloudlet := testutil.CloudletData()[0]
 
-	cloudletPool := testutil.CloudletPoolData[0]
+	cloudletPool := testutil.CloudletPoolData()[0]
 	cloudletPool.Key.Organization = cloudlet.Key.Organization
 	cloudletPool.Cloudlets = []edgeproto.CloudletKey{cloudlet.Key}
 
@@ -227,13 +227,13 @@ func (s *AddRefsDataGen) GetCreateCloudletPoolTestObj() (*edgeproto.CloudletPool
 
 func (s *AddRefsDataGen) GetCreateClusterInstTestObj() (*edgeproto.ClusterInst, *testSupportData) {
 	cloudlet := testutil.CloudletData()[0]
-	cloudletInfo := testutil.CloudletInfoData[0]
-	flavor := testutil.FlavorData[0]
-	autoScalePolicy := testutil.AutoScalePolicyData[0]
-	network := testutil.NetworkData[0]
+	cloudletInfo := testutil.CloudletInfoData()[0]
+	flavor := testutil.FlavorData()[0]
+	autoScalePolicy := testutil.AutoScalePolicyData()[0]
+	network := testutil.NetworkData()[0]
 	network.Key.CloudletKey = cloudlet.Key
 
-	clusterInst := testutil.ClusterInstData[0]
+	clusterInst := testutil.ClusterInstData()[0]
 	clusterInst.Key.CloudletKey = cloudlet.Key
 	clusterInst.Flavor = flavor.Key
 	clusterInst.AutoScalePolicy = autoScalePolicy.Key.Name
@@ -254,7 +254,7 @@ func (s *AddRefsDataGen) GetCreateClusterInstTestObj() (*edgeproto.ClusterInst, 
 func (s *AddRefsDataGen) GetCreateNetworkTestObj() (*edgeproto.Network, *testSupportData) {
 	cloudlet := testutil.CloudletData()[0]
 
-	network := testutil.NetworkData[0]
+	network := testutil.NetworkData()[0]
 	network.Key.CloudletKey = cloudlet.Key
 
 	supportData := &testSupportData{}
@@ -263,10 +263,10 @@ func (s *AddRefsDataGen) GetCreateNetworkTestObj() (*edgeproto.Network, *testSup
 }
 
 func (s *AddRefsDataGen) GetCreateTrustPolicyExceptionTestObj() (*edgeproto.TrustPolicyException, *testSupportData) {
-	cloudletPool := testutil.CloudletPoolData[0]
-	app := testutil.AppData[0]
+	cloudletPool := testutil.CloudletPoolData()[0]
+	app := testutil.AppData()[0]
 
-	tpe := testutil.TrustPolicyExceptionData[0]
+	tpe := testutil.TrustPolicyExceptionData()[0]
 	tpe.Key.AppKey = app.Key
 	tpe.Key.CloudletPoolKey = cloudletPool.Key
 
@@ -337,7 +337,7 @@ func (s *AddRefsDataGen) GetUpdateCloudletTestObj() (*edgeproto.Cloudlet, *testS
 	updatable.GpuConfig.Driver = edgeproto.GPUDriverKey{}
 
 	supportData.Cloudlets = []edgeproto.Cloudlet{updatable}
-	supportData.CloudletInfos = []edgeproto.CloudletInfo{testutil.CloudletInfoData[2]}
+	supportData.CloudletInfos = []edgeproto.CloudletInfo{testutil.CloudletInfoData()[2]}
 
 	testObj.Fields = []string{
 		edgeproto.CloudletFieldTrustPolicy,

--- a/cmd/controller/alert_api_test.go
+++ b/cmd/controller/alert_api_test.go
@@ -50,20 +50,21 @@ func TestAlertApi(t *testing.T) {
 	sync.Start()
 	defer sync.Done()
 
-	for _, alert := range testutil.AlertData {
+	alertData := testutil.AlertData()
+	for _, alert := range alertData {
 		apis.alertApi.Update(ctx, &alert, 0)
 	}
-	testutil.InternalAlertTest(t, "show", apis.alertApi, testutil.AlertData)
+	testutil.InternalAlertTest(t, "show", apis.alertApi, alertData)
 
 	cloudletData := testutil.CloudletData()
-	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData)
-	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData)
-	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData)
+	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData())
+	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData())
+	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData())
 	testutil.InternalCloudletCreate(t, apis.cloudletApi, cloudletData)
 	testCloudlet := cloudletData[0]
 	testCloudlet.Key.Name = "testcloudlet"
 	testutil.InternalCloudletCreate(t, apis.cloudletApi, []edgeproto.Cloudlet{testCloudlet})
-	testCloudletInfo := testutil.CloudletInfoData[0]
+	testCloudletInfo := testutil.CloudletInfoData()[0]
 	testCloudletInfo.Key.Name = testCloudlet.Key.Name
 	insertCloudletInfo(ctx, apis, []edgeproto.CloudletInfo{testCloudletInfo})
 	getAlertsCount := func() (int, int) {
@@ -122,34 +123,33 @@ func TestAppInstDownAlert(t *testing.T) {
 	dummyResponder.InitDummyInfoResponder()
 
 	// create supporting data
-	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData)
-	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData)
-	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData)
+	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData())
+	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData())
+	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData())
 	testutil.InternalCloudletCreate(t, apis.cloudletApi, testutil.CloudletData())
-	insertCloudletInfo(ctx, apis, testutil.CloudletInfoData)
-	testutil.InternalAutoProvPolicyCreate(t, apis.autoProvPolicyApi, testutil.AutoProvPolicyData)
-	testutil.InternalAutoScalePolicyCreate(t, apis.autoScalePolicyApi, testutil.AutoScalePolicyData)
-	testutil.InternalAppCreate(t, apis.appApi, testutil.AppData)
-	testutil.InternalClusterInstCreate(t, apis.clusterInstApi, testutil.ClusterInstData)
-	testutil.InternalAppInstCreate(t, apis.appInstApi, testutil.AppInstData)
+	insertCloudletInfo(ctx, apis, testutil.CloudletInfoData())
+	testutil.InternalAutoProvPolicyCreate(t, apis.autoProvPolicyApi, testutil.AutoProvPolicyData())
+	testutil.InternalAutoScalePolicyCreate(t, apis.autoScalePolicyApi, testutil.AutoScalePolicyData())
+	testutil.InternalAppCreate(t, apis.appApi, testutil.AppData())
+	testutil.InternalClusterInstCreate(t, apis.clusterInstApi, testutil.ClusterInstData())
+	testutil.InternalAppInstCreate(t, apis.appInstApi, testutil.AppInstData())
 	// Create a reservable clusterInst
-	cinst := testutil.ClusterInstData[7]
+	cinst := testutil.ClusterInstData()[7]
 	streamOut := testutil.NewCudStreamoutAppInst(ctx)
 	appinst := edgeproto.AppInst{}
-	appinst.Key.AppKey = testutil.AppData[0].Key
+	appinst.Key.AppKey = testutil.AppData()[0].Key
 	appinst.Key.ClusterInstKey = *cinst.Key.Virtual("")
 	err := apis.appInstApi.CreateAppInst(&appinst, streamOut)
 	require.Nil(t, err, "create AppInst")
 	// Inject AppInst info check that all appInsts are Healthy
-	for ii, _ := range testutil.AppInstInfoData {
-		in := &testutil.AppInstInfoData[ii]
-		apis.appInstInfoApi.Update(ctx, in, 0)
+	for _, in := range testutil.AppInstInfoData() {
+		apis.appInstInfoApi.Update(ctx, &in, 0)
 	}
 	for _, val := range apis.appInstApi.cache.Objs {
 		require.Equal(t, dme.HealthCheck_HEALTH_CHECK_OK, val.Obj.HealthCheck)
 	}
 	// Trigger Alerts
-	for _, alert := range testutil.AlertData {
+	for _, alert := range testutil.AlertData() {
 		apis.alertApi.Update(ctx, &alert, 0)
 	}
 	// Check reservable cluster

--- a/cmd/controller/alertpolicy_api_test.go
+++ b/cmd/controller/alertpolicy_api_test.go
@@ -51,34 +51,34 @@ func TestAlertPolicyApi(t *testing.T) {
 	dummyResponder.InitDummyInfoResponder()
 	reduceInfoTimeouts(t, ctx, apis)
 	// create supporting data
-	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData)
-	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData)
-	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData)
+	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData())
+	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData())
+	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData())
 	testutil.InternalCloudletCreate(t, apis.cloudletApi, testutil.CloudletData())
-	insertCloudletInfo(ctx, apis, testutil.CloudletInfoData)
-	testutil.InternalAutoProvPolicyCreate(t, apis.autoProvPolicyApi, testutil.AutoProvPolicyData)
-	testutil.InternalAutoScalePolicyCreate(t, apis.autoScalePolicyApi, testutil.AutoScalePolicyData)
-	testutil.InternalAppCreate(t, apis.appApi, testutil.AppData)
-	testutil.InternalClusterInstCreate(t, apis.clusterInstApi, testutil.ClusterInstData)
-	testutil.InternalCloudletRefsTest(t, "show", apis.cloudletRefsApi, testutil.CloudletRefsData)
+	insertCloudletInfo(ctx, apis, testutil.CloudletInfoData())
+	testutil.InternalAutoProvPolicyCreate(t, apis.autoProvPolicyApi, testutil.AutoProvPolicyData())
+	testutil.InternalAutoScalePolicyCreate(t, apis.autoScalePolicyApi, testutil.AutoScalePolicyData())
+	testutil.InternalAppCreate(t, apis.appApi, testutil.AppData())
+	testutil.InternalClusterInstCreate(t, apis.clusterInstApi, testutil.ClusterInstData())
+	testutil.InternalCloudletRefsTest(t, "show", apis.cloudletRefsApi, testutil.CloudletRefsData())
 	clusterInstCnt := len(apis.clusterInstApi.cache.Objs)
-	require.Equal(t, len(testutil.ClusterInstData), clusterInstCnt)
-	testutil.InternalAppInstCreate(t, apis.appInstApi, testutil.AppInstData)
+	require.Equal(t, len(testutil.ClusterInstData()), clusterInstCnt)
+	testutil.InternalAppInstCreate(t, apis.appInstApi, testutil.AppInstData())
 
 	// Invalid severity
-	userAlert := testutil.AlertPolicyData[0]
+	userAlert := testutil.AlertPolicyData()[0]
 	userAlert.Severity = "invalid"
 	_, err := apis.alertPolicyApi.CreateAlertPolicy(ctx, &userAlert)
 	require.NotNil(t, err, "Invlid severity passed in")
 
 	// Invalid set of conditions for an alert
-	userAlert = testutil.AlertPolicyData[0]
+	userAlert = testutil.AlertPolicyData()[0]
 	userAlert.ActiveConnLimit = 10
 	_, err = apis.alertPolicyApi.CreateAlertPolicy(ctx, &userAlert)
 	require.NotNil(t, err, "Both active connections and cpu cannot be set for a user alert")
 
 	// Invalid set of conditions for an alert
-	userAlert = testutil.AlertPolicyData[0]
+	userAlert = testutil.AlertPolicyData()[0]
 	userAlert.ActiveConnLimit = 0
 	userAlert.CpuUtilizationLimit = 0
 	userAlert.MemUtilizationLimit = 0
@@ -87,36 +87,36 @@ func TestAlertPolicyApi(t *testing.T) {
 	require.NotNil(t, err, "User Alert should have at least one set value")
 
 	// Invalid set of conditions for an alert
-	userAlert = testutil.AlertPolicyData[0]
+	userAlert = testutil.AlertPolicyData()[0]
 	userAlert.CpuUtilizationLimit = 200
 	_, err = apis.alertPolicyApi.CreateAlertPolicy(ctx, &userAlert)
 	require.NotNil(t, err, "Cpu cannot be >100%")
 
 	// Create user alert with trigger time, that's invalid
-	userAlert = testutil.AlertPolicyData[0]
+	userAlert = testutil.AlertPolicyData()[0]
 	userAlert.TriggerTime = 0
 	_, err = apis.alertPolicyApi.CreateAlertPolicy(ctx, &userAlert)
 	require.NotNil(t, err, "Trigger Time should be at least 30s")
 
 	// Create user alert with trigger time, that's invalid
-	userAlert = testutil.AlertPolicyData[0]
+	userAlert = testutil.AlertPolicyData()[0]
 	userAlert.TriggerTime = edgeproto.Duration(80 * time.Hour)
 	_, err = apis.alertPolicyApi.CreateAlertPolicy(ctx, &userAlert)
 	require.NotNil(t, err, "Trigger Time cannot exceed 3 days")
 
 	// Delete non-existent user alert
-	userAlert = testutil.AlertPolicyData[0]
+	userAlert = testutil.AlertPolicyData()[0]
 	_, err = apis.alertPolicyApi.DeleteAlertPolicy(ctx, &userAlert)
 	require.NotNil(t, err)
 	require.Equal(t, err, userAlert.Key.NotFoundError())
 
 	// Create a user alerts
-	testutil.InternalAlertPolicyTest(t, "cud", apis.alertPolicyApi, testutil.AlertPolicyData)
+	testutil.InternalAlertPolicyTest(t, "cud", apis.alertPolicyApi, testutil.AlertPolicyData())
 
 	// Add alert to app
 	appAlert := edgeproto.AppAlertPolicy{
-		AppKey:      testutil.AppData[0].Key,
-		AlertPolicy: testutil.AlertPolicyData[0].Key.Name,
+		AppKey:      testutil.AppData()[0].Key,
+		AlertPolicy: testutil.AlertPolicyData()[0].Key.Name,
 	}
 	_, err = apis.appApi.AddAppAlertPolicy(ctx, &appAlert)
 	require.Nil(t, err)
@@ -132,38 +132,38 @@ func TestAlertPolicyApi(t *testing.T) {
 	require.NotNil(t, err, "User Alert Should exist on the app to be removed")
 
 	// Remove user alert, that is configured on the app - should fail
-	userAlert = testutil.AlertPolicyData[0]
+	userAlert = testutil.AlertPolicyData()[0]
 	_, err = apis.alertPolicyApi.DeleteAlertPolicy(ctx, &userAlert)
 	require.NotNil(t, err, "Cannot delete alert that's configured on an app")
 
 	// Update user alert - add invalid selection
-	userAlert = testutil.AlertPolicyData[1]
+	userAlert = testutil.AlertPolicyData()[1]
 	userAlert.CpuUtilizationLimit = 30
 	userAlert.Fields = []string{edgeproto.AlertPolicyFieldCpuUtilizationLimit}
 	_, err = apis.alertPolicyApi.UpdateAlertPolicy(ctx, &userAlert)
 	require.NotNil(t, err, "Should not be allowed to update alert with invalid set of arguments")
-	userAlert = testutil.AlertPolicyData[1]
+	userAlert = testutil.AlertPolicyData()[1]
 	userAlert.TriggerTime = 0
 	userAlert.Fields = []string{edgeproto.AlertPolicyFieldTriggerTime}
 	_, err = apis.alertPolicyApi.UpdateAlertPolicy(ctx, &userAlert)
 	require.NotNil(t, err, "Should not be allowed to update alert with invalid trigger time")
 
 	// Update user alert
-	userAlert = testutil.AlertPolicyData[0]
+	userAlert = testutil.AlertPolicyData()[0]
 	userAlert.CpuUtilizationLimit = 90
 	_, err = apis.alertPolicyApi.UpdateAlertPolicy(ctx, &userAlert)
 	require.Nil(t, err)
 
 	// Remove user alert from the app
 	appAlert = edgeproto.AppAlertPolicy{
-		AppKey:      testutil.AppData[0].Key,
-		AlertPolicy: testutil.AlertPolicyData[0].Key.Name,
+		AppKey:      testutil.AppData()[0].Key,
+		AlertPolicy: testutil.AlertPolicyData()[0].Key.Name,
 	}
 	_, err = apis.appApi.RemoveAppAlertPolicy(ctx, &appAlert)
 	require.Nil(t, err)
 
 	// Delete all user alert
-	userAlert = testutil.AlertPolicyData[0]
+	userAlert = testutil.AlertPolicyData()[0]
 	_, err = apis.alertPolicyApi.DeleteAlertPolicy(ctx, &userAlert)
 	require.Nil(t, err)
 }

--- a/cmd/controller/appinst_api_test.go
+++ b/cmd/controller/appinst_api_test.go
@@ -125,7 +125,7 @@ func TestAppInstApi(t *testing.T) {
 	reduceInfoTimeouts(t, ctx, apis)
 
 	// cannote create instances without apps and cloudlets
-	for _, data := range testutil.AppInstData {
+	for _, data := range testutil.AppInstData() {
 		obj := data
 		err := apis.appInstApi.CreateAppInst(&obj, testutil.NewCudStreamoutAppInst(ctx))
 		require.NotNil(t, err, "Create app inst without apps/cloudlets")
@@ -134,18 +134,18 @@ func TestAppInstApi(t *testing.T) {
 	}
 
 	// create supporting data
-	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData)
-	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData)
-	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData)
+	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData())
+	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData())
+	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData())
 	testutil.InternalCloudletCreate(t, apis.cloudletApi, testutil.CloudletData())
-	insertCloudletInfo(ctx, apis, testutil.CloudletInfoData)
-	testutil.InternalAutoProvPolicyCreate(t, apis.autoProvPolicyApi, testutil.AutoProvPolicyData)
-	testutil.InternalAutoScalePolicyCreate(t, apis.autoScalePolicyApi, testutil.AutoScalePolicyData)
-	testutil.InternalAppCreate(t, apis.appApi, testutil.AppData)
-	testutil.InternalClusterInstCreate(t, apis.clusterInstApi, testutil.ClusterInstData)
-	testutil.InternalCloudletRefsTest(t, "show", apis.cloudletRefsApi, testutil.CloudletRefsData)
+	insertCloudletInfo(ctx, apis, testutil.CloudletInfoData())
+	testutil.InternalAutoProvPolicyCreate(t, apis.autoProvPolicyApi, testutil.AutoProvPolicyData())
+	testutil.InternalAutoScalePolicyCreate(t, apis.autoScalePolicyApi, testutil.AutoScalePolicyData())
+	testutil.InternalAppCreate(t, apis.appApi, testutil.AppData())
+	testutil.InternalClusterInstCreate(t, apis.clusterInstApi, testutil.ClusterInstData())
+	testutil.InternalCloudletRefsTest(t, "show", apis.cloudletRefsApi, testutil.CloudletRefsData())
 	clusterInstCnt := len(apis.clusterInstApi.cache.Objs)
-	require.Equal(t, len(testutil.ClusterInstData), clusterInstCnt)
+	require.Equal(t, len(testutil.ClusterInstData()), clusterInstCnt)
 
 	// Set responder to fail. This should clean up the object after
 	// the fake crm returns a failure. If it doesn't, the next test to
@@ -153,7 +153,7 @@ func TestAppInstApi(t *testing.T) {
 	responder.SetSimulateAppCreateFailure(true)
 	// clean up on failure may find ports inconsistent
 	RequireAppInstPortConsistency = false
-	for ii, data := range testutil.AppInstData {
+	for ii, data := range testutil.AppInstData() {
 		obj := data // make new copy since range variable gets reused each iter
 		if testutil.IsAutoClusterAutoDeleteApp(&obj.Key) {
 			continue
@@ -180,18 +180,18 @@ func TestAppInstApi(t *testing.T) {
 	RequireAppInstPortConsistency = true
 	require.Equal(t, 0, len(apis.appInstApi.cache.Objs))
 	require.Equal(t, clusterInstCnt, len(apis.clusterInstApi.cache.Objs))
-	testutil.InternalCloudletRefsTest(t, "show", apis.cloudletRefsApi, testutil.CloudletRefsData)
+	testutil.InternalCloudletRefsTest(t, "show", apis.cloudletRefsApi, testutil.CloudletRefsData())
 
-	testutil.InternalAppInstTest(t, "cud", apis.appInstApi, testutil.AppInstData, testutil.WithCreatedAppInstTestData(testutil.CreatedAppInstData()))
+	testutil.InternalAppInstTest(t, "cud", apis.appInstApi, testutil.AppInstData(), testutil.WithCreatedAppInstTestData(testutil.CreatedAppInstData()))
 	InternalAppInstCachedFieldsTest(t, ctx, apis)
 	// check cluster insts created (includes explicit and auto)
 	testutil.InternalClusterInstTest(t, "show", apis.clusterInstApi,
-		append(testutil.ClusterInstData, testutil.ClusterInstAutoData...))
-	require.Equal(t, len(testutil.ClusterInstData)+len(testutil.ClusterInstAutoData), len(apis.clusterInstApi.cache.Objs))
+		append(testutil.ClusterInstData(), testutil.ClusterInstAutoData()...))
+	require.Equal(t, len(testutil.ClusterInstData())+len(testutil.ClusterInstAutoData()), len(apis.clusterInstApi.cache.Objs))
 
 	// after app insts create, check that cloudlet refs data is correct.
 	// Note this refs data is a second set after app insts were created.
-	testutil.InternalCloudletRefsTest(t, "show", apis.cloudletRefsApi, testutil.CloudletRefsWithAppInstsData)
+	testutil.InternalCloudletRefsTest(t, "show", apis.cloudletRefsApi, testutil.CloudletRefsWithAppInstsData())
 	testutil.InternalAppInstRefsTest(t, "show", apis.appInstRefsApi, testutil.GetAppInstRefsData())
 
 	// Test for being created and being deleted errors.
@@ -201,7 +201,7 @@ func TestAppInstApi(t *testing.T) {
 
 	// Set responder to fail delete.
 	responder.SetSimulateAppDeleteFailure(true)
-	obj := testutil.AppInstData[0]
+	obj := testutil.AppInstData()[0]
 	err := apis.appInstApi.DeleteAppInst(&obj, testutil.NewCudStreamoutAppInst(ctx))
 	require.NotNil(t, err, "Delete AppInst responder failure")
 	responder.SetSimulateAppDeleteFailure(false)
@@ -211,7 +211,7 @@ func TestAppInstApi(t *testing.T) {
 	msgs := GetAppInstStreamMsgs(t, ctx, &obj.Key, apis, Fail)
 	require.Greater(t, len(msgs), 0, "some progress messages before failure")
 
-	obj = testutil.AppInstData[0]
+	obj = testutil.AppInstData()[0]
 	// check override of error DELETE_ERROR
 	err = forceAppInstState(ctx, &obj, edgeproto.TrackedState_DELETE_ERROR, responder, apis)
 	require.Nil(t, err, "force state")
@@ -265,21 +265,21 @@ func TestAppInstApi(t *testing.T) {
 	// override CRM error
 	responder.SetSimulateAppCreateFailure(true)
 	responder.SetSimulateAppDeleteFailure(true)
-	obj = testutil.AppInstData[0]
+	obj = testutil.AppInstData()[0]
 	obj.CrmOverride = edgeproto.CRMOverride_IGNORE_CRM_ERRORS
 	err = apis.appInstApi.CreateAppInst(&obj, testutil.NewCudStreamoutAppInst(ctx))
 	require.Nil(t, err, "override crm error")
-	obj = testutil.AppInstData[0]
+	obj = testutil.AppInstData()[0]
 	obj.CrmOverride = edgeproto.CRMOverride_IGNORE_CRM_ERRORS
 	err = apis.appInstApi.DeleteAppInst(&obj, testutil.NewCudStreamoutAppInst(ctx))
 	require.Nil(t, err, "override crm error")
 
 	// ignore CRM
-	obj = testutil.AppInstData[0]
+	obj = testutil.AppInstData()[0]
 	obj.CrmOverride = edgeproto.CRMOverride_IGNORE_CRM
 	err = apis.appInstApi.CreateAppInst(&obj, testutil.NewCudStreamoutAppInst(ctx))
 	require.Nil(t, err, "ignore crm")
-	obj = testutil.AppInstData[0]
+	obj = testutil.AppInstData()[0]
 	obj.CrmOverride = edgeproto.CRMOverride_IGNORE_CRM
 	err = apis.appInstApi.DeleteAppInst(&obj, testutil.NewCudStreamoutAppInst(ctx))
 	require.Nil(t, err, "ignore crm")
@@ -293,13 +293,13 @@ func TestAppInstApi(t *testing.T) {
 		if !edgeproto.IsTransientState(state) {
 			continue
 		}
-		obj = testutil.AppInstData[0]
+		obj = testutil.AppInstData()[0]
 		err = apis.appInstApi.CreateAppInst(&obj, testutil.NewCudStreamoutAppInst(ctx))
 		require.Nil(t, err, "create AppInst")
 		err = forceAppInstState(ctx, &obj, state, responder, apis)
 		require.Nil(t, err, "force state")
 		checkAppInstState(t, ctx, commonApi, &obj, state)
-		obj = testutil.AppInstData[0]
+		obj = testutil.AppInstData()[0]
 		obj.CrmOverride = edgeproto.CRMOverride_IGNORE_CRM_AND_TRANSIENT_STATE
 		err = apis.appInstApi.DeleteAppInst(&obj, testutil.NewCudStreamoutAppInst(ctx))
 		require.Nil(t, err, "override crm and transient state %s", stateName)
@@ -338,14 +338,14 @@ func TestAppInstApi(t *testing.T) {
 	}
 
 	// test appint create with overlapping ports
-	obj = testutil.AppInstData[0]
-	obj.Key.AppKey = testutil.AppData[1].Key
+	obj = testutil.AppInstData()[0]
+	obj.Key.AppKey = testutil.AppData()[1].Key
 	err = apis.appInstApi.CreateAppInst(&obj, testutil.NewCudStreamoutAppInst(ctx))
 	require.NotNil(t, err, "Overlapping ports would trigger an app inst create failure")
 	require.Contains(t, err.Error(), "port 80 is already in use")
 
 	// delete all AppInsts and Apps and check that refs are empty
-	for ii, data := range testutil.AppInstData {
+	for ii, data := range testutil.AppInstData() {
 		obj := data
 		if ii == 0 {
 			// skip AppInst[0], it was deleted earlier in the test
@@ -367,7 +367,7 @@ func TestAppInstApi(t *testing.T) {
 	apis.clusterInstApi.cleanupIdleReservableAutoClusters(ctx, time.Duration(0))
 	apis.clusterInstApi.cleanupWorkers.WaitIdle()
 
-	for ii, data := range testutil.AppData {
+	for ii, data := range testutil.AppData() {
 		obj := data
 		_, err := apis.appApi.DeleteApp(ctx, &obj)
 		require.Nil(t, err, "Delete app %d: %s failed", ii, obj.Key.GetKeyString())
@@ -384,7 +384,7 @@ func appInstCachedFieldsTest(t *testing.T, ctx context.Context, cAppApi *testuti
 
 	// update app and check that app insts are updated
 	updater := edgeproto.App{}
-	updater.Key = testutil.AppData[0].Key
+	updater.Key = testutil.AppData()[0].Key
 	newPath := "resources: a new config"
 	updater.AndroidPackageName = newPath
 	updater.Fields = make([]string, 0)
@@ -395,7 +395,7 @@ func appInstCachedFieldsTest(t *testing.T, ctx context.Context, cAppApi *testuti
 	show := testutil.ShowAppInst{}
 	show.Init()
 	filter := edgeproto.AppInst{}
-	filter.Key.AppKey = testutil.AppData[0].Key
+	filter.Key.AppKey = testutil.AppData()[0].Key
 	err = cAppInstApi.ShowAppInst(ctx, &filter, &show)
 	require.Nil(t, err, "show app inst data")
 	require.True(t, len(show.Data) > 0, "number of matching app insts")
@@ -461,15 +461,15 @@ func TestAutoClusterInst(t *testing.T) {
 	reduceInfoTimeouts(t, ctx, apis)
 
 	// create supporting data
-	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData)
-	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData)
-	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData)
+	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData())
+	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData())
+	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData())
 	testutil.InternalCloudletCreate(t, apis.cloudletApi, testutil.CloudletData())
-	insertCloudletInfo(ctx, apis, testutil.CloudletInfoData)
-	testutil.InternalAutoProvPolicyCreate(t, apis.autoProvPolicyApi, testutil.AutoProvPolicyData)
-	testutil.InternalAppCreate(t, apis.appApi, testutil.AppData)
+	insertCloudletInfo(ctx, apis, testutil.CloudletInfoData())
+	testutil.InternalAutoProvPolicyCreate(t, apis.autoProvPolicyApi, testutil.AutoProvPolicyData())
+	testutil.InternalAppCreate(t, apis.appApi, testutil.AppData())
 	// multi-tenant ClusterInst
-	mt := testutil.ClusterInstData[8]
+	mt := testutil.ClusterInstData()[8]
 	require.True(t, mt.MultiTenant)
 	// negative tests
 	// bad Organization
@@ -542,8 +542,8 @@ func TestAutoClusterInst(t *testing.T) {
 	}
 
 	// create auto-cluster AppInsts
-	appInst := testutil.AppInstData[0]
-	appInst.Key.AppKey = testutil.AppData[1].Key // does not support multi-tenant
+	appInst := testutil.AppInstData()[0]
+	appInst.Key.AppKey = testutil.AppData()[1].Key // does not support multi-tenant
 	cloudletKey := appInst.Key.ClusterInstKey.CloudletKey
 	createAutoClusterAppInst(appInst, "0")
 	checkReservedIds(cloudletKey, 1)
@@ -582,7 +582,7 @@ func TestAutoClusterInst(t *testing.T) {
 	checkReservedIds(cloudletKey, 0)
 
 	// Autocluster AppInst with AutoDelete delete option should fail
-	autoDeleteAppInst := testutil.AppInstData[10]
+	autoDeleteAppInst := testutil.AppInstData()[10]
 	autoDeleteAppInst.RealClusterName = ""
 	autoDeleteAppInst.Key.ClusterInstKey.ClusterKey.Name = cloudcommon.AutoClusterPrefix + "foo"
 	err = apis.appInstApi.CreateAppInst(&autoDeleteAppInst, testutil.NewCudStreamoutAppInst(ctx))
@@ -607,7 +607,7 @@ func TestAutoClusterInst(t *testing.T) {
 func testDeprecatedAutoCluster(t *testing.T, ctx context.Context, apis *AllApis) {
 	// downgrade cloudlets to older crm compatibility version
 	cloudletInfos := []edgeproto.CloudletInfo{}
-	for _, info := range testutil.CloudletInfoData {
+	for _, info := range testutil.CloudletInfoData() {
 		info.CompatibilityVersion = 0
 		cloudletInfos = append(cloudletInfos, info)
 	}
@@ -615,7 +615,7 @@ func testDeprecatedAutoCluster(t *testing.T, ctx context.Context, apis *AllApis)
 
 	// existing AppInst creates should fail because the ClusterInst org
 	// must match the AppInst org.
-	for ii, data := range testutil.AppInstData {
+	for ii, data := range testutil.AppInstData() {
 		obj := data
 		if !strings.HasPrefix(obj.Key.ClusterInstKey.ClusterKey.Name, cloudcommon.AutoClusterPrefix) {
 			continue
@@ -632,7 +632,7 @@ func testDeprecatedAutoCluster(t *testing.T, ctx context.Context, apis *AllApis)
 
 	appInsts := []edgeproto.AppInst{}
 	clusterInsts := []edgeproto.ClusterInst{}
-	for ii, data := range testutil.AppInstData {
+	for ii, data := range testutil.AppInstData() {
 		obj := data
 		if !strings.HasPrefix(obj.Key.ClusterInstKey.ClusterKey.Name, cloudcommon.AutoClusterPrefix) {
 			continue
@@ -645,7 +645,7 @@ func testDeprecatedAutoCluster(t *testing.T, ctx context.Context, apis *AllApis)
 		require.Nil(t, err, "Create autocluster appinst[%d]: %v", ii, obj.Key)
 		// find app for AppInst
 		var app *edgeproto.App
-		for _, a := range testutil.AppData {
+		for _, a := range testutil.AppData() {
 			if a.Key.Matches(&obj.Key.AppKey) {
 				app = &a
 				break
@@ -679,7 +679,7 @@ func testDeprecatedAutoCluster(t *testing.T, ctx context.Context, apis *AllApis)
 func testDeprecatedSharedRootLBFQDN(t *testing.T, ctx context.Context, apis *AllApis) {
 	// downgrade cloudlets to older crm compatibility version
 	cloudletInfos := []edgeproto.CloudletInfo{}
-	for _, info := range testutil.CloudletInfoData {
+	for _, info := range testutil.CloudletInfoData() {
 		info.CompatibilityVersion = 0
 		cloudletInfos = append(cloudletInfos, info)
 	}
@@ -687,7 +687,7 @@ func testDeprecatedSharedRootLBFQDN(t *testing.T, ctx context.Context, apis *All
 
 	// create appInst with internalports set to true, this means
 	// that this appInst will not need access from external network
-	appInstData := testutil.AppInstData[9]
+	appInstData := testutil.AppInstData()[9]
 	err := apis.appInstApi.CreateAppInst(&appInstData, testutil.NewCudStreamoutAppInst(ctx))
 	require.Nil(t, err, "Create appinst: %v", appInstData.Key)
 
@@ -776,7 +776,7 @@ func testAppFlavorRequest(t *testing.T, ctx context.Context, api *testutil.AppIn
 	}
 	_, err := apis.flavorApi.CreateFlavor(ctx, &testflavor)
 	require.Nil(t, err, "CreateFlavor")
-	nonNomApp := testutil.AppInstData[2]
+	nonNomApp := testutil.AppInstData()[2]
 	nonNomApp.Flavor = testflavor.Key
 	err = apis.appInstApi.CreateAppInst(&nonNomApp, testutil.NewCudStreamoutAppInst(ctx))
 	require.NotNil(t, err, "non-nom-app-create")
@@ -789,7 +789,7 @@ func testAppInstOverrideTransientDelete(t *testing.T, ctx context.Context, api *
 	// autocluster app
 	ai := edgeproto.AppInst{
 		Key: edgeproto.AppInstKey{
-			AppKey: testutil.AppData[0].Key,
+			AppKey: testutil.AppData()[0].Key,
 			ClusterInstKey: edgeproto.VirtualClusterInstKey{
 				ClusterKey: edgeproto.ClusterKey{
 					Name: util.K8SSanitize(cloudcommon.AutoClusterPrefix + "override-clust"),
@@ -800,10 +800,10 @@ func testAppInstOverrideTransientDelete(t *testing.T, ctx context.Context, api *
 		},
 	}
 	// autoapp
-	require.Equal(t, edgeproto.DeleteType_AUTO_DELETE, testutil.AppData[9].DelOpt)
+	require.Equal(t, edgeproto.DeleteType_AUTO_DELETE, testutil.AppData()[9].DelOpt)
 	aiauto := edgeproto.AppInst{
 		Key: edgeproto.AppInstKey{
-			AppKey:         testutil.AppData[9].Key, // auto-delete app
+			AppKey:         testutil.AppData()[9].Key, // auto-delete app
 			ClusterInstKey: ai.Key.ClusterInstKey,
 		},
 	}
@@ -894,7 +894,7 @@ func testSingleKubernetesCloudlet(t *testing.T, ctx context.Context, apis *AllAp
 		CompatibilityVersion: 2, // cloudcommon.GetCRMCompatibilityVersion()
 	}
 	mtOrg := edgeproto.OrganizationEdgeCloud
-	stOrg := testutil.AppInstData[0].Key.AppKey.Organization
+	stOrg := testutil.AppInstData()[0].Key.AppKey.Organization
 
 	cloudletST := cloudletMT
 	cloudletST.Key.Name = "singlek8sST"
@@ -932,7 +932,7 @@ func testSingleKubernetesCloudlet(t *testing.T, ctx context.Context, apis *AllAp
 				},
 				Organization: "foo",
 			},
-			Flavor:     testutil.FlavorData[0].Key,
+			Flavor:     testutil.FlavorData()[0].Key,
 			NumMasters: 1,
 			NumNodes:   2,
 		}
@@ -1043,7 +1043,7 @@ func testSingleKubernetesCloudlet(t *testing.T, ctx context.Context, apis *AllAp
 		"Cannot deploy docker app to single kubernetes cloudlet",
 	}}
 	for _, test := range appInstCreateTests {
-		ai := testutil.AppInstData[test.aiIdx]
+		ai := testutil.AppInstData()[test.aiIdx]
 		ai.Key.ClusterInstKey.CloudletKey = test.cloudlet.Key
 		ai.Key.ClusterInstKey.ClusterKey.Name = test.clusterName
 		ai.Key.ClusterInstKey.Organization = test.clusterOrg
@@ -1076,7 +1076,7 @@ func testSingleKubernetesCloudlet(t *testing.T, ctx context.Context, apis *AllAp
 	for _, test := range cleanupTests {
 		clusterInstKey := getDefaultClustKey(test.cloudlet.Key, test.ownerOrg)
 		// Create AppInst
-		ai := testutil.AppInstData[0]
+		ai := testutil.AppInstData()[0]
 		ai.Key.ClusterInstKey.CloudletKey = test.cloudlet.Key
 		ai.Key.ClusterInstKey.ClusterKey.Name = "blocker"
 		ai.Key.ClusterInstKey.Organization = clusterInstKey.Organization
@@ -1124,7 +1124,7 @@ func testAppInstId(t *testing.T, ctx context.Context, apis *AllApis) {
 	// In this case, we purposely name the Apps so that the generated
 	// ids will conflict.
 	// Both app Keys should dns sanitize to "app110"
-	app0 := testutil.AppData[0]
+	app0 := testutil.AppData()[0]
 	app0.Key.Name = "app"
 	app0.Key.Version = "1.1.0"
 	app0.AccessPorts = "tcp:81"
@@ -1134,7 +1134,7 @@ func testAppInstId(t *testing.T, ctx context.Context, apis *AllApis) {
 	app1.Key.Version = "1.0"
 	app0.AccessPorts = "tcp:82"
 
-	appInst0 := testutil.AppInstData[0]
+	appInst0 := testutil.AppInstData()[0]
 	appInst0.Key.AppKey = app0.Key
 
 	appInst1 := appInst0
@@ -1142,7 +1142,7 @@ func testAppInstId(t *testing.T, ctx context.Context, apis *AllApis) {
 
 	// also create ClusterInsts because they share the same dns id
 	// namespace as AppInsts
-	cl0 := testutil.ClusterInstData[0]
+	cl0 := testutil.ClusterInstData()[0]
 	cl0.Key.ClusterKey.Name = app0.Key.Name + app0.Key.Version
 	cl0.Key.Organization = app0.Key.Organization
 
@@ -1270,20 +1270,20 @@ func TestAppInstIdDelimiter(t *testing.T) {
 	// in it. That will allow any platform-specific code
 	// to append further strings to it, delimited by '.',
 	// and maintain the uniqueness.
-	for _, ai := range testutil.AppInstData {
+	for _, ai := range testutil.AppInstData() {
 		// need the app definition as well
-		for _, app := range testutil.AppData {
+		for _, app := range testutil.AppData() {
 			if app.Key.Matches(&ai.Key.AppKey) {
 				id, _ := pfutils.GetAppInstId(ctx, &ai, &app, "", edgeproto.PlatformType_PLATFORM_TYPE_FAKE)
 				require.NotContains(t, id, ".", "id must not contain '.'")
 			}
 		}
 	}
-	app := testutil.AppData[0]
+	app := testutil.AppData()[0]
 	app.Key.Name += "."
 	app.Key.Organization += "."
 	app.Key.Version += "."
-	appInst := testutil.AppInstData[0]
+	appInst := testutil.AppInstData()[0]
 	appInst.Key.AppKey = app.Key
 	appInst.Key.ClusterInstKey.ClusterKey.Name += "."
 	appInst.Key.ClusterInstKey.Organization += "."
@@ -1345,8 +1345,8 @@ func testBeingErrors(t *testing.T, ctx context.Context, responder *DummyInfoResp
 
 	testedAutoCluster := false
 	// Error messages may vary based on autocluster/no-autocluster
-	for ii := 0; ii < len(testutil.AppInstData); ii++ {
-		ai := testutil.AppInstData[ii]
+	for ii := 0; ii < len(testutil.AppInstData()); ii++ {
+		ai := testutil.AppInstData()[ii]
 		if strings.HasPrefix(ai.Key.ClusterInstKey.ClusterKey.Name, cloudcommon.AutoClusterPrefix) {
 			testedAutoCluster = true
 		}
@@ -1369,7 +1369,7 @@ func testBeingErrors(t *testing.T, ctx context.Context, responder *DummyInfoResp
 		wg.Wait()
 
 		// start create of appinst
-		ai = testutil.AppInstData[ii]
+		ai = testutil.AppInstData()[ii]
 		wg.Add(1)
 		responder.SetPause(true)
 		go func() {

--- a/cmd/controller/appinstclient_api_test.go
+++ b/cmd/controller/appinstclient_api_test.go
@@ -78,7 +78,7 @@ func TestAppInstClientApi(t *testing.T) {
 
 	qSize := int(apis.settingsApi.Get().MaxTrackedDmeClients)
 	// Add a client for a non-existent AppInst
-	apis.appInstClientApi.RecvAppInstClient(ctx, &testutil.AppInstClientData[0])
+	apis.appInstClientApi.RecvAppInstClient(ctx, &testutil.AppInstClientData()[0])
 	// Make sure that we didn't save it
 	require.Empty(t, apis.appInstClientApi.appInstClients)
 	// Try to do a show without an org in the ClientKey
@@ -92,57 +92,57 @@ func TestAppInstClientApi(t *testing.T) {
 	// Tests to verify that queue is being handled correctly
 	// Add a channel for appInst1
 	ch1 := make(chan edgeproto.AppInstClient, qSize)
-	apis.appInstClientApi.SetRecvChan(ctx, &testutil.AppInstClientKeyData[0], ch1)
+	apis.appInstClientApi.SetRecvChan(ctx, &testutil.AppInstClientKeyData()[0], ch1)
 	// Wait for local cache since it's in a separate go routine
 	notify.WaitFor(&apis.appInstClientKeyApi.cache, 1)
 
 	// Add Client for AppInst1
-	apis.appInstClientApi.AddAppInstClient(ctx, &testutil.AppInstClientData[0])
+	apis.appInstClientApi.AddAppInstClient(ctx, &testutil.AppInstClientData()[0])
 	// Check client is received in the channel
 	appInstClient := <-ch1
-	assert.Equal(t, testutil.AppInstClientData[0], appInstClient)
+	assert.Equal(t, testutil.AppInstClientData()[0], appInstClient)
 	// 3. Add a second channel for the different appInst
 	ch2 := make(chan edgeproto.AppInstClient, qSize)
-	apis.appInstClientApi.SetRecvChan(ctx, &testutil.AppInstClientKeyData[1], ch2)
+	apis.appInstClientApi.SetRecvChan(ctx, &testutil.AppInstClientKeyData()[1], ch2)
 	// Wait for local cache since it's in a separate go routine
 	notify.WaitFor(&apis.appInstClientKeyApi.cache, 2)
 
 	// Add a Client for AppInst2
-	apis.appInstClientApi.AddAppInstClient(ctx, &testutil.AppInstClientData[3])
+	apis.appInstClientApi.AddAppInstClient(ctx, &testutil.AppInstClientData()[3])
 	// Check client is received in the channel 2
 	appInstClient = <-ch2
-	assert.Equal(t, testutil.AppInstClientData[3], appInstClient)
+	assert.Equal(t, testutil.AppInstClientData()[3], appInstClient)
 	// Delete channel 2 - check that list is 0
-	count := apis.appInstClientApi.ClearRecvChan(ctx, &testutil.AppInstClientKeyData[1], ch2)
+	count := apis.appInstClientApi.ClearRecvChan(ctx, &testutil.AppInstClientKeyData()[1], ch2)
 	assert.Equal(t, 0, count)
 	// Make sure we clean up the buffer and there is nothing
 	assert.Equal(t, 0, len(apis.appInstClientApi.appInstClients))
 	// Delete non-existent channel, return is -1
-	count = apis.appInstClientApi.ClearRecvChan(ctx, &testutil.AppInstClientKeyData[1], ch2)
+	count = apis.appInstClientApi.ClearRecvChan(ctx, &testutil.AppInstClientKeyData()[1], ch2)
 	assert.Equal(t, -1, count)
 	// Add a second Channel for AppInst1
 	ch12 := make(chan edgeproto.AppInstClient, qSize)
-	apis.appInstClientApi.SetRecvChan(ctx, &testutil.AppInstClientKeyData[0], ch12)
+	apis.appInstClientApi.SetRecvChan(ctx, &testutil.AppInstClientKeyData()[0], ch12)
 	// Wait for local cache since it's in a separate go routine
 	notify.WaitFor(&apis.appInstClientKeyApi.cache, 2)
 
 	// Add a client 2 for AppInst1
-	apis.appInstClientApi.AddAppInstClient(ctx, &testutil.AppInstClientData[1])
+	apis.appInstClientApi.AddAppInstClient(ctx, &testutil.AppInstClientData()[1])
 	// Check that both of the channels receive the AppInstClient
 	appInstClient = <-ch1
-	assert.Equal(t, testutil.AppInstClientData[1], appInstClient)
+	assert.Equal(t, testutil.AppInstClientData()[1], appInstClient)
 	appInstClient = <-ch12
-	assert.Equal(t, testutil.AppInstClientData[1], appInstClient)
+	assert.Equal(t, testutil.AppInstClientData()[1], appInstClient)
 	// Delete Channel 1 - verify that count is 1
-	count = apis.appInstClientApi.ClearRecvChan(ctx, &testutil.AppInstClientKeyData[0], ch1)
+	count = apis.appInstClientApi.ClearRecvChan(ctx, &testutil.AppInstClientKeyData()[0], ch1)
 	assert.Equal(t, 1, count)
 	// Add client 3 for AppInst1
-	apis.appInstClientApi.AddAppInstClient(ctx, &testutil.AppInstClientData[2])
+	apis.appInstClientApi.AddAppInstClient(ctx, &testutil.AppInstClientData()[2])
 	// Verify that it's received in channel 2 for appInst1
 	appInstClient = <-ch12
-	assert.Equal(t, testutil.AppInstClientData[2], appInstClient)
+	assert.Equal(t, testutil.AppInstClientData()[2], appInstClient)
 	// Delete channel 2 - verify that count is 0
-	count = apis.appInstClientApi.ClearRecvChan(ctx, &testutil.AppInstClientKeyData[0], ch12)
+	count = apis.appInstClientApi.ClearRecvChan(ctx, &testutil.AppInstClientKeyData()[0], ch12)
 	assert.Equal(t, 0, count)
 
 	dummy.Stop()

--- a/cmd/controller/autoprovpolicy_api_test.go
+++ b/cmd/controller/autoprovpolicy_api_test.go
@@ -57,15 +57,15 @@ func TestAutoProvPolicyApi(t *testing.T) {
 	reduceInfoTimeouts(t, ctx, apis)
 
 	cloudletData := testutil.CloudletData()
-	testutil.InternalAutoProvPolicyTest(t, "cud", apis.autoProvPolicyApi, testutil.AutoProvPolicyData)
-	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData)
-	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData)
-	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData)
+	testutil.InternalAutoProvPolicyTest(t, "cud", apis.autoProvPolicyApi, testutil.AutoProvPolicyData())
+	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData())
+	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData())
+	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData())
 	testutil.InternalCloudletCreate(t, apis.cloudletApi, cloudletData)
 
 	// test adding cloudlet to policy
 	pc := edgeproto.AutoProvPolicyCloudlet{}
-	pc.Key = testutil.AutoProvPolicyData[0].Key
+	pc.Key = testutil.AutoProvPolicyData()[0].Key
 	pc.CloudletKey = cloudletData[0].Key
 
 	_, err := apis.autoProvPolicyApi.AddAutoProvPolicyCloudlet(ctx, &pc)
@@ -78,7 +78,7 @@ func TestAutoProvPolicyApi(t *testing.T) {
 
 	// test adding another cloudlet to policy
 	pc2 := edgeproto.AutoProvPolicyCloudlet{}
-	pc2.Key = testutil.AutoProvPolicyData[0].Key
+	pc2.Key = testutil.AutoProvPolicyData()[0].Key
 	pc2.CloudletKey = cloudletData[1].Key
 
 	_, err = apis.autoProvPolicyApi.AddAutoProvPolicyCloudlet(ctx, &pc2)
@@ -128,13 +128,13 @@ func TestAutoProvPolicyApi(t *testing.T) {
 
 func addRemoveAutoProvPolicy(t *testing.T, ctx context.Context, apis *AllApis) {
 	// add app with multiple policies
-	app := testutil.AppData[11]
+	app := testutil.AppData()[11]
 	require.True(t, len(app.AutoProvPolicies) > 1)
 	_, err := apis.appApi.CreateApp(ctx, &app)
 	require.Nil(t, err)
 
 	// new policy (copy)
-	ap := testutil.AutoProvPolicyData[3]
+	ap := testutil.AutoProvPolicyData()[3]
 	ap.Key.Name = "test-policy"
 	_, err = apis.autoProvPolicyApi.CreateAutoProvPolicy(ctx, &ap)
 	require.Nil(t, err)
@@ -180,7 +180,7 @@ func addRemoveAutoProvPolicy(t *testing.T, ctx context.Context, apis *AllApis) {
 
 func testApiChecks(t *testing.T, ctx context.Context, apis *AllApis) {
 	var err error
-	flavor := testutil.FlavorData[3]
+	flavor := testutil.FlavorData()[3]
 	app := edgeproto.App{}
 	app.Key.Name = "checkDemand"
 	app.Key.Organization = "org"

--- a/cmd/controller/autoscalepolicy_api_test.go
+++ b/cmd/controller/autoscalepolicy_api_test.go
@@ -40,7 +40,7 @@ func TestAutoScalePolicyApi(t *testing.T) {
 	sync.Start()
 	defer sync.Done()
 
-	testutil.InternalAutoScalePolicyTest(t, "cud", apis.autoScalePolicyApi, testutil.AutoScalePolicyData)
+	testutil.InternalAutoScalePolicyTest(t, "cud", apis.autoScalePolicyApi, testutil.AutoScalePolicyData())
 
 	policy := edgeproto.AutoScalePolicy{}
 	policy.Key.Name = "auto-scale-policy-name"

--- a/cmd/controller/cloudlet_api_test.go
+++ b/cmd/controller/cloudlet_api_test.go
@@ -173,9 +173,9 @@ func TestCloudletApi(t *testing.T) {
 
 	// create flavors
 	cloudletData := testutil.CloudletData()
-	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData)
-	testutil.InternalGPUDriverTest(t, "cud", apis.gpuDriverApi, testutil.GPUDriverData)
-	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData)
+	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData())
+	testutil.InternalGPUDriverTest(t, "cud", apis.gpuDriverApi, testutil.GPUDriverData())
+	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData())
 	testutil.InternalCloudletTest(t, "cud", apis.cloudletApi, cloudletData)
 
 	// test invalid location values
@@ -539,16 +539,16 @@ func testResMapKeysApi(t *testing.T, ctx context.Context, cl *edgeproto.Cloudlet
 	// setup the test map using the test_data objects
 	// The AddCloudResMapKey is setup to accept multiple res tbl keys at once
 	// but we're doing it one by one.
-
-	resmap.Mapping[strings.ToLower(edgeproto.OptResNames_name[0])] = testutil.Restblkeys[0].Name
+	restblkeys := testutil.Restblkeys()
+	resmap.Mapping[strings.ToLower(edgeproto.OptResNames_name[0])] = restblkeys[0].Name
 	_, err := apis.cloudletApi.AddCloudletResMapping(ctx, &resmap)
 	require.Nil(t, err, "AddCloudletResMapKey")
 
-	resmap.Mapping[strings.ToLower(edgeproto.OptResNames_name[1])] = testutil.Restblkeys[1].Name
+	resmap.Mapping[strings.ToLower(edgeproto.OptResNames_name[1])] = restblkeys[1].Name
 	_, err = apis.cloudletApi.AddCloudletResMapping(ctx, &resmap)
 	require.Nil(t, err, "AddCloudletResMapKey")
 
-	resmap.Mapping[strings.ToLower(edgeproto.OptResNames_name[2])] = testutil.Restblkeys[2].Name
+	resmap.Mapping[strings.ToLower(edgeproto.OptResNames_name[2])] = restblkeys[2].Name
 	_, err = apis.cloudletApi.AddCloudletResMapping(ctx, &resmap)
 	require.Nil(t, err, "AddCloudletResMapKey")
 
@@ -563,21 +563,21 @@ func testResMapKeysApi(t *testing.T, ctx context.Context, cl *edgeproto.Cloudlet
 
 	// what's in our testcl? Check the resource map
 	tkey := testcl.ResTagMap[strings.ToLower(edgeproto.OptResNames_name[0])]
-	require.Equal(t, testutil.Restblkeys[0].Name, tkey.Name, "AddCloudletResMapKey")
+	require.Equal(t, testutil.Restblkeys()[0].Name, tkey.Name, "AddCloudletResMapKey")
 	tkey = testcl.ResTagMap[strings.ToLower(edgeproto.OptResNames_name[1])]
-	require.Equal(t, testutil.Restblkeys[1].Name, tkey.Name, "AddCloudletResMapKey")
+	require.Equal(t, testutil.Restblkeys()[1].Name, tkey.Name, "AddCloudletResMapKey")
 	tkey = testcl.ResTagMap[strings.ToLower(edgeproto.OptResNames_name[2])]
-	require.Equal(t, testutil.Restblkeys[2].Name, tkey.Name, "AddCloudletResMapKey")
+	require.Equal(t, testutil.Restblkeys()[2].Name, tkey.Name, "AddCloudletResMapKey")
 
 	// and the actual keys should match as well
-	require.Equal(t, testutil.Restblkeys[0], *testcl.ResTagMap[testutil.Restblkeys[0].Name], "AddCloudletResMapKey")
-	require.Equal(t, testutil.Restblkeys[1], *testcl.ResTagMap[testutil.Restblkeys[1].Name], "AddCloudletResMapKey")
-	require.Equal(t, testutil.Restblkeys[2], *testcl.ResTagMap[testutil.Restblkeys[2].Name], "AddCloudletResMapKey")
+	require.Equal(t, testutil.Restblkeys()[0], *testcl.ResTagMap[testutil.Restblkeys()[0].Name], "AddCloudletResMapKey")
+	require.Equal(t, testutil.Restblkeys()[1], *testcl.ResTagMap[testutil.Restblkeys()[1].Name], "AddCloudletResMapKey")
+	require.Equal(t, testutil.Restblkeys()[2], *testcl.ResTagMap[testutil.Restblkeys()[2].Name], "AddCloudletResMapKey")
 
 	resmap1 := edgeproto.CloudletResMap{}
 	resmap1.Mapping = make(map[string]string)
-	resmap1.Mapping[strings.ToLower(edgeproto.OptResNames_name[2])] = testutil.Restblkeys[2].Name
-	resmap1.Mapping[strings.ToLower(edgeproto.OptResNames_name[1])] = testutil.Restblkeys[1].Name
+	resmap1.Mapping[strings.ToLower(edgeproto.OptResNames_name[2])] = testutil.Restblkeys()[2].Name
+	resmap1.Mapping[strings.ToLower(edgeproto.OptResNames_name[1])] = testutil.Restblkeys()[1].Name
 	resmap1.Key = cl.Key
 
 	_, err = apis.cloudletApi.RemoveCloudletResMapping(ctx, &resmap1)
@@ -600,7 +600,7 @@ func testResMapKeysApi(t *testing.T, ctx context.Context, cl *edgeproto.Cloudlet
 	// and check the maps len = 1
 	require.Equal(t, 1, len(rmcl.ResTagMap), "RemoveCloudletResMapKey")
 	// and might as well check the key "gpu" exists
-	_, ok := rmcl.ResTagMap[testutil.Restblkeys[0].Name]
+	_, ok := rmcl.ResTagMap[testutil.Restblkeys()[0].Name]
 	require.Equal(t, true, ok, "RemoveCloudletResMapKey")
 }
 
@@ -615,7 +615,7 @@ func testGpuResourceMapping(t *testing.T, ctx context.Context, cl *edgeproto.Clo
 	// is to take our meta-flavor resourse request object, and return, for this
 	// operator/cloudlet the closest matching available flavor to use in the eventual
 	// launch of a suitable image.
-	var cli edgeproto.CloudletInfo = testutil.CloudletInfoData[0]
+	var cli edgeproto.CloudletInfo = testutil.CloudletInfoData()[0]
 
 	if cl.ResTagMap == nil {
 		cl.ResTagMap = make(map[string]*edgeproto.ResTagTableKey)
@@ -855,7 +855,7 @@ func testGpuResourceMapping(t *testing.T, ctx context.Context, cl *edgeproto.Clo
 }
 
 func testShowFlavorsForCloudlet(t *testing.T, ctx context.Context, apis *AllApis) {
-	insertCloudletInfo(ctx, apis, testutil.CloudletInfoData)
+	insertCloudletInfo(ctx, apis, testutil.CloudletInfoData())
 	// Use a clouldet with no ResourceTagMap
 	cCldApi := testutil.NewInternalCloudletApi(apis.cloudletApi)
 	cld := testutil.CloudletData()[1]
@@ -962,21 +962,21 @@ func TestShowCloudletsAppDeploy(t *testing.T) {
 	show := testutil.ShowCloudletsForAppDeployment{}
 	show.Init()
 
-	app := testutil.AppData[2]
+	app := testutil.AppData()[2]
 	request := edgeproto.DeploymentCloudletRequest{
 		App:          &app,
 		DryRunDeploy: false,
 	}
-	app.DefaultFlavor = testutil.FlavorData[0].Key // x1.tiny
+	app.DefaultFlavor = testutil.FlavorData()[0].Key // x1.tiny
 	app.Deployment = cloudcommon.DeploymentTypeVM
 	filter := request
 
 	// test data
-	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData)
-	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData)
-	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData)
+	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData())
+	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData())
+	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData())
 	testutil.InternalCloudletCreate(t, apis.cloudletApi, testutil.CloudletData())
-	insertCloudletInfo(ctx, apis, testutil.CloudletInfoData)
+	insertCloudletInfo(ctx, apis, testutil.CloudletInfoData())
 
 	// without a responder, clusterInst create waits forever
 	dummyResponder := DummyInfoResponder{
@@ -991,10 +991,10 @@ func TestShowCloudletsAppDeploy(t *testing.T) {
 
 	// either create the policy expected by one of all cloudlets, or remove that bit of config, or
 	// just don't create that specific cloudlet. #1 create the policy.
-	testutil.InternalAutoProvPolicyCreate(t, apis.autoProvPolicyApi, testutil.AutoProvPolicyData)
-	testutil.InternalAutoScalePolicyCreate(t, apis.autoScalePolicyApi, testutil.AutoScalePolicyData)
+	testutil.InternalAutoProvPolicyCreate(t, apis.autoProvPolicyApi, testutil.AutoProvPolicyData())
+	testutil.InternalAutoScalePolicyCreate(t, apis.autoScalePolicyApi, testutil.AutoScalePolicyData())
 
-	for _, obj := range testutil.ClusterInstData {
+	for _, obj := range testutil.ClusterInstData() {
 		err := apis.clusterInstApi.CreateClusterInst(&obj, testutil.NewCudStreamoutClusterInst(ctx))
 		require.Nil(t, err, "Create ClusterInst")
 	}
@@ -1010,13 +1010,13 @@ func TestShowCloudletsAppDeploy(t *testing.T) {
 	// increase the flavor size, and expect fewer cloudlet matches
 	// TODO: create sets of OS flavors to attach to our CloudletInfo objs  as substitues for whats there in test_data.go
 	// for more complex matching.
-	app.DefaultFlavor = testutil.FlavorData[2].Key // 3 = x1.large 4 = x1.tiny.gpu 2 = x1.medium
+	app.DefaultFlavor = testutil.FlavorData()[2].Key // 3 = x1.large 4 = x1.tiny.gpu 2 = x1.medium
 	err = cAppApi.ShowCloudletsForAppDeployment(ctx, &filter, &show)
 	require.Nil(t, err, "ShowCloudletsForAppDeployment")
 	require.Equal(t, 3, len(show.Data), "SHowCloudletsForAppDeployment")
 
 	show.Init()
-	app.DefaultFlavor = testutil.FlavorData[3].Key // 3 = x1.large 4 = x1.tiny.gpu 2 = x1.medium
+	app.DefaultFlavor = testutil.FlavorData()[3].Key // 3 = x1.large 4 = x1.tiny.gpu 2 = x1.medium
 	err = cAppApi.ShowCloudletsForAppDeployment(ctx, &filter, &show)
 	require.Nil(t, err, "ShowCloudletsForAppDeployment")
 	require.Equal(t, 1, len(show.Data), "SHowCloudletsForAppDeployment")

--- a/cmd/controller/cloudletinfo_api_test.go
+++ b/cmd/controller/cloudletinfo_api_test.go
@@ -44,17 +44,17 @@ func TestCloudletInfo(t *testing.T) {
 	defer sync.Done()
 
 	// create supporting data
-	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData)
-	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData)
-	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData)
+	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData())
+	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData())
+	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData())
 	testutil.InternalCloudletCreate(t, apis.cloudletApi, testutil.CloudletData())
-	insertCloudletInfo(ctx, apis, testutil.CloudletInfoData)
+	insertCloudletInfo(ctx, apis, testutil.CloudletInfoData())
 
-	testutil.InternalCloudletInfoTest(t, "show", apis.cloudletInfoApi, testutil.CloudletInfoData)
-	evictCloudletInfo(ctx, apis, testutil.CloudletInfoData)
+	testutil.InternalCloudletInfoTest(t, "show", apis.cloudletInfoApi, testutil.CloudletInfoData())
+	evictCloudletInfo(ctx, apis, testutil.CloudletInfoData())
 
 	// test revision changes to cloudletinfo object on update
-	testCloudletInfoRevs(t, ctx, &dummy, apis, testutil.CloudletInfoData)
+	testCloudletInfoRevs(t, ctx, &dummy, apis, testutil.CloudletInfoData())
 }
 
 func insertCloudletInfo(ctx context.Context, apis *AllApis, data []edgeproto.CloudletInfo) {

--- a/cmd/controller/cloudletpool_api_test.go
+++ b/cmd/controller/cloudletpool_api_test.go
@@ -42,18 +42,18 @@ func TestCloudletPoolApi(t *testing.T) {
 	defer sync.Done()
 
 	// create supporting data
-	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData)
-	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData)
-	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData)
+	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData())
+	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData())
+	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData())
 	testutil.InternalCloudletCreate(t, apis.cloudletApi, testutil.CloudletData())
 
-	testutil.InternalCloudletPoolTest(t, "cud", apis.cloudletPoolApi, testutil.CloudletPoolData)
+	testutil.InternalCloudletPoolTest(t, "cud", apis.cloudletPoolApi, testutil.CloudletPoolData())
 
 	// create test cloudlet
 	testcloudlet := edgeproto.Cloudlet{
 		Key: edgeproto.CloudletKey{
 			Name:         "testcloudlet",
-			Organization: testutil.CloudletPoolData[0].Key.Organization,
+			Organization: testutil.CloudletPoolData()[0].Key.Organization,
 		},
 		NumDynamicIps: 100,
 		Location: dme.Loc{
@@ -67,7 +67,7 @@ func TestCloudletPoolApi(t *testing.T) {
 	fedcloudlet := edgeproto.Cloudlet{
 		Key: edgeproto.CloudletKey{
 			Name:                  "testfedcloudlet",
-			Organization:          testutil.CloudletPoolData[0].Key.Organization,
+			Organization:          testutil.CloudletPoolData()[0].Key.Organization,
 			FederatedOrganization: "FedOrg",
 		},
 		NumDynamicIps: 100,
@@ -85,7 +85,7 @@ func TestCloudletPoolApi(t *testing.T) {
 	count := 1
 	for _, cloudlet := range testcloudlets {
 		// set up test data
-		poolKey := testutil.CloudletPoolData[0].Key
+		poolKey := testutil.CloudletPoolData()[0].Key
 		member := edgeproto.CloudletPoolMember{}
 		member.Key = poolKey
 		member.Cloudlet = cloudlet.Key

--- a/cmd/controller/delete_test.go
+++ b/cmd/controller/delete_test.go
@@ -51,11 +51,11 @@ type DeleteDataGen struct{}
 
 // AlertPolicy
 func (s *DeleteDataGen) GetAlertPolicyTestObj() (*edgeproto.AlertPolicy, *testSupportData) {
-	obj := testutil.AlertPolicyData[0]
+	obj := testutil.AlertPolicyData()[0]
 	return &obj, noSupportData
 }
 func (s *DeleteDataGen) GetAppAlertPoliciesRef(key *edgeproto.AlertPolicyKey) (*edgeproto.App, *testSupportData) {
-	ref := testutil.AppData[0]
+	ref := testutil.AppData()[0]
 	ref.Key.Organization = key.Organization
 	ref.AlertPolicies = []string{key.Name}
 	return &ref, noSupportData
@@ -63,16 +63,16 @@ func (s *DeleteDataGen) GetAppAlertPoliciesRef(key *edgeproto.AlertPolicyKey) (*
 
 // App
 func (s *DeleteDataGen) GetAppTestObj() (*edgeproto.App, *testSupportData) {
-	obj := testutil.AppData[0]
+	obj := testutil.AppData()[0]
 	return &obj, noSupportData
 }
 func (s *DeleteDataGen) GetTrustPolicyExceptionKeyAppKeyRef(key *edgeproto.AppKey) (*edgeproto.TrustPolicyException, *testSupportData) {
-	ref := testutil.TrustPolicyExceptionData[0]
+	ref := testutil.TrustPolicyExceptionData()[0]
 	ref.Key.AppKey = *key
 	return &ref, noSupportData
 }
 func (s *DeleteDataGen) GetAppAppInstInstsRef(key *edgeproto.AppKey) (*edgeproto.AppInstRefs, *testSupportData) {
-	instKey := testutil.AppInstData[0].Key
+	instKey := testutil.AppInstData()[0].Key
 	instKey.AppKey = *key
 	inst := edgeproto.AppInst{
 		Key:      instKey,
@@ -95,11 +95,11 @@ func (s *DeleteDataGen) GetAppAppInstInstsRef(key *edgeproto.AppKey) (*edgeproto
 
 // AutoProvPolicy
 func (s *DeleteDataGen) GetAutoProvPolicyTestObj() (*edgeproto.AutoProvPolicy, *testSupportData) {
-	obj := testutil.AutoProvPolicyData[0]
+	obj := testutil.AutoProvPolicyData()[0]
 	return &obj, noSupportData
 }
 func (s *DeleteDataGen) GetAppAutoProvPoliciesRef(key *edgeproto.PolicyKey) (*edgeproto.App, *testSupportData) {
-	ref := testutil.AppData[0]
+	ref := testutil.AppData()[0]
 	ref.Key.Organization = key.Organization
 	ref.AutoProvPolicies = []string{key.Name}
 	return &ref, noSupportData
@@ -107,11 +107,11 @@ func (s *DeleteDataGen) GetAppAutoProvPoliciesRef(key *edgeproto.PolicyKey) (*ed
 
 // AutoScalePolicy
 func (s *DeleteDataGen) GetAutoScalePolicyTestObj() (*edgeproto.AutoScalePolicy, *testSupportData) {
-	obj := testutil.AutoScalePolicyData[0]
+	obj := testutil.AutoScalePolicyData()[0]
 	return &obj, noSupportData
 }
 func (s *DeleteDataGen) GetClusterInstAutoScalePolicyRef(key *edgeproto.PolicyKey) (*edgeproto.ClusterInst, *testSupportData) {
-	ref := testutil.ClusterInstData[0]
+	ref := testutil.ClusterInstData()[0]
 	ref.Key.Organization = key.Organization
 	ref.AutoScalePolicy = key.Name
 	return &ref, noSupportData
@@ -121,11 +121,11 @@ func (s *DeleteDataGen) GetClusterInstAutoScalePolicyRef(key *edgeproto.PolicyKe
 func (s *DeleteDataGen) GetCloudletTestObj() (*edgeproto.Cloudlet, *testSupportData) {
 	obj := testutil.CloudletData()[0]
 	supportData := &testSupportData{}
-	supportData.GpuDrivers = []edgeproto.GPUDriver{testutil.GPUDriverData[0]}
+	supportData.GpuDrivers = []edgeproto.GPUDriver{testutil.GPUDriverData()[0]}
 	return &obj, supportData
 }
 func (s *DeleteDataGen) GetAutoProvPolicyCloudletsRef(key *edgeproto.CloudletKey) (*edgeproto.AutoProvPolicy, *testSupportData) {
-	ref := testutil.AutoProvPolicyData[0]
+	ref := testutil.AutoProvPolicyData()[0]
 	ref.Cloudlets = []*edgeproto.AutoProvCloudlet{
 		&edgeproto.AutoProvCloudlet{
 			Key: *key,
@@ -134,20 +134,20 @@ func (s *DeleteDataGen) GetAutoProvPolicyCloudletsRef(key *edgeproto.CloudletKey
 	return &ref, noSupportData
 }
 func (s *DeleteDataGen) GetCloudletPoolCloudletsRef(key *edgeproto.CloudletKey) (*edgeproto.CloudletPool, *testSupportData) {
-	ref := testutil.CloudletPoolData[0]
+	ref := testutil.CloudletPoolData()[0]
 	ref.Key.Organization = key.Organization
 	ref.Cloudlets = []edgeproto.CloudletKey{*key}
 	return &ref, noSupportData
 }
 func (s *DeleteDataGen) GetNetworkKeyCloudletKeyRef(key *edgeproto.CloudletKey) (*edgeproto.Network, *testSupportData) {
-	ref := testutil.NetworkData[0]
+	ref := testutil.NetworkData()[0]
 	ref.Key.CloudletKey = *key
 	return &ref, noSupportData
 }
 func (s *DeleteDataGen) GetCloudletClusterInstClusterInstsRef(key *edgeproto.CloudletKey) (*edgeproto.CloudletRefs, *testSupportData) {
 	ref := edgeproto.CloudletRefs{}
 	ref.Key = *key
-	clusterInst := testutil.ClusterInstData[0]
+	clusterInst := testutil.ClusterInstData()[0]
 	supportData := &testSupportData{}
 	supportData.ClusterInsts = []edgeproto.ClusterInst{clusterInst}
 	clusterInstRefKey := edgeproto.ClusterInstRefKey{}
@@ -159,18 +159,18 @@ func (s *DeleteDataGen) GetCloudletClusterInstClusterInstsRef(key *edgeproto.Clo
 
 // CloudletPool
 func (s *DeleteDataGen) GetCloudletPoolTestObj() (*edgeproto.CloudletPool, *testSupportData) {
-	obj := testutil.CloudletPoolData[0]
+	obj := testutil.CloudletPoolData()[0]
 	return &obj, noSupportData
 }
 func (s *DeleteDataGen) GetTrustPolicyExceptionKeyCloudletPoolKeyRef(key *edgeproto.CloudletPoolKey) (*edgeproto.TrustPolicyException, *testSupportData) {
-	ref := testutil.TrustPolicyExceptionData[0]
+	ref := testutil.TrustPolicyExceptionData()[0]
 	ref.Key.CloudletPoolKey = *key
 	return &ref, noSupportData
 }
 
 // ClusterInst
 func (s *DeleteDataGen) GetClusterInstTestObj() (*edgeproto.ClusterInst, *testSupportData) {
-	obj := testutil.ClusterInstData[0]
+	obj := testutil.ClusterInstData()[0]
 	obj.CrmOverride = edgeproto.CRMOverride_IGNORE_CRM
 	cloudlet := edgeproto.Cloudlet{}
 	cloudlet.Key = obj.Key.CloudletKey
@@ -180,11 +180,11 @@ func (s *DeleteDataGen) GetClusterInstTestObj() (*edgeproto.ClusterInst, *testSu
 	supportData := &testSupportData{}
 	supportData.Cloudlets = []edgeproto.Cloudlet{cloudlet}
 	supportData.CloudletInfos = []edgeproto.CloudletInfo{cloudletInfo}
-	supportData.Flavors = []edgeproto.Flavor{testutil.FlavorData[0]}
+	supportData.Flavors = []edgeproto.Flavor{testutil.FlavorData()[0]}
 	return &obj, supportData
 }
 func (s *DeleteDataGen) GetClusterInstAppInstAppsRef(key *edgeproto.ClusterInstKey) (*edgeproto.ClusterRefs, *testSupportData) {
-	app := testutil.AppData[0]
+	app := testutil.AppData()[0]
 	appInst := edgeproto.AppInst{}
 	appInst.Key.AppKey = app.Key
 	appInst.Key.ClusterInstKey = *key.Virtual("")
@@ -205,11 +205,11 @@ func (s *DeleteDataGen) GetFlavorTestObj() (*edgeproto.Flavor, *testSupportData)
 	supportData := &testSupportData{}
 	supportData.Settings = edgeproto.GetDefaultSettings()
 
-	obj := testutil.FlavorData[0]
+	obj := testutil.FlavorData()[0]
 	return &obj, supportData
 }
 func (s *DeleteDataGen) GetAppDefaultFlavorRef(key *edgeproto.FlavorKey) (*edgeproto.App, *testSupportData) {
-	ref := testutil.AppData[0]
+	ref := testutil.AppData()[0]
 	ref.DefaultFlavor = *key
 	return &ref, noSupportData
 }
@@ -219,19 +219,19 @@ func (s *DeleteDataGen) GetCloudletFlavorRef(key *edgeproto.FlavorKey) (*edgepro
 	return &ref, noSupportData
 }
 func (s *DeleteDataGen) GetClusterInstFlavorRef(key *edgeproto.FlavorKey) (*edgeproto.ClusterInst, *testSupportData) {
-	ref := testutil.ClusterInstData[0]
+	ref := testutil.ClusterInstData()[0]
 	ref.Flavor = *key
 	return &ref, noSupportData
 }
 func (s *DeleteDataGen) GetAppInstFlavorRef(key *edgeproto.FlavorKey) (*edgeproto.AppInst, *testSupportData) {
-	ref := testutil.AppInstData[0]
+	ref := testutil.AppInstData()[0]
 	ref.Flavor = *key
 	return &ref, noSupportData
 }
 
 // GPUDriver
 func (s *DeleteDataGen) GetGPUDriverTestObj() (*edgeproto.GPUDriver, *testSupportData) {
-	obj := testutil.GPUDriverData[0]
+	obj := testutil.GPUDriverData()[0]
 	return &obj, noSupportData
 }
 func (s *DeleteDataGen) GetCloudletGpuConfigDriverRef(key *edgeproto.GPUDriverKey) (*edgeproto.Cloudlet, *testSupportData) {
@@ -242,11 +242,11 @@ func (s *DeleteDataGen) GetCloudletGpuConfigDriverRef(key *edgeproto.GPUDriverKe
 
 // Network
 func (s *DeleteDataGen) GetNetworkTestObj() (*edgeproto.Network, *testSupportData) {
-	obj := testutil.NetworkData[0]
+	obj := testutil.NetworkData()[0]
 	return &obj, noSupportData
 }
 func (s *DeleteDataGen) GetClusterInstNetworksRef(key *edgeproto.NetworkKey) (*edgeproto.ClusterInst, *testSupportData) {
-	ref := testutil.ClusterInstData[0]
+	ref := testutil.ClusterInstData()[0]
 	ref.Key.CloudletKey = key.CloudletKey
 	ref.Networks = []string{key.Name}
 	return &ref, noSupportData
@@ -254,7 +254,7 @@ func (s *DeleteDataGen) GetClusterInstNetworksRef(key *edgeproto.NetworkKey) (*e
 
 // ResTagTable
 func (s *DeleteDataGen) GetResTagTableTestObj() (*edgeproto.ResTagTable, *testSupportData) {
-	obj := testutil.ResTagTableData[0]
+	obj := testutil.ResTagTableData()[0]
 	return &obj, noSupportData
 }
 func (s *DeleteDataGen) GetCloudletResTagMapRef(key *edgeproto.ResTagTableKey) (*edgeproto.Cloudlet, *testSupportData) {
@@ -267,7 +267,7 @@ func (s *DeleteDataGen) GetCloudletResTagMapRef(key *edgeproto.ResTagTableKey) (
 
 // TrustPolicy
 func (s *DeleteDataGen) GetTrustPolicyTestObj() (*edgeproto.TrustPolicy, *testSupportData) {
-	obj := testutil.TrustPolicyData[0]
+	obj := testutil.TrustPolicyData()[0]
 	return &obj, noSupportData
 }
 func (s *DeleteDataGen) GetCloudletTrustPolicyRef(key *edgeproto.PolicyKey) (*edgeproto.Cloudlet, *testSupportData) {
@@ -279,7 +279,7 @@ func (s *DeleteDataGen) GetCloudletTrustPolicyRef(key *edgeproto.PolicyKey) (*ed
 
 // VMPool
 func (s *DeleteDataGen) GetVMPoolTestObj() (*edgeproto.VMPool, *testSupportData) {
-	obj := testutil.VMPoolData[0]
+	obj := testutil.VMPoolData()[0]
 	return &obj, noSupportData
 }
 func (s *DeleteDataGen) GetCloudletVmPoolRef(key *edgeproto.VMPoolKey) (*edgeproto.Cloudlet, *testSupportData) {

--- a/cmd/controller/device_api_test.go
+++ b/cmd/controller/device_api_test.go
@@ -44,24 +44,25 @@ func TestDeviceApi(t *testing.T) {
 	defer sync.Done()
 
 	log.SpanLog(ctx, log.DebugLevelApi, "Starting tests")
+	devices := testutil.PlatformDeviceClientData()
 	// Test Update of the platform device
-	for _, obj := range testutil.PlarformDeviceClientData {
+	for _, obj := range testutil.PlatformDeviceClientData() {
 		apis.deviceApi.Update(ctx, &obj, 0)
 	}
-	testutil.InternalDeviceTest(t, "show", apis.deviceApi, testutil.PlarformDeviceClientData)
+	testutil.InternalDeviceTest(t, "show", apis.deviceApi, devices)
 	// Add the existing platform device with the new timestamp
-	dev := testutil.PlarformDeviceClientData[0]
+	dev := testutil.PlatformDeviceClientData()[0]
 	dev.FirstSeen = testutil.GetTimestamp(time.Date(2009, time.November, 11, 23, 0, 0, 0, time.UTC))
 	apis.deviceApi.Update(ctx, &dev, 0)
-	testutil.InternalDeviceTest(t, "show", apis.deviceApi, testutil.PlarformDeviceClientData)
+	testutil.InternalDeviceTest(t, "show", apis.deviceApi, devices)
 	// Test Update of a platform device without uniqueID
-	dev = testutil.PlarformDeviceClientData[0]
+	dev = testutil.PlatformDeviceClientData()[0]
 	dev.Key.UniqueId = ""
 	apis.deviceApi.Update(ctx, &dev, 0)
-	testutil.InternalDeviceTest(t, "show", apis.deviceApi, testutil.PlarformDeviceClientData)
+	testutil.InternalDeviceTest(t, "show", apis.deviceApi, devices)
 	// Test that flush doesn't remove the entries
 	apis.deviceApi.Flush(ctx, 0)
-	testutil.InternalDeviceTest(t, "show", apis.deviceApi, testutil.PlarformDeviceClientData)
+	testutil.InternalDeviceTest(t, "show", apis.deviceApi, devices)
 	// Test report to show only a single device in December
 	report := edgeproto.DeviceReport{
 		Begin: testutil.GetTimestamp(time.Date(2009, time.December, 1, 23, 0, 0, 0, time.UTC)),
@@ -74,25 +75,25 @@ func TestDeviceApi(t *testing.T) {
 	require.Equal(t, 2, len(show.Data))
 	// Verify that the two devices got were correct
 	for _, dev := range show.Data {
-		if dev.Key.UniqueIdType == testutil.PlarformDeviceClientData[2].Key.UniqueIdType {
-			require.Equal(t, testutil.PlarformDeviceClientData[2], dev)
+		if dev.Key.UniqueIdType == devices[2].Key.UniqueIdType {
+			require.Equal(t, devices[2], dev)
 		} else {
-			require.Equal(t, testutil.PlarformDeviceClientData[4], dev)
+			require.Equal(t, devices[4], dev)
 		}
 	}
 
 	// I want to call testutil.ApiClient.ShowDeviceReport()...
 
 	// Evict all the platform device
-	for _, obj := range testutil.PlarformDeviceClientData {
+	for _, obj := range devices {
 		apis.deviceApi.EvictDevice(ctx, &obj)
 	}
 	testutil.InternalDeviceTest(t, "show", apis.deviceApi, []edgeproto.Device{})
 	// Test Inject of the platform devices
-	for _, obj := range testutil.PlarformDeviceClientData {
+	for _, obj := range devices {
 		apis.deviceApi.InjectDevice(ctx, &obj)
 	}
-	testutil.InternalDeviceTest(t, "show", apis.deviceApi, testutil.PlarformDeviceClientData)
+	testutil.InternalDeviceTest(t, "show", apis.deviceApi, devices)
 
 	dummy.Stop()
 }

--- a/cmd/controller/flavor_api_test.go
+++ b/cmd/controller/flavor_api_test.go
@@ -42,7 +42,7 @@ func TestFlavorApi(t *testing.T) {
 	sync.Start()
 	defer sync.Done()
 
-	testutil.InternalFlavorTest(t, "cud", apis.flavorApi, testutil.FlavorData)
+	testutil.InternalFlavorTest(t, "cud", apis.flavorApi, testutil.FlavorData())
 	testMasterFlavor(t, ctx, apis)
 	dummy.Stop()
 }
@@ -63,7 +63,7 @@ func testMasterFlavor(t *testing.T, ctx context.Context, apis *AllApis) {
 	// ensure the master node default flavor is created, using the default value
 	// of settings.MasterNodeFlavor
 	cl := testutil.CloudletData()[1]
-	var cli edgeproto.CloudletInfo = testutil.CloudletInfoData[0]
+	var cli edgeproto.CloudletInfo = testutil.CloudletInfoData()[0]
 	settings := apis.settingsApi.Get()
 	masterFlavor := edgeproto.Flavor{}
 	flavorKey := edgeproto.FlavorKey{}

--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -132,8 +132,8 @@ func testC(t *testing.T) {
 		RecvClusterInstInfo: &crmNotify.ClusterInstInfoCache,
 	}
 	dummyResponder.InitDummyInfoResponder()
-	for ii, _ := range testutil.CloudletInfoData {
-		crmNotify.CloudletInfoCache.Update(ctx, &testutil.CloudletInfoData[ii], 0)
+	for ii, _ := range testutil.CloudletInfoData() {
+		crmNotify.CloudletInfoCache.Update(ctx, &testutil.CloudletInfoData()[ii], 0)
 	}
 	go crmClient.Start()
 	defer crmClient.Stop()
@@ -156,41 +156,41 @@ func testC(t *testing.T) {
 
 	crmClient.WaitForConnect(1)
 	dmeClient.WaitForConnect(1)
-	for ii, _ := range testutil.CloudletInfoData {
-		err := apis.cloudletInfoApi.cache.WaitForCloudletState(ctx, &testutil.CloudletInfoData[ii].Key, dme.CloudletState_CLOUDLET_STATE_READY, time.Second)
+	for ii, _ := range testutil.CloudletInfoData() {
+		err := apis.cloudletInfoApi.cache.WaitForCloudletState(ctx, &testutil.CloudletInfoData()[ii].Key, dme.CloudletState_CLOUDLET_STATE_READY, time.Second)
 		require.Nil(t, err)
 	}
 
 	cloudletData := testutil.CloudletData()
-	testutil.ClientFlavorTest(t, "cud", flavorClient, testutil.FlavorData)
-	testutil.ClientAutoProvPolicyTest(t, "cud", autoProvPolicyClient, testutil.AutoProvPolicyData)
-	testutil.ClientAutoScalePolicyTest(t, "cud", autoScalePolicyClient, testutil.AutoScalePolicyData)
-	testutil.ClientAppTest(t, "cud", appClient, testutil.AppData)
-	testutil.ClientGPUDriverTest(t, "cud", gpuDriverClient, testutil.GPUDriverData)
-	testutil.ClientResTagTableTest(t, "cud", resTagTableClient, testutil.ResTagTableData)
+	testutil.ClientFlavorTest(t, "cud", flavorClient, testutil.FlavorData())
+	testutil.ClientAutoProvPolicyTest(t, "cud", autoProvPolicyClient, testutil.AutoProvPolicyData())
+	testutil.ClientAutoScalePolicyTest(t, "cud", autoScalePolicyClient, testutil.AutoScalePolicyData())
+	testutil.ClientAppTest(t, "cud", appClient, testutil.AppData())
+	testutil.ClientGPUDriverTest(t, "cud", gpuDriverClient, testutil.GPUDriverData())
+	testutil.ClientResTagTableTest(t, "cud", resTagTableClient, testutil.ResTagTableData())
 	testutil.ClientCloudletTest(t, "cud", cloudletClient, cloudletData)
-	testutil.ClientClusterInstTest(t, "cud", clusterInstClient, testutil.ClusterInstData)
-	testutil.ClientAppInstTest(t, "cud", appInstClient, testutil.AppInstData, testutil.WithCreatedAppInstTestData(testutil.CreatedAppInstData()))
+	testutil.ClientClusterInstTest(t, "cud", clusterInstClient, testutil.ClusterInstData())
+	testutil.ClientAppInstTest(t, "cud", appInstClient, testutil.AppInstData(), testutil.WithCreatedAppInstTestData(testutil.CreatedAppInstData()))
 
-	require.Nil(t, dmeNotify.WaitForAppInsts(len(testutil.AppInstData)))
-	require.Nil(t, crmNotify.WaitForFlavors(len(testutil.FlavorData)))
+	require.Nil(t, dmeNotify.WaitForAppInsts(len(testutil.AppInstData())))
+	require.Nil(t, crmNotify.WaitForFlavors(len(testutil.FlavorData())))
 
-	require.Equal(t, len(testutil.AppInstData), len(dmeNotify.AppInstCache.Objs), "num appinsts")
-	require.Equal(t, len(testutil.FlavorData), len(crmNotify.FlavorCache.Objs), "num flavors")
-	require.Equal(t, len(testutil.ClusterInstData)+len(testutil.ClusterInstAutoData), len(crmNotify.ClusterInstInfoCache.Objs), "crm cluster inst infos")
-	require.Equal(t, len(testutil.AppInstData), len(crmNotify.AppInstInfoCache.Objs), "crm cluster inst infos")
+	require.Equal(t, len(testutil.AppInstData()), len(dmeNotify.AppInstCache.Objs), "num appinsts")
+	require.Equal(t, len(testutil.FlavorData()), len(crmNotify.FlavorCache.Objs), "num flavors")
+	require.Equal(t, len(testutil.ClusterInstData())+len(testutil.ClusterInstAutoData()), len(crmNotify.ClusterInstInfoCache.Objs), "crm cluster inst infos")
+	require.Equal(t, len(testutil.AppInstData()), len(crmNotify.AppInstInfoCache.Objs), "crm cluster inst infos")
 
 	ClientAppInstCachedFieldsTest(t, ctx, appClient, cloudletClient, appInstClient)
 
-	WaitForCloudletInfo(apis, len(testutil.CloudletInfoData))
-	require.Equal(t, len(testutil.CloudletInfoData), len(apis.cloudletInfoApi.cache.Objs))
+	WaitForCloudletInfo(apis, len(testutil.CloudletInfoData()))
+	require.Equal(t, len(testutil.CloudletInfoData()), len(apis.cloudletInfoApi.cache.Objs))
 	require.Equal(t, len(crmNotify.CloudletInfoCache.Objs), len(apis.cloudletInfoApi.cache.Objs))
 
 	// test show api for info structs
 	// XXX These checks won't work until we move notifyId out of struct
 	// and into meta data in cache (TODO)
 	if false {
-		CheckCloudletInfo(t, cloudletInfoClient, testutil.CloudletInfoData)
+		CheckCloudletInfo(t, cloudletInfoClient, testutil.CloudletInfoData())
 	}
 	testKeepAliveRecovery(t, ctx, apis)
 
@@ -198,12 +198,12 @@ func testC(t *testing.T) {
 	stream, err := cloudletClient.DeleteCloudlet(ctx, &cloudletData[0])
 	err = testutil.CloudletReadResultStream(stream, err)
 	require.NotNil(t, err)
-	_, err = appClient.DeleteApp(ctx, &testutil.AppData[0])
+	_, err = appClient.DeleteApp(ctx, &testutil.AppData()[0])
 	require.NotNil(t, err)
-	_, err = autoScalePolicyClient.DeleteAutoScalePolicy(ctx, &testutil.AutoScalePolicyData[0])
+	_, err = autoScalePolicyClient.DeleteAutoScalePolicy(ctx, &testutil.AutoScalePolicyData()[0])
 	require.NotNil(t, err)
 	// test that delete works after removing dependencies
-	for _, inst := range testutil.AppInstData {
+	for _, inst := range testutil.AppInstData() {
 		if testutil.IsAutoClusterAutoDeleteApp(&inst.Key) {
 			continue
 		}
@@ -211,7 +211,7 @@ func testC(t *testing.T) {
 		err = testutil.AppInstReadResultStream(stream, err)
 		require.Nil(t, err)
 	}
-	for _, inst := range testutil.ClusterInstData {
+	for _, inst := range testutil.ClusterInstData() {
 		stream, err := clusterInstClient.DeleteClusterInst(ctx, &inst)
 		err = testutil.ClusterInstReadResultStream(stream, err)
 		require.Nil(t, err)
@@ -219,16 +219,16 @@ func testC(t *testing.T) {
 	// cleanup unused reservable auto clusters
 	_, err = clusterInstClient.DeleteIdleReservableClusterInsts(ctx, &edgeproto.IdleReservableClusterInsts{})
 	require.Nil(t, err)
-	for _, obj := range testutil.AppData {
+	for _, obj := range testutil.AppData() {
 		_, err = appClient.DeleteApp(ctx, &obj)
 		require.Nil(t, err)
 	}
-	for _, obj := range testutil.AutoScalePolicyData {
+	for _, obj := range testutil.AutoScalePolicyData() {
 		_, err = autoScalePolicyClient.DeleteAutoScalePolicy(ctx, &obj)
 		require.Nil(t, err)
 	}
-	for ii, _ := range testutil.CloudletInfoData {
-		obj := testutil.CloudletInfoData[ii]
+	for ii, _ := range testutil.CloudletInfoData() {
+		obj := testutil.CloudletInfoData()[ii]
 		obj.State = dme.CloudletState_CLOUDLET_STATE_OFFLINE
 		crmNotify.CloudletInfoCache.Update(ctx, &obj, 0)
 	}
@@ -253,7 +253,7 @@ func TestDataGen(t *testing.T) {
 		require.Nil(t, err, "open file")
 		return
 	}
-	for _, obj := range testutil.DevData {
+	for _, obj := range testutil.DevData() {
 		val, err := json.Marshal(&obj)
 		require.Nil(t, err, "marshal %s", obj)
 		out.Write(val)
@@ -409,10 +409,10 @@ func testKeepAliveRecovery(t *testing.T, ctx context.Context, apis *AllApis) {
 	require.Equal(t, 0, len(apis.alertApi.sourceCache.Objs))
 
 	// add some alerts from crm, will go into source cache
-	for _, alert := range testutil.AlertData {
+	for _, alert := range testutil.AlertData() {
 		apis.alertApi.Update(ctx, &alert, 0)
 	}
-	numCrmAlerts := len(testutil.AlertData)
+	numCrmAlerts := len(testutil.AlertData())
 	totalAlerts := numPrevAlerts + numCrmAlerts
 	WaitForAlerts(t, apis, totalAlerts)
 	require.Equal(t, numCrmAlerts, len(apis.alertApi.sourceCache.Objs))
@@ -445,7 +445,7 @@ func testKeepAliveRecovery(t *testing.T, ctx context.Context, apis *AllApis) {
 
 	log.SpanLog(ctx, log.DebugLevelInfo, "delete alerts")
 	// delete alerts
-	for _, alert := range testutil.AlertData {
+	for _, alert := range testutil.AlertData() {
 		apis.alertApi.Delete(ctx, &alert, 0)
 	}
 	WaitForAlerts(t, apis, numPrevAlerts)
@@ -525,15 +525,15 @@ func TestControllerRace(t *testing.T) {
 // ClusterInst delete to fall in between the AppInst creates.
 func testClusterInstDeleteChecks(t *testing.T, ctx context.Context, apis1, apis2 *AllApis) {
 	var err error
-	testutil.InternalFlavorCreate(t, apis1.flavorApi, testutil.FlavorData)
-	testutil.InternalGPUDriverCreate(t, apis1.gpuDriverApi, testutil.GPUDriverData)
-	testutil.InternalResTagTableCreate(t, apis1.resTagTableApi, testutil.ResTagTableData)
+	testutil.InternalFlavorCreate(t, apis1.flavorApi, testutil.FlavorData())
+	testutil.InternalGPUDriverCreate(t, apis1.gpuDriverApi, testutil.GPUDriverData())
+	testutil.InternalResTagTableCreate(t, apis1.resTagTableApi, testutil.ResTagTableData())
 
 	numTries := 0
 	deleteDelay := 700 * time.Millisecond
 	numApps := 100
 	for ii := 0; ii < numApps; ii++ {
-		app := testutil.AppData[9]
+		app := testutil.AppData()[9]
 		app.Key.Name += fmt.Sprintf("%d", ii)
 		_, err = apis1.appApi.CreateApp(ctx, &app)
 		require.Nil(t, err)
@@ -541,13 +541,13 @@ func testClusterInstDeleteChecks(t *testing.T, ctx context.Context, apis1, apis2
 	cl := testutil.CloudletData()[0]
 	err = apis1.cloudletApi.CreateCloudlet(&cl, testutil.NewCudStreamoutCloudlet(ctx))
 	require.Nil(t, err)
-	insertCloudletInfo(ctx, apis1, testutil.CloudletInfoData)
-	insertCloudletInfo(ctx, apis2, testutil.CloudletInfoData)
-	ci := testutil.ClusterInstData[0]
+	insertCloudletInfo(ctx, apis1, testutil.CloudletInfoData())
+	insertCloudletInfo(ctx, apis2, testutil.CloudletInfoData())
+	ci := testutil.ClusterInstData()[0]
 
 	ai := edgeproto.AppInst{
 		Key: edgeproto.AppInstKey{
-			AppKey:         testutil.AppData[9].Key, // auto-delete app
+			AppKey:         testutil.AppData()[9].Key, // auto-delete app
 			ClusterInstKey: *ci.Key.Virtual(""),
 		},
 		Liveness: edgeproto.Liveness_LIVENESS_DYNAMIC,
@@ -608,17 +608,17 @@ func testClusterInstDeleteChecks(t *testing.T, ctx context.Context, apis1, apis2
 	// clean up
 	err = apis1.cloudletApi.DeleteCloudlet(&cl, testutil.NewCudStreamoutCloudlet(ctx))
 	require.Nil(t, err)
-	evictCloudletInfo(ctx, apis1, testutil.CloudletInfoData)
-	evictCloudletInfo(ctx, apis2, testutil.CloudletInfoData)
+	evictCloudletInfo(ctx, apis1, testutil.CloudletInfoData())
+	evictCloudletInfo(ctx, apis2, testutil.CloudletInfoData())
 	for ii := 0; ii < numApps; ii++ {
-		app := testutil.AppData[9]
+		app := testutil.AppData()[9]
 		app.Key.Name += fmt.Sprintf("%d", ii)
 		_, err = apis1.appApi.DeleteApp(ctx, &app)
 		require.Nil(t, err)
 	}
-	testutil.InternalResTagTableDelete(t, apis1.resTagTableApi, testutil.ResTagTableData)
-	testutil.InternalGPUDriverDelete(t, apis1.gpuDriverApi, testutil.GPUDriverData)
-	testutil.InternalFlavorDelete(t, apis1.flavorApi, testutil.FlavorData)
+	testutil.InternalResTagTableDelete(t, apis1.resTagTableApi, testutil.ResTagTableData())
+	testutil.InternalGPUDriverDelete(t, apis1.gpuDriverApi, testutil.GPUDriverData())
+	testutil.InternalFlavorDelete(t, apis1.flavorApi, testutil.FlavorData())
 }
 
 // Test race between App create (which depends on Flavor) and Flavor delete.
@@ -630,8 +630,8 @@ func testFlavorDeleteChecks(t *testing.T, ctx context.Context, apis1, apis2 *All
 	if numTries == 0 {
 		return
 	}
-	flavor := testutil.FlavorData[0]
-	app := testutil.AppData[0]
+	flavor := testutil.FlavorData()[0]
+	app := testutil.AppData()[0]
 	app.DefaultFlavor = flavor.Key
 	numBothCreated := 0
 	numBothDeleted := 0

--- a/cmd/controller/network_api_test.go
+++ b/cmd/controller/network_api_test.go
@@ -39,16 +39,16 @@ func TestNetworkApi(t *testing.T) {
 	sync.Start()
 	defer sync.Done()
 
-	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData)
-	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData)
-	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData)
+	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData())
+	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData())
+	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData())
 	testutil.InternalCloudletCreate(t, apis.cloudletApi, testutil.CloudletData())
 
-	testutil.InternalNetworkTest(t, "cud", apis.networkApi, testutil.NetworkData)
+	testutil.InternalNetworkTest(t, "cud", apis.networkApi, testutil.NetworkData())
 	// error cases
-	expectCreateNetworkError(t, ctx, apis, &testutil.NetworkErrorData[0], "Invalid route destination cidr")
-	expectCreateNetworkError(t, ctx, apis, &testutil.NetworkErrorData[1], "Invalid next hop")
-	expectCreateNetworkError(t, ctx, apis, &testutil.NetworkErrorData[2], "Invalid connection type")
+	expectCreateNetworkError(t, ctx, apis, &testutil.NetworkErrorData()[0], "Invalid route destination cidr")
+	expectCreateNetworkError(t, ctx, apis, &testutil.NetworkErrorData()[1], "Invalid next hop")
+	expectCreateNetworkError(t, ctx, apis, &testutil.NetworkErrorData()[2], "Invalid connection type")
 
 }
 

--- a/cmd/controller/operatorcode_api_test.go
+++ b/cmd/controller/operatorcode_api_test.go
@@ -41,9 +41,9 @@ func TestOperatorCodeApi(t *testing.T) {
 	sync.Start()
 	defer sync.Done()
 
-	testutil.InternalOperatorCodeTest(t, "cud", apis.operatorCodeApi, testutil.OperatorCodeData)
+	testutil.InternalOperatorCodeTest(t, "cud", apis.operatorCodeApi, testutil.OperatorCodeData())
 	// create duplicate key should fail
-	code := testutil.OperatorCodeData[0]
+	code := testutil.OperatorCodeData()[0]
 	_, err := apis.operatorCodeApi.CreateOperatorCode(ctx, &code)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "already exists")

--- a/cmd/controller/restagtable_api_test.go
+++ b/cmd/controller/restagtable_api_test.go
@@ -45,12 +45,12 @@ func TestResTagTableApi(t *testing.T) {
 	sync.Start()
 	defer sync.Done()
 
-	testutil.InternalResTagTableTest(t, "cud", apis.resTagTableApi, testutil.ResTagTableData)
-	testutil.InternalResTagTableTest(t, "show", apis.resTagTableApi, testutil.ResTagTableData)
+	testutil.InternalResTagTableTest(t, "cud", apis.resTagTableApi, testutil.ResTagTableData())
+	testutil.InternalResTagTableTest(t, "show", apis.resTagTableApi, testutil.ResTagTableData())
 
 	// Non-Nominal attempt to create a table that should already exist from our cud tests
 	var tab = edgeproto.ResTagTable{
-		Key: testutil.Restblkeys[0],
+		Key: testutil.Restblkeys()[0],
 	}
 	_, err := apis.resTagTableApi.CreateResTagTable(ctx, &tab)
 	require.Equal(t, "ResTagTable key {\"name\":\"gpu\",\"organization\":\"UFGT Inc.\"} already exists", err.Error(), "create tag table EEXIST expected")

--- a/cmd/controller/trustpolicy_api_test.go
+++ b/cmd/controller/trustpolicy_api_test.go
@@ -40,11 +40,11 @@ func TestTrustPolicyApi(t *testing.T) {
 	sync.Start()
 	defer sync.Done()
 
-	testutil.InternalTrustPolicyTest(t, "cud", apis.trustPolicyApi, testutil.TrustPolicyData)
+	testutil.InternalTrustPolicyTest(t, "cud", apis.trustPolicyApi, testutil.TrustPolicyData())
 	// error cases
-	expectCreatePolicyError(t, ctx, apis, &testutil.TrustPolicyErrorData[0], "cannot be higher than max")
-	expectCreatePolicyError(t, ctx, apis, &testutil.TrustPolicyErrorData[1], "invalid CIDR")
-	expectCreatePolicyError(t, ctx, apis, &testutil.TrustPolicyErrorData[2], "Invalid min port: 0")
+	expectCreatePolicyError(t, ctx, apis, &testutil.TrustPolicyErrorData()[0], "cannot be higher than max")
+	expectCreatePolicyError(t, ctx, apis, &testutil.TrustPolicyErrorData()[1], "invalid CIDR")
+	expectCreatePolicyError(t, ctx, apis, &testutil.TrustPolicyErrorData()[2], "Invalid min port: 0")
 
 	dummy.Stop()
 }

--- a/cmd/controller/trustpolicyexception_api_test.go
+++ b/cmd/controller/trustpolicyexception_api_test.go
@@ -49,23 +49,23 @@ func TestTrustPolicyExceptionApi(t *testing.T) {
 	dummyResponder.InitDummyInfoResponder()
 
 	// create supporting data
-	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData)
-	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData)
-	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData)
+	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData())
+	testutil.InternalGPUDriverCreate(t, apis.gpuDriverApi, testutil.GPUDriverData())
+	testutil.InternalResTagTableCreate(t, apis.resTagTableApi, testutil.ResTagTableData())
 	testutil.InternalCloudletCreate(t, apis.cloudletApi, testutil.CloudletData())
-	insertCloudletInfo(ctx, apis, testutil.CloudletInfoData)
-	testutil.InternalAutoProvPolicyCreate(t, apis.autoProvPolicyApi, testutil.AutoProvPolicyData)
-	testutil.InternalAutoScalePolicyCreate(t, apis.autoScalePolicyApi, testutil.AutoScalePolicyData)
-	testutil.InternalAppCreate(t, apis.appApi, testutil.AppData)
-	testutil.InternalClusterInstCreate(t, apis.clusterInstApi, testutil.ClusterInstData)
-	testutil.InternalAppInstCreate(t, apis.appInstApi, testutil.AppInstData)
-	testutil.InternalCloudletPoolTest(t, "cud", apis.cloudletPoolApi, testutil.CloudletPoolData)
+	insertCloudletInfo(ctx, apis, testutil.CloudletInfoData())
+	testutil.InternalAutoProvPolicyCreate(t, apis.autoProvPolicyApi, testutil.AutoProvPolicyData())
+	testutil.InternalAutoScalePolicyCreate(t, apis.autoScalePolicyApi, testutil.AutoScalePolicyData())
+	testutil.InternalAppCreate(t, apis.appApi, testutil.AppData())
+	testutil.InternalClusterInstCreate(t, apis.clusterInstApi, testutil.ClusterInstData())
+	testutil.InternalAppInstCreate(t, apis.appInstApi, testutil.AppInstData())
+	testutil.InternalCloudletPoolTest(t, "cud", apis.cloudletPoolApi, testutil.CloudletPoolData())
 
 	// CUD for Trust Policy Exception
-	testutil.InternalTrustPolicyExceptionTest(t, "cud", apis.trustPolicyExceptionApi, testutil.TrustPolicyExceptionData)
+	testutil.InternalTrustPolicyExceptionTest(t, "cud", apis.trustPolicyExceptionApi, testutil.TrustPolicyExceptionData())
 
 	// Basic error case - when TPE already exists
-	_, err := apis.trustPolicyExceptionApi.CreateTrustPolicyException(ctx, &testutil.TrustPolicyExceptionData[0])
+	_, err := apis.trustPolicyExceptionApi.CreateTrustPolicyException(ctx, &testutil.TrustPolicyExceptionData()[0])
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), " already exists")
 
@@ -73,12 +73,12 @@ func TestTrustPolicyExceptionApi(t *testing.T) {
 	tpeDataFail := edgeproto.TrustPolicyException{
 		Key: edgeproto.TrustPolicyExceptionKey{
 			AppKey: edgeproto.AppKey{
-				Organization: testutil.DevData[0],
+				Organization: testutil.DevData()[0],
 				Name:         "Pillimo Go!",
 				Version:      "1.0.1",
 			},
 			CloudletPoolKey: edgeproto.CloudletPoolKey{
-				Organization: testutil.OperatorData[2],
+				Organization: testutil.OperatorData()[2],
 				Name:         "test-and-dev",
 			},
 			Name: "someapp-tpe2",
@@ -101,12 +101,12 @@ func TestTrustPolicyExceptionApi(t *testing.T) {
 	tpeDataFail2 := edgeproto.TrustPolicyException{
 		Key: edgeproto.TrustPolicyExceptionKey{
 			AppKey: edgeproto.AppKey{
-				Organization: testutil.DevData[0],
+				Organization: testutil.DevData()[0],
 				Name:         "Pillimo Go!",
 				Version:      "1.0.0",
 			},
 			CloudletPoolKey: edgeproto.CloudletPoolKey{
-				Organization: testutil.OperatorData[2],
+				Organization: testutil.OperatorData()[2],
 				Name:         "test-and-dev",
 			},
 			Name: "someapp-tpe2",
@@ -120,12 +120,12 @@ func TestTrustPolicyExceptionApi(t *testing.T) {
 	tpeData := edgeproto.TrustPolicyException{
 		Key: edgeproto.TrustPolicyExceptionKey{
 			AppKey: edgeproto.AppKey{
-				Organization: testutil.DevData[0],
+				Organization: testutil.DevData()[0],
 				Name:         "Pillimo Go!",
 				Version:      "1.0.0",
 			},
 			CloudletPoolKey: edgeproto.CloudletPoolKey{
-				Organization: testutil.OperatorData[2],
+				Organization: testutil.OperatorData()[2],
 				Name:         "test-and-dev",
 			},
 			Name: "someapp-tpe2",
@@ -191,7 +191,7 @@ func TestTrustPolicyExceptionApi(t *testing.T) {
 	require.Equal(t, err.Error(), strAppOrgErr)
 
 	// State related tests - end, restore everything
-	tpeData.Key.AppKey.Organization = testutil.DevData[0]
+	tpeData.Key.AppKey.Organization = testutil.DevData()[0]
 	tpeData.Fields = []string{}
 	// test that TPE create when specified CloudletPool does not exist, fails
 	tpeData.Key.CloudletPoolKey.Organization = "Mission Mars"
@@ -199,20 +199,20 @@ func TestTrustPolicyExceptionApi(t *testing.T) {
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), tpeData.Key.CloudletPoolKey.NotFoundError().Error())
 	// Restore tpeData Key to original values
-	tpeData.Key.CloudletPoolKey.Organization = testutil.OperatorData[2]
+	tpeData.Key.CloudletPoolKey.Organization = testutil.OperatorData()[2]
 
 	// test that TPE create when specified App does not exist, fails
-	tpeData.Key.AppKey.Organization = testutil.DevData[2]
+	tpeData.Key.AppKey.Organization = testutil.DevData()[2]
 	_, err = apis.trustPolicyExceptionApi.CreateTrustPolicyException(ctx, &tpeData)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), tpeData.Key.AppKey.NotFoundError().Error())
 	// Restore tpeData Key to original values
-	tpeData.Key.AppKey.Organization = testutil.DevData[0]
+	tpeData.Key.AppKey.Organization = testutil.DevData()[0]
 
-	testutil.InternalAppInstDelete(t, apis.appInstApi, testutil.AppInstData)
+	testutil.InternalAppInstDelete(t, apis.appInstApi, testutil.AppInstData())
 
 	// test that App delete fails if TPE exists that refers to it
-	app0 := testutil.AppData[0]
+	app0 := testutil.AppData()[0]
 	_, err = apis.appApi.DeleteApp(ctx, &app0)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "Application in use by Trust Policy Exception")
@@ -222,13 +222,13 @@ func TestTrustPolicyExceptionApi(t *testing.T) {
 	require.Nil(t, err)
 
 	// error cases for Create Trust Policy Exception
-	expectCreatePolicyExceptionError(t, ctx, apis, &testutil.TrustPolicyExceptionErrorData[0], "cannot be higher than max")
-	expectCreatePolicyExceptionError(t, ctx, apis, &testutil.TrustPolicyExceptionErrorData[1], "invalid CIDR")
-	expectCreatePolicyExceptionError(t, ctx, apis, &testutil.TrustPolicyExceptionErrorData[2], "Invalid min port")
-	expectCreatePolicyExceptionError(t, ctx, apis, &testutil.TrustPolicyExceptionErrorData[3],
-		testutil.TrustPolicyExceptionErrorData[3].Key.AppKey.NotFoundError().Error())
-	expectCreatePolicyExceptionError(t, ctx, apis, &testutil.TrustPolicyExceptionErrorData[4],
-		testutil.TrustPolicyExceptionErrorData[4].Key.CloudletPoolKey.NotFoundError().Error())
+	expectCreatePolicyExceptionError(t, ctx, apis, &testutil.TrustPolicyExceptionErrorData()[0], "cannot be higher than max")
+	expectCreatePolicyExceptionError(t, ctx, apis, &testutil.TrustPolicyExceptionErrorData()[1], "invalid CIDR")
+	expectCreatePolicyExceptionError(t, ctx, apis, &testutil.TrustPolicyExceptionErrorData()[2], "Invalid min port")
+	expectCreatePolicyExceptionError(t, ctx, apis, &testutil.TrustPolicyExceptionErrorData()[3],
+		testutil.TrustPolicyExceptionErrorData()[3].Key.AppKey.NotFoundError().Error())
+	expectCreatePolicyExceptionError(t, ctx, apis, &testutil.TrustPolicyExceptionErrorData()[4],
+		testutil.TrustPolicyExceptionErrorData()[4].Key.CloudletPoolKey.NotFoundError().Error())
 
 	dummy.Stop()
 }

--- a/cmd/controller/vmpool_api_test.go
+++ b/cmd/controller/vmpool_api_test.go
@@ -40,7 +40,7 @@ func TestVMPoolApi(t *testing.T) {
 	sync.Start()
 	defer sync.Done()
 
-	testutil.InternalVMPoolTest(t, "cud", apis.vmPoolApi, testutil.VMPoolData)
+	testutil.InternalVMPoolTest(t, "cud", apis.vmPoolApi, testutil.VMPoolData())
 
 	testAddRemoveVM(t, ctx, apis)
 	testUpdateVMPool(t, ctx, apis)
@@ -51,7 +51,7 @@ func TestVMPoolApi(t *testing.T) {
 func testAddRemoveVM(t *testing.T, ctx context.Context, apis *AllApis) {
 	// test adding cloudlet vm to the pool
 	cm1 := edgeproto.VMPoolMember{}
-	cm1.Key = testutil.VMPoolData[1].Key
+	cm1.Key = testutil.VMPoolData()[1].Key
 	cm1.Vm = edgeproto.VM{
 		Name: "vmX",
 		NetInfo: edgeproto.VMNetInfo{
@@ -70,7 +70,7 @@ func testAddRemoveVM(t *testing.T, ctx context.Context, apis *AllApis) {
 
 	// test adding another cloudlet vm to the pool
 	cm2 := edgeproto.VMPoolMember{}
-	cm2.Key = testutil.VMPoolData[1].Key
+	cm2.Key = testutil.VMPoolData()[1].Key
 	cm2.Vm = edgeproto.VM{
 		Name: "vmY",
 		NetInfo: edgeproto.VMNetInfo{
@@ -107,7 +107,7 @@ func testAddRemoveVM(t *testing.T, ctx context.Context, apis *AllApis) {
 
 	// add/update VM with same external/internal IP as another VM to the pool
 	cm3 := edgeproto.VMPoolMember{}
-	cm3.Key = testutil.VMPoolData[1].Key
+	cm3.Key = testutil.VMPoolData()[1].Key
 	cm3.Vm = edgeproto.VM{
 		Name: "vmZ",
 		NetInfo: edgeproto.VMNetInfo{
@@ -130,7 +130,7 @@ func testAddRemoveVM(t *testing.T, ctx context.Context, apis *AllApis) {
 	require.NotNil(t, err, "add cloudlet vm to cloudlet vm pool should fail as same internalIP exists")
 
 	updateCM := edgeproto.VMPool{}
-	updateCM.Key = testutil.VMPoolData[1].Key
+	updateCM.Key = testutil.VMPoolData()[1].Key
 	updateCM.Vms = []edgeproto.VM{
 		edgeproto.VM{
 			Name: "vmX",
@@ -186,10 +186,10 @@ func testUpdateVMPool(t *testing.T, ctx context.Context, apis *AllApis) {
 	reduceInfoTimeouts(t, ctx, apis)
 
 	// create support data
-	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData)
+	testutil.InternalFlavorCreate(t, apis.flavorApi, testutil.FlavorData())
 
 	cl := testutil.CloudletData()[1]
-	vmp := testutil.VMPoolData[0]
+	vmp := testutil.VMPoolData()[0]
 	cl.VmPool = vmp.Key.Name
 	cl.PlatformType = edgeproto.PlatformType_PLATFORM_TYPE_FAKE_VM_POOL
 	err := apis.cloudletApi.CreateCloudlet(&cl, testutil.NewCudStreamoutCloudlet(ctx))
@@ -230,5 +230,5 @@ func testUpdateVMPool(t *testing.T, ctx context.Context, apis *AllApis) {
 	require.Nil(t, err, "remove vm from pool")
 	err = apis.cloudletApi.DeleteCloudlet(&cl, testutil.NewCudStreamoutCloudlet(ctx))
 	require.Nil(t, err)
-	testutil.InternalFlavorDelete(t, apis.flavorApi, testutil.FlavorData)
+	testutil.InternalFlavorDelete(t, apis.flavorApi, testutil.FlavorData())
 }

--- a/cmd/shepherd/cluster-autoscaler_test.go
+++ b/cmd/shepherd/cluster-autoscaler_test.go
@@ -30,7 +30,7 @@ func TestClusterAutoScaler(t *testing.T) {
 	defer log.FinishTracer()
 	log.SetDebugLevel(log.DebugLevelMetrics | log.DebugLevelApi)
 
-	cluster := testutil.ClusterInstData[2]
+	cluster := testutil.ClusterInstData()[2]
 	policy := edgeproto.AutoScalePolicy{}
 	policy.Key.Name = "test-policy"
 	policy.Key.Organization = cluster.Key.Organization

--- a/cmd/shepherd/proxy-stats_test.go
+++ b/cmd/shepherd/proxy-stats_test.go
@@ -88,23 +88,23 @@ func TestCollectProxyStats(t *testing.T) {
 	edgeproto.InitClusterInstCache(&ClusterInstCache)
 
 	//Create all clusters, apps, appInstances
-	for ii, obj := range testutil.ClusterInstData {
+	for ii, obj := range testutil.ClusterInstData() {
 		// default all to dedicated access
 		if obj.IpAccess == edgeproto.IpAccess_IP_ACCESS_UNKNOWN {
 			obj.IpAccess = edgeproto.IpAccess_IP_ACCESS_DEDICATED
 		}
-		ClusterInstCache.Update(ctx, &testutil.ClusterInstData[ii], 0)
+		ClusterInstCache.Update(ctx, &testutil.ClusterInstData()[ii], 0)
 	}
-	for ii, obj := range testutil.ClusterInstAutoData {
+	for ii, obj := range testutil.ClusterInstAutoData() {
 		// default all to dedicated access
 		if obj.IpAccess == edgeproto.IpAccess_IP_ACCESS_UNKNOWN {
 			obj.IpAccess = edgeproto.IpAccess_IP_ACCESS_DEDICATED
 		}
-		ClusterInstCache.Update(ctx, &testutil.ClusterInstAutoData[ii], 0)
+		ClusterInstCache.Update(ctx, &testutil.ClusterInstAutoData()[ii], 0)
 	}
 
-	for ii, _ := range testutil.AppData {
-		AppCache.Update(ctx, &testutil.AppData[ii], 0)
+	for ii, _ := range testutil.AppData() {
+		AppCache.Update(ctx, &testutil.AppData()[ii], 0)
 	}
 	// Now test each entry in AppInstData
 	for ii, obj := range testutil.CreatedAppInstData() {
@@ -118,7 +118,7 @@ func TestCollectProxyStats(t *testing.T) {
 		obj.MappedPorts = ports
 		obj.State = edgeproto.TrackedState_READY
 
-		// For each appInst in testutil.AppInstData the result might differ
+		// For each appInst in testutil.AppInstData() the result might differ
 		switch ii {
 		case 0, 1, 3, 4, 6, 7:
 			// tcp,udp,http ports, load-balancer access
@@ -148,7 +148,7 @@ func TestCollectProxyStats(t *testing.T) {
 			target := CollectProxyStats(ctx, &obj)
 			require.NotEmpty(t, target)
 		}
-		AppInstCache.Update(ctx, &testutil.AppInstData[ii], 0)
+		AppInstCache.Update(ctx, &testutil.AppInstData()[ii], 0)
 	}
 	// Test removal of each entry
 	for ii, obj := range testutil.CreatedAppInstData() {
@@ -162,7 +162,7 @@ func TestCollectProxyStats(t *testing.T) {
 		obj.MappedPorts = ports
 		obj.State = edgeproto.TrackedState_DELETING
 
-		// For each appInst in testutil.AppInstData the result might differ
+		// For each appInst in testutil.AppInstData() the result might differ
 		switch ii {
 		case 0, 1, 3, 4, 6, 7:
 			// tcp,udp,http ports, load-balancer access
@@ -192,11 +192,11 @@ func TestCollectProxyStats(t *testing.T) {
 			target := CollectProxyStats(ctx, &obj)
 			require.NotEmpty(t, target)
 		}
-		AppInstCache.Delete(ctx, &testutil.AppInstData[ii], 0)
+		AppInstCache.Delete(ctx, &testutil.AppInstData()[ii], 0)
 	}
 	// test an entry that has a failing platform client
 	myPlatform = &shepherd_unittest.Platform{FailPlatformClient: true}
-	appInst := testutil.AppInstData[0]
+	appInst := testutil.AppInstData()[0]
 	// set mapped ports and state
 	app := edgeproto.App{}
 	found := AppCache.Get(&appInst.Key.AppKey, &app)
@@ -218,7 +218,7 @@ func TestCollectProxyStats(t *testing.T) {
 	require.NotNil(t, ProxyMap[target].Client)
 
 	// Add a second appinst to the same cluster to test cluster net stats
-	appInst = testutil.AppInstData[7]
+	appInst = testutil.AppInstData()[7]
 	// set mapped ports and state
 	app = edgeproto.App{}
 	found = AppCache.Get(&appInst.Key.AppKey, &app)
@@ -254,16 +254,16 @@ func testProxyScraper(ctx context.Context, db *testProxyMetricsdb, t *testing.T)
 	// Verify collected stats
 	require.Equal(t, 2, len(db.appStats))
 	for k, v := range db.appStats {
-		if k.AppKey == testutil.AppInstData[7].Key.AppKey {
+		if k.AppKey == testutil.AppInstData()[7].Key.AppKey {
 			require.Equal(t, 3050, v.NetSent)
 			require.Equal(t, 400, v.NetRecv)
-		} else if k.AppKey == testutil.AppInstData[0].Key.AppKey {
+		} else if k.AppKey == testutil.AppInstData()[0].Key.AppKey {
 			require.Equal(t, 7002, v.NetSent)
 			require.Equal(t, 701, v.NetRecv)
 		}
 	}
 	require.Equal(t, 1, len(db.clusterStats))
-	stat, found := db.clusterStats[testutil.ClusterInstData[0].Key]
+	stat, found := db.clusterStats[testutil.ClusterInstData()[0].Key]
 	require.True(t, found)
 	require.Equal(t, uint64(1101), stat.NetRecv)
 	require.Equal(t, uint64(10052), stat.NetSent)

--- a/pkg/alerts/alertrules_test.go
+++ b/pkg/alerts/alertrules_test.go
@@ -23,10 +23,10 @@ import (
 )
 
 func TestGetPromAlertFromEdgeprotoAlert(t *testing.T) {
-	appInst := testutil.AppInstData[0]
+	appInst := testutil.AppInstData()[0]
 
 	// test non-default description alert
-	alert := testutil.AlertPolicyData[0]
+	alert := testutil.AlertPolicyData()[0]
 	rule := getPromAlertFromEdgeprotoAlert(&appInst, &alert)
 	require.Equal(t, alert.Key.Name, rule.Alert, "Alert name should match")
 	require.Equal(t, alert.Description, rule.Annotations[cloudcommon.AlertAnnotationDescription],
@@ -35,7 +35,7 @@ func TestGetPromAlertFromEdgeprotoAlert(t *testing.T) {
 		"Title is Alert Name")
 
 	// test default description with a single trigger
-	alert = testutil.AlertPolicyData[1]
+	alert = testutil.AlertPolicyData()[1]
 	rule = getPromAlertFromEdgeprotoAlert(&appInst, &alert)
 	require.Equal(t, alert.Key.Name, rule.Alert, "Alert name should match")
 	expectedDescription := "Number of active connections > 10"
@@ -45,7 +45,7 @@ func TestGetPromAlertFromEdgeprotoAlert(t *testing.T) {
 		"Title is Alert Name")
 
 	// test default description with multiple triggers
-	alert = testutil.AlertPolicyData[3]
+	alert = testutil.AlertPolicyData()[3]
 	rule = getPromAlertFromEdgeprotoAlert(&appInst, &alert)
 	require.Equal(t, alert.Key.Name, rule.Alert, "Alert name should match")
 	expectedDescription = "CPU Utilization > 80% and Memory Utilization > 80%"
@@ -55,7 +55,7 @@ func TestGetPromAlertFromEdgeprotoAlert(t *testing.T) {
 		"Title is Alert Name")
 
 	// test title and description as annotations
-	alert = testutil.AlertPolicyData[4]
+	alert = testutil.AlertPolicyData()[4]
 	rule = getPromAlertFromEdgeprotoAlert(&appInst, &alert)
 	require.Equal(t, alert.Key.Name, rule.Alert, "Alert name should match")
 	require.Equal(t, alert.Annotations[cloudcommon.AlertAnnotationDescription],

--- a/pkg/cli/input_test.go
+++ b/pkg/cli/input_test.go
@@ -336,10 +336,10 @@ func TestConversion(t *testing.T) {
 			"optresmap":        "StringToString",
 		},
 	}
-	for _, flavor := range testutil.FlavorData {
+	for _, flavor := range testutil.FlavorData() {
 		testConversion(t, input, &flavor, &edgeproto.Flavor{}, &edgeproto.Flavor{}, nil)
 	}
-	for _, app := range testutil.AppData {
+	for _, app := range testutil.AppData() {
 		testConversion(t, input, &app, &edgeproto.App{}, &edgeproto.App{}, nil)
 	}
 	for _, cloudlet := range testutil.CloudletData() {
@@ -347,13 +347,13 @@ func TestConversion(t *testing.T) {
 		cloudlet.ResTagMap = nil
 		testConversion(t, input, &cloudlet, &edgeproto.Cloudlet{}, &edgeproto.Cloudlet{}, nil)
 	}
-	for _, cinst := range testutil.ClusterInstData {
+	for _, cinst := range testutil.ClusterInstData() {
 		testConversion(t, input, &cinst, &edgeproto.ClusterInst{}, &edgeproto.ClusterInst{}, nil)
 	}
-	for _, appinst := range testutil.AppInstData {
+	for _, appinst := range testutil.AppInstData() {
 		testConversion(t, input, &appinst, &edgeproto.AppInst{}, &edgeproto.AppInst{}, nil)
 	}
-	for _, pp := range testutil.TrustPolicyData {
+	for _, pp := range testutil.TrustPolicyData() {
 		testConversion(t, input, &pp, &edgeproto.TrustPolicy{}, &edgeproto.TrustPolicy{}, nil)
 	}
 	settings := edgeproto.GetDefaultSettings()

--- a/pkg/k8smgmt/manifest_test.go
+++ b/pkg/k8smgmt/manifest_test.go
@@ -44,7 +44,7 @@ func TestEnvVars(t *testing.T) {
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 
-	app := &testutil.AppData[0]
+	app := &testutil.AppData()[0]
 	app.Deployment = cloudcommon.DeploymentTypeKubernetes
 	app.DeploymentGenerator = ""
 	config := &edgeproto.ConfigFile{
@@ -61,7 +61,7 @@ func TestEnvVars(t *testing.T) {
 
 	names := &KubeNames{}
 
-	defaultFlavor := testutil.FlavorData[0]
+	defaultFlavor := testutil.FlavorData()[0]
 
 	authApi := &cloudcommon.DummyRegistryAuthApi{}
 	// Test Deployment manifest with inline EnvVars
@@ -83,7 +83,7 @@ func TestEnvVars(t *testing.T) {
 		Ram:         20,
 		MinReplicas: 2,
 	}
-	gpuFlavor := testutil.FlavorData[4]
+	gpuFlavor := testutil.FlavorData()[4]
 	merged, err := MergeEnvVars(ctx, authApi, app, baseMf, nil, names, &gpuFlavor)
 	require.Nil(t, err)
 	require.Equal(t, expectedFullManifest, merged)
@@ -454,10 +454,10 @@ func TestImagePullSecrets(t *testing.T) {
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 
-	app := &testutil.AppData[1]
+	app := &testutil.AppData()[1]
 	app.ImagePath = "docker-test.mobiledgex.net/atlanticinc/images/pillimogo12:1.0.1"
-	clusterInst := &testutil.ClusterInstData[0]
-	appInst := &testutil.AppInstData[0]
+	clusterInst := &testutil.ClusterInstData()[0]
+	appInst := &testutil.AppInstData()[0]
 	app.Deployment = cloudcommon.DeploymentTypeKubernetes
 	app.DeploymentManifest = deploymentManifest
 
@@ -473,7 +473,7 @@ func TestImagePullSecrets(t *testing.T) {
 		names.ImagePullSecrets = append(names.ImagePullSecrets, secret)
 	}
 
-	defaultFlavor := testutil.FlavorData[0]
+	defaultFlavor := testutil.FlavorData()[0]
 	newMf, err := MergeEnvVars(ctx, nil, app, baseMf, names.ImagePullSecrets, &KubeNames{}, &defaultFlavor)
 	require.Nil(t, err)
 	fmt.Println(newMf)

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -72,20 +72,20 @@ func TestNotifyBasic(t *testing.T) {
 	checkServerConnections(t, &serverMgr, 2)
 
 	// Create some app insts which will trigger updates
-	serverHandler.AppCache.Update(ctx, &testutil.AppData[0], 1)
-	serverHandler.AppCache.Update(ctx, &testutil.AppData[1], 2)
-	serverHandler.AppCache.Update(ctx, &testutil.AppData[2], 3)
-	serverHandler.AppCache.Update(ctx, &testutil.AppData[3], 4)
-	serverHandler.AppCache.Update(ctx, &testutil.AppData[4], 5)
+	serverHandler.AppCache.Update(ctx, &testutil.AppData()[0], 1)
+	serverHandler.AppCache.Update(ctx, &testutil.AppData()[1], 2)
+	serverHandler.AppCache.Update(ctx, &testutil.AppData()[2], 3)
+	serverHandler.AppCache.Update(ctx, &testutil.AppData()[3], 4)
+	serverHandler.AppCache.Update(ctx, &testutil.AppData()[4], 5)
 	dmeHandler.WaitForAppInsts(5)
 	require.Equal(t, 5, len(dmeHandler.AppCache.Objs), "num Apps")
 	stats := serverMgr.GetStats(clientDME.GetLocalAddr())
 	require.Equal(t, uint64(5), stats.ObjSend["App"])
 
 	// Create some app insts which will trigger updates
-	serverHandler.AppInstCache.Update(ctx, &testutil.AppInstData[0], 0)
-	serverHandler.AppInstCache.Update(ctx, &testutil.AppInstData[1], 0)
-	serverHandler.AppInstCache.Update(ctx, &testutil.AppInstData[2], 0)
+	serverHandler.AppInstCache.Update(ctx, &testutil.AppInstData()[0], 0)
+	serverHandler.AppInstCache.Update(ctx, &testutil.AppInstData()[1], 0)
+	serverHandler.AppInstCache.Update(ctx, &testutil.AppInstData()[2], 0)
 	dmeHandler.WaitForAppInsts(3)
 	require.Equal(t, 3, len(dmeHandler.AppInstCache.Objs), "num appInsts")
 	clientDME.GetStats(stats)
@@ -104,7 +104,7 @@ func TestNotifyBasic(t *testing.T) {
 
 	// All cloudlets and all app insts will be sent again
 	// Note on server side, this is a new connection so stats are reset
-	serverHandler.AppInstCache.Update(ctx, &testutil.AppInstData[3], 0)
+	serverHandler.AppInstCache.Update(ctx, &testutil.AppInstData()[3], 0)
 	dmeHandler.WaitForAppInsts(4)
 	require.Equal(t, 4, len(dmeHandler.AppInstCache.Objs), "num appInsts")
 	require.Equal(t, uint64(17), clientDME.sendrecv.stats.Recv, "num updates")
@@ -113,7 +113,7 @@ func TestNotifyBasic(t *testing.T) {
 	require.Equal(t, uint64(5), stats.ObjSend["App"])
 
 	// Delete an inst
-	serverHandler.AppInstCache.Delete(ctx, &testutil.AppInstData[0], 0)
+	serverHandler.AppInstCache.Delete(ctx, &testutil.AppInstData()[0], 0)
 	dmeHandler.WaitForAppInsts(3)
 	require.Equal(t, 3, len(dmeHandler.AppInstCache.Objs), "num appInsts")
 	require.Equal(t, uint64(18), clientDME.sendrecv.stats.Recv, "num updates")
@@ -143,7 +143,7 @@ func TestNotifyBasic(t *testing.T) {
 	// of the sendall done command by removing the stale entry.
 	fmt.Println("ServerMgr done")
 	serverMgr.Stop()
-	serverHandler.AppInstCache.Delete(ctx, &testutil.AppInstData[1], 0)
+	serverHandler.AppInstCache.Delete(ctx, &testutil.AppInstData()[1], 0)
 	serverMgr.Start("ctrl", addr, nil)
 	clientDME.WaitForConnect(4)
 	dmeHandler.WaitForAppInsts(2)
@@ -156,11 +156,11 @@ func TestNotifyBasic(t *testing.T) {
 
 	// set ClusterInst and AppInst state to CREATE_REQUESTED so they get
 	// sent to the CRM.
-	for i, _ := range testutil.ClusterInstData {
-		testutil.ClusterInstData[i].State = edgeproto.TrackedState_CREATE_REQUESTED
+	for i, _ := range testutil.ClusterInstData() {
+		testutil.ClusterInstData()[i].State = edgeproto.TrackedState_CREATE_REQUESTED
 	}
-	for i, _ := range testutil.AppInstData {
-		testutil.AppInstData[i].State = edgeproto.TrackedState_CREATE_REQUESTED
+	for i, _ := range testutil.AppInstData() {
+		testutil.AppInstData()[i].State = edgeproto.TrackedState_CREATE_REQUESTED
 	}
 
 	// Now test CRM
@@ -173,43 +173,43 @@ func TestNotifyBasic(t *testing.T) {
 	require.Equal(t, 5, len(crmHandler.AppCache.Objs), "num apps")
 	require.Equal(t, 0, len(crmHandler.AppInstCache.Objs), "num appInsts")
 	// crm must send cloudletinfo to receive clusterInsts and appInsts
-	serverHandler.VMPoolCache.Update(ctx, &testutil.VMPoolData[0], 0)
-	serverHandler.VMPoolCache.Update(ctx, &testutil.VMPoolData[1], 0)
-	serverHandler.GPUDriverCache.Update(ctx, &testutil.GPUDriverData[0], 0)
-	serverHandler.GPUDriverCache.Update(ctx, &testutil.GPUDriverData[1], 0)
-	serverHandler.GPUDriverCache.Update(ctx, &testutil.GPUDriverData[2], 0)
+	serverHandler.VMPoolCache.Update(ctx, &testutil.VMPoolData()[0], 0)
+	serverHandler.VMPoolCache.Update(ctx, &testutil.VMPoolData()[1], 0)
+	serverHandler.GPUDriverCache.Update(ctx, &testutil.GPUDriverData()[0], 0)
+	serverHandler.GPUDriverCache.Update(ctx, &testutil.GPUDriverData()[1], 0)
+	serverHandler.GPUDriverCache.Update(ctx, &testutil.GPUDriverData()[2], 0)
 	// add vmpool for cloudlet
 	cloudletData := testutil.CloudletData()
 	vmpoolCloudlet := cloudletData[0]
-	vmpoolCloudlet.VmPool = testutil.VMPoolData[0].Key.Name
+	vmpoolCloudlet.VmPool = testutil.VMPoolData()[0].Key.Name
 	vmpoolCloudlet.GpuConfig = edgeproto.GPUConfig{
-		Driver: testutil.GPUDriverData[0].Key,
+		Driver: testutil.GPUDriverData()[0].Key,
 	}
 	// gpu config cloudlet with no restag table
 	gpuConfigNoResTagCloudlet := cloudletData[2]
 	gpuConfigNoResTagCloudlet.GpuConfig = edgeproto.GPUConfig{
-		Driver: testutil.GPUDriverData[2].Key,
+		Driver: testutil.GPUDriverData()[2].Key,
 	}
 	serverHandler.CloudletCache.Update(ctx, &vmpoolCloudlet, 6)
 	serverHandler.CloudletCache.Update(ctx, &gpuConfigNoResTagCloudlet, 7)
-	serverHandler.FlavorCache.Update(ctx, &testutil.FlavorData[0], 8)
-	serverHandler.FlavorCache.Update(ctx, &testutil.FlavorData[1], 9)
-	serverHandler.FlavorCache.Update(ctx, &testutil.FlavorData[2], 10)
-	serverHandler.ClusterInstCache.Update(ctx, &testutil.ClusterInstData[0], 11)
-	serverHandler.ClusterInstCache.Update(ctx, &testutil.ClusterInstData[1], 12)
-	serverHandler.ClusterInstCache.Update(ctx, &testutil.ClusterInstData[2], 13)
-	serverHandler.ClusterInstCache.Update(ctx, &testutil.ClusterInstData[3], 14)
-	serverHandler.AppInstCache.Update(ctx, &testutil.AppInstData[0], 15)
-	serverHandler.AppInstCache.Update(ctx, &testutil.AppInstData[1], 16)
-	serverHandler.AppInstCache.Update(ctx, &testutil.AppInstData[2], 17)
-	serverHandler.AppInstCache.Update(ctx, &testutil.AppInstData[3], 18)
-	serverHandler.NetworkCache.Update(ctx, &testutil.NetworkData[0], 19)
+	serverHandler.FlavorCache.Update(ctx, &testutil.FlavorData()[0], 8)
+	serverHandler.FlavorCache.Update(ctx, &testutil.FlavorData()[1], 9)
+	serverHandler.FlavorCache.Update(ctx, &testutil.FlavorData()[2], 10)
+	serverHandler.ClusterInstCache.Update(ctx, &testutil.ClusterInstData()[0], 11)
+	serverHandler.ClusterInstCache.Update(ctx, &testutil.ClusterInstData()[1], 12)
+	serverHandler.ClusterInstCache.Update(ctx, &testutil.ClusterInstData()[2], 13)
+	serverHandler.ClusterInstCache.Update(ctx, &testutil.ClusterInstData()[3], 14)
+	serverHandler.AppInstCache.Update(ctx, &testutil.AppInstData()[0], 15)
+	serverHandler.AppInstCache.Update(ctx, &testutil.AppInstData()[1], 16)
+	serverHandler.AppInstCache.Update(ctx, &testutil.AppInstData()[2], 17)
+	serverHandler.AppInstCache.Update(ctx, &testutil.AppInstData()[3], 18)
+	serverHandler.NetworkCache.Update(ctx, &testutil.NetworkData()[0], 19)
 	// trigger updates with CloudletInfo update after updating other
 	// data, otherwise the updates here plus the updates triggered by
 	// updating CloudletInfo can cause updates to get sent twice,
 	// messing up the stats counter checks. There's no functional
 	// issue, just makes it difficult to predict the stats values.
-	crmHandler.CloudletInfoCache.Update(ctx, &testutil.CloudletInfoData[0], 0)
+	crmHandler.CloudletInfoCache.Update(ctx, &testutil.CloudletInfoData()[0], 0)
 	// Note: only ClusterInsts and AppInsts with cloudlet keys that
 	// match the CRM's cloudletinfo will be sent.
 	require.Nil(t, crmHandler.WaitForCloudlets(1), "num cloudlets")
@@ -223,7 +223,7 @@ func TestNotifyBasic(t *testing.T) {
 
 	// trigger updates with another CloudletInfo update, this also tests that
 	// GPU driver update is received by cloudlet with no restag table configured
-	crmHandler.CloudletInfoCache.Update(ctx, &testutil.CloudletInfoData[2], 0)
+	crmHandler.CloudletInfoCache.Update(ctx, &testutil.CloudletInfoData()[2], 0)
 	require.Nil(t, crmHandler.WaitForCloudlets(2), "num cloudlets")
 	require.Nil(t, crmHandler.WaitForFlavors(3), "num flavors")
 	require.Nil(t, crmHandler.WaitForClusterInsts(3), "num clusterInsts")
@@ -239,26 +239,26 @@ func TestNotifyBasic(t *testing.T) {
 	clusterInstBuf := edgeproto.ClusterInst{}
 	appInstBuf := edgeproto.AppInst{}
 	var modRev int64
-	require.True(t, crmHandler.AppCache.GetWithRev(&testutil.AppData[0].Key, &appBuf, &modRev))
+	require.True(t, crmHandler.AppCache.GetWithRev(&testutil.AppData()[0].Key, &appBuf, &modRev))
 	require.Equal(t, int64(1), modRev)
-	require.True(t, crmHandler.FlavorCache.GetWithRev(&testutil.FlavorData[0].Key, &flavorBuf, &modRev))
+	require.True(t, crmHandler.FlavorCache.GetWithRev(&testutil.FlavorData()[0].Key, &flavorBuf, &modRev))
 	require.Equal(t, int64(8), modRev)
-	require.True(t, crmHandler.FlavorCache.GetWithRev(&testutil.FlavorData[1].Key, &flavorBuf, &modRev))
+	require.True(t, crmHandler.FlavorCache.GetWithRev(&testutil.FlavorData()[1].Key, &flavorBuf, &modRev))
 	require.Equal(t, int64(9), modRev)
-	require.True(t, crmHandler.FlavorCache.GetWithRev(&testutil.FlavorData[2].Key, &flavorBuf, &modRev))
+	require.True(t, crmHandler.FlavorCache.GetWithRev(&testutil.FlavorData()[2].Key, &flavorBuf, &modRev))
 	require.Equal(t, int64(10), modRev)
-	require.True(t, crmHandler.ClusterInstCache.GetWithRev(&testutil.ClusterInstData[0].Key, &clusterInstBuf, &modRev))
+	require.True(t, crmHandler.ClusterInstCache.GetWithRev(&testutil.ClusterInstData()[0].Key, &clusterInstBuf, &modRev))
 	require.Equal(t, int64(11), modRev)
-	require.True(t, crmHandler.ClusterInstCache.GetWithRev(&testutil.ClusterInstData[3].Key, &clusterInstBuf, &modRev))
+	require.True(t, crmHandler.ClusterInstCache.GetWithRev(&testutil.ClusterInstData()[3].Key, &clusterInstBuf, &modRev))
 	require.Equal(t, int64(14), modRev)
-	require.True(t, crmHandler.AppInstCache.GetWithRev(&testutil.AppInstData[0].Key, &appInstBuf, &modRev))
+	require.True(t, crmHandler.AppInstCache.GetWithRev(&testutil.AppInstData()[0].Key, &appInstBuf, &modRev))
 	require.Equal(t, int64(15), modRev)
-	require.True(t, crmHandler.AppInstCache.GetWithRev(&testutil.AppInstData[1].Key, &appInstBuf, &modRev))
+	require.True(t, crmHandler.AppInstCache.GetWithRev(&testutil.AppInstData()[1].Key, &appInstBuf, &modRev))
 	require.Equal(t, int64(16), modRev)
 
-	serverHandler.FlavorCache.Delete(ctx, &testutil.FlavorData[1], 0)
-	serverHandler.ClusterInstCache.Delete(ctx, &testutil.ClusterInstData[0], 0)
-	serverHandler.AppInstCache.Delete(ctx, &testutil.AppInstData[0], 0)
+	serverHandler.FlavorCache.Delete(ctx, &testutil.FlavorData()[1], 0)
+	serverHandler.ClusterInstCache.Delete(ctx, &testutil.ClusterInstData()[0], 0)
+	serverHandler.AppInstCache.Delete(ctx, &testutil.AppInstData()[0], 0)
 	crmHandler.WaitForFlavors(2)
 	crmHandler.WaitForClusterInsts(2)
 	crmHandler.WaitForAppInsts(1)
@@ -279,23 +279,23 @@ func TestNotifyBasic(t *testing.T) {
 
 	// Send data from CRM to server
 	fmt.Println("Create AppInstInfo")
-	for _, ai := range testutil.AppInstData {
+	for _, ai := range testutil.AppInstData() {
 		info := edgeproto.AppInstInfo{}
 		info.Key = ai.Key
 		crmHandler.AppInstInfoCache.Update(ctx, &info, 0)
 	}
-	serverHandler.WaitForAppInstInfo(len(testutil.AppInstData))
-	require.Equal(t, len(testutil.AppInstData),
+	serverHandler.WaitForAppInstInfo(len(testutil.AppInstData()))
+	require.Equal(t, len(testutil.AppInstData()),
 		len(serverHandler.AppInstInfoCache.Objs),
 		"sent appInstInfo")
 
-	for _, ci := range testutil.ClusterInstData {
+	for _, ci := range testutil.ClusterInstData() {
 		info := edgeproto.ClusterInstInfo{}
 		info.Key = ci.Key
 		crmHandler.ClusterInstInfoCache.Update(ctx, &info, 0)
 	}
-	serverHandler.WaitForClusterInstInfo(len(testutil.ClusterInstData))
-	require.Equal(t, len(testutil.ClusterInstData),
+	serverHandler.WaitForClusterInstInfo(len(testutil.ClusterInstData()))
+	require.Equal(t, len(testutil.ClusterInstData()),
 		len(serverHandler.ClusterInstInfoCache.Objs),
 		"sent clusterInstInfo")
 

--- a/pkg/notify/notify_tree_test.go
+++ b/pkg/notify/notify_tree_test.go
@@ -82,30 +82,30 @@ func TestNotifyTree(t *testing.T) {
 
 	// crms need to send cloudletInfo up to trigger sending of
 	// data down.
-	low21.handler.CloudletInfoCache.Update(ctx, &testutil.CloudletInfoData[0], 0)
-	low22.handler.CloudletInfoCache.Update(ctx, &testutil.CloudletInfoData[1], 0)
+	low21.handler.CloudletInfoCache.Update(ctx, &testutil.CloudletInfoData()[0], 0)
+	low22.handler.CloudletInfoCache.Update(ctx, &testutil.CloudletInfoData()[1], 0)
 
 	// Add data to top server
-	top.handler.FlavorCache.Update(ctx, &testutil.FlavorData[0], 0)
-	top.handler.FlavorCache.Update(ctx, &testutil.FlavorData[1], 0)
-	top.handler.FlavorCache.Update(ctx, &testutil.FlavorData[2], 0)
+	top.handler.FlavorCache.Update(ctx, &testutil.FlavorData()[0], 0)
+	top.handler.FlavorCache.Update(ctx, &testutil.FlavorData()[1], 0)
+	top.handler.FlavorCache.Update(ctx, &testutil.FlavorData()[2], 0)
 
 	// set ClusterInst and AppInst state to CREATE_REQUESTED so they get
 	// sent to the CRM.
-	for ii, _ := range testutil.ClusterInstData {
-		testutil.ClusterInstData[ii].State = edgeproto.TrackedState_CREATE_REQUESTED
-		top.handler.ClusterInstCache.Update(ctx, &testutil.ClusterInstData[ii], 0)
+	for ii, _ := range testutil.ClusterInstData() {
+		testutil.ClusterInstData()[ii].State = edgeproto.TrackedState_CREATE_REQUESTED
+		top.handler.ClusterInstCache.Update(ctx, &testutil.ClusterInstData()[ii], 0)
 	}
-	for ii, _ := range testutil.AppInstData {
-		testutil.AppInstData[ii].State = edgeproto.TrackedState_CREATE_REQUESTED
-		top.handler.AppInstCache.Update(ctx, &testutil.AppInstData[ii], 0)
+	for ii, _ := range testutil.AppInstData() {
+		testutil.AppInstData()[ii].State = edgeproto.TrackedState_CREATE_REQUESTED
+		top.handler.AppInstCache.Update(ctx, &testutil.AppInstData()[ii], 0)
 	}
 	cloudletData := testutil.CloudletData()
 	top.handler.CloudletCache.Update(ctx, &cloudletData[0], 0)
 	top.handler.CloudletCache.Update(ctx, &cloudletData[1], 0)
 	// dmes should get all app insts but no cloudlets
 	for _, n := range dmes {
-		checkClientCache(t, n, 0, 0, len(testutil.AppInstData), 0)
+		checkClientCache(t, n, 0, 0, len(testutil.AppInstData()), 0)
 	}
 	// crms at all levels get all flavors
 	// mid level gets the appInsts and clusterInsts for all below it.
@@ -116,10 +116,10 @@ func TestNotifyTree(t *testing.T) {
 	checkCache(t, mid1, FreeReservableClusterInstType, 1)
 
 	// Add info objs to low nodes
-	low11.handler.AppInstInfoCache.Update(ctx, &testutil.AppInstInfoData[0], 0)
-	low12.handler.AppInstInfoCache.Update(ctx, &testutil.AppInstInfoData[1], 0)
-	low21.handler.AppInstInfoCache.Update(ctx, &testutil.AppInstInfoData[2], 0)
-	low22.handler.AppInstInfoCache.Update(ctx, &testutil.AppInstInfoData[3], 0)
+	low11.handler.AppInstInfoCache.Update(ctx, &testutil.AppInstInfoData()[0], 0)
+	low12.handler.AppInstInfoCache.Update(ctx, &testutil.AppInstInfoData()[1], 0)
+	low21.handler.AppInstInfoCache.Update(ctx, &testutil.AppInstInfoData()[2], 0)
+	low22.handler.AppInstInfoCache.Update(ctx, &testutil.AppInstInfoData()[3], 0)
 	// dme mid should get 0 because it doesn't want infos
 	// crm mid should get 2, 1 from each crm low
 	mid1.handler.WaitForAppInstInfo(0)
@@ -143,9 +143,9 @@ func TestNotifyTree(t *testing.T) {
 	checkCache(t, low12, AlertType, 0)
 	checkCache(t, low21, AlertType, 0)
 	checkCache(t, low22, AlertType, 0)
-	low21.handler.AlertCache.Update(ctx, &testutil.AlertData[0], 0)
-	low21.handler.AlertCache.Update(ctx, &testutil.AlertData[1], 0)
-	low22.handler.AlertCache.Update(ctx, &testutil.AlertData[2], 0)
+	low21.handler.AlertCache.Update(ctx, &testutil.AlertData()[0], 0)
+	low21.handler.AlertCache.Update(ctx, &testutil.AlertData()[1], 0)
+	low22.handler.AlertCache.Update(ctx, &testutil.AlertData()[2], 0)
 	checkCache(t, top, AlertType, 3)
 	checkCache(t, mid1, AlertType, 0)
 	checkCache(t, mid2, AlertType, 3)
@@ -164,18 +164,18 @@ func TestNotifyTree(t *testing.T) {
 	require.Equal(t, 1, len(mid2.handler.AppInstInfoCache.Objs), "AppInstInfos")
 	require.Equal(t, 1, len(mid2.handler.CloudletInfoCache.Objs), "CloudletInfos")
 	require.Equal(t, 0, len(mid1.handler.CloudletInfoCache.Objs), "CloudletInfos")
-	_, found = mid2.handler.AppInstInfoCache.Objs[testutil.AppInstInfoData[2].Key]
+	_, found = mid2.handler.AppInstInfoCache.Objs[testutil.AppInstInfoData()[2].Key]
 	require.False(t, found, "disconnected AppInstInfo")
-	_, found = mid2.handler.CloudletInfoCache.Objs[testutil.CloudletInfoData[0].Key]
+	_, found = mid2.handler.CloudletInfoCache.Objs[testutil.CloudletInfoData()[0].Key]
 	require.False(t, found, "disconnected CloudletInfo")
 
 	top.handler.WaitForAppInstInfo(1)
 	top.handler.WaitForCloudletInfo(1)
 	require.Equal(t, 1, len(top.handler.AppInstInfoCache.Objs), "AppInstInfos")
 	require.Equal(t, 1, len(top.handler.CloudletInfoCache.Objs), "CloudletInfos")
-	_, found = top.handler.AppInstInfoCache.Objs[testutil.AppInstInfoData[2].Key]
+	_, found = top.handler.AppInstInfoCache.Objs[testutil.AppInstInfoData()[2].Key]
 	require.False(t, found, "disconnected AppInstInfo")
-	_, found = top.handler.CloudletInfoCache.Objs[testutil.CloudletInfoData[0].Key]
+	_, found = top.handler.CloudletInfoCache.Objs[testutil.CloudletInfoData()[0].Key]
 	require.False(t, found, "disconnected CloudletInfo")
 
 	checkCache(t, top, AlertType, 1)
@@ -192,16 +192,16 @@ func TestNotifyTree(t *testing.T) {
 	fmt.Println("========== cleanup")
 
 	// Delete objects to make sure deletes propagate and are applied
-	for ii, _ := range testutil.AppInstData {
-		top.handler.AppInstCache.Delete(ctx, &testutil.AppInstData[ii], 0)
+	for ii, _ := range testutil.AppInstData() {
+		top.handler.AppInstCache.Delete(ctx, &testutil.AppInstData()[ii], 0)
 	}
-	for ii, _ := range testutil.ClusterInstData {
-		log.SpanLog(ctx, log.DebugLevelNotify, "deleting ClusterInst", "key", testutil.ClusterInstData[ii].Key)
-		top.handler.ClusterInstCache.Delete(ctx, &testutil.ClusterInstData[ii], 0)
+	for ii, _ := range testutil.ClusterInstData() {
+		log.SpanLog(ctx, log.DebugLevelNotify, "deleting ClusterInst", "key", testutil.ClusterInstData()[ii].Key)
+		top.handler.ClusterInstCache.Delete(ctx, &testutil.ClusterInstData()[ii], 0)
 	}
-	top.handler.FlavorCache.Delete(ctx, &testutil.FlavorData[0], 0)
-	top.handler.FlavorCache.Delete(ctx, &testutil.FlavorData[1], 0)
-	top.handler.FlavorCache.Delete(ctx, &testutil.FlavorData[2], 0)
+	top.handler.FlavorCache.Delete(ctx, &testutil.FlavorData()[0], 0)
+	top.handler.FlavorCache.Delete(ctx, &testutil.FlavorData()[1], 0)
+	top.handler.FlavorCache.Delete(ctx, &testutil.FlavorData()[2], 0)
 	top.handler.CloudletCache.Delete(ctx, &cloudletData[0], 0)
 	top.handler.CloudletCache.Delete(ctx, &cloudletData[1], 0)
 	checkClientCache(t, mid2, 0, 0, 0, 0)

--- a/pkg/notify/worker_test.go
+++ b/pkg/notify/worker_test.go
@@ -32,21 +32,21 @@ func TestWorker(t *testing.T) {
 	mgr.SetChangedCb(TypeClusterInst, edgeproto.ClusterInstGenericNotifyCb(changes.clusterInstChanged))
 
 	// spawn a task. It will wait since go channel is empty.
-	mgr.AppInstChanged(&testutil.AppInstData[0].Key, &testutil.AppInstData[0])
+	mgr.AppInstChanged(&testutil.AppInstData()[0].Key, &testutil.AppInstData()[0])
 	assert.Equal(t, 1, len(mgr.workers))
 	<-changes.appInstWorkStarted
 	assert.Equal(t, 1, len(changes.curAppInst))
 	assert.Equal(t, 0, changes.appInstChanges)
-	checkCurAppInst(t, changes, &testutil.AppInstData[0].Key, &testutil.AppInstData[0])
+	checkCurAppInst(t, changes, &testutil.AppInstData()[0].Key, &testutil.AppInstData()[0])
 
 	// create another two tasks with the same key. Because it's the same
 	// key, they will get absorbed behind the current blocked task.
-	mgr.AppInstChanged(&testutil.AppInstData[0].Key, &testutil.AppInstData[1])
-	mgr.AppInstChanged(&testutil.AppInstData[0].Key, &testutil.AppInstData[2])
+	mgr.AppInstChanged(&testutil.AppInstData()[0].Key, &testutil.AppInstData()[1])
+	mgr.AppInstChanged(&testutil.AppInstData()[0].Key, &testutil.AppInstData()[2])
 	assert.Equal(t, 1, len(mgr.workers))
 	assert.Equal(t, 1, len(changes.curAppInst))
 	assert.Equal(t, 0, changes.appInstChanges)
-	checkCurAppInst(t, changes, &testutil.AppInstData[0].Key, &testutil.AppInstData[0])
+	checkCurAppInst(t, changes, &testutil.AppInstData()[0].Key, &testutil.AppInstData()[0])
 
 	// trigger first task to finish. Another task will be run because
 	// changes were queued.
@@ -57,7 +57,7 @@ func TestWorker(t *testing.T) {
 	assert.Equal(t, 1, len(changes.curAppInst))
 	assert.Equal(t, 1, changes.appInstChanges)
 	// key is same, but old should be first old after blocked task
-	checkCurAppInst(t, changes, &testutil.AppInstData[0].Key, &testutil.AppInstData[1])
+	checkCurAppInst(t, changes, &testutil.AppInstData()[0].Key, &testutil.AppInstData()[1])
 
 	// trigger task to finish. Because two tasks were absorbed into one
 	// change, no more work is needed.
@@ -72,8 +72,8 @@ func TestWorker(t *testing.T) {
 	changes.appInstChanges = 0
 
 	// Now add multiple keys. They should run in parallel (two workers)
-	mgr.AppInstChanged(&testutil.AppInstData[0].Key, &testutil.AppInstData[0])
-	mgr.AppInstChanged(&testutil.AppInstData[1].Key, &testutil.AppInstData[1])
+	mgr.AppInstChanged(&testutil.AppInstData()[0].Key, &testutil.AppInstData()[0])
+	mgr.AppInstChanged(&testutil.AppInstData()[1].Key, &testutil.AppInstData()[1])
 	<-changes.appInstWorkStarted
 	<-changes.appInstWorkStarted
 	assert.Equal(t, 2, len(mgr.workers))
@@ -93,24 +93,24 @@ func TestWorker(t *testing.T) {
 	assert.Equal(t, 2, changes.appInstChanges)
 
 	// Add multiple of single key
-	mgr.ClusterInstChanged(&testutil.ClusterInstData[0].Key, &testutil.ClusterInstData[0])
+	mgr.ClusterInstChanged(&testutil.ClusterInstData()[0].Key, &testutil.ClusterInstData()[0])
 	// wait until first thread is spawned
 	<-changes.clusterInstWorkStarted
-	mgr.ClusterInstChanged(&testutil.ClusterInstData[0].Key, &testutil.ClusterInstData[3])
-	mgr.ClusterInstChanged(&testutil.ClusterInstData[0].Key, &testutil.ClusterInstData[1])
-	mgr.ClusterInstChanged(&testutil.ClusterInstData[0].Key, &testutil.ClusterInstData[2])
+	mgr.ClusterInstChanged(&testutil.ClusterInstData()[0].Key, &testutil.ClusterInstData()[3])
+	mgr.ClusterInstChanged(&testutil.ClusterInstData()[0].Key, &testutil.ClusterInstData()[1])
+	mgr.ClusterInstChanged(&testutil.ClusterInstData()[0].Key, &testutil.ClusterInstData()[2])
 	// Add multiple keys
-	mgr.ClusterInstChanged(&testutil.ClusterInstData[1].Key, &testutil.ClusterInstData[1])
-	mgr.ClusterInstChanged(&testutil.ClusterInstData[2].Key, &testutil.ClusterInstData[2])
+	mgr.ClusterInstChanged(&testutil.ClusterInstData()[1].Key, &testutil.ClusterInstData()[1])
+	mgr.ClusterInstChanged(&testutil.ClusterInstData()[2].Key, &testutil.ClusterInstData()[2])
 	// There should be 3 threads
 	assert.Equal(t, 3, len(mgr.workers))
 	<-changes.clusterInstWorkStarted
 	<-changes.clusterInstWorkStarted
 	assert.Equal(t, 3, len(changes.curClusterInst))
 	assert.Equal(t, 0, changes.clusterInstChanges)
-	checkCurClusterInst(t, changes, &testutil.ClusterInstData[0].Key, &testutil.ClusterInstData[0])
-	checkCurClusterInst(t, changes, &testutil.ClusterInstData[1].Key, &testutil.ClusterInstData[1])
-	checkCurClusterInst(t, changes, &testutil.ClusterInstData[2].Key, &testutil.ClusterInstData[2])
+	checkCurClusterInst(t, changes, &testutil.ClusterInstData()[0].Key, &testutil.ClusterInstData()[0])
+	checkCurClusterInst(t, changes, &testutil.ClusterInstData()[1].Key, &testutil.ClusterInstData()[1])
+	checkCurClusterInst(t, changes, &testutil.ClusterInstData()[2].Key, &testutil.ClusterInstData()[2])
 	// Trigger all three. Note that multiple changes are behind the
 	// first key, so it will run again. So there will be a total of four
 	// callbacks called.

--- a/pkg/platform/vmpool/vmpool-vmspec_test.go
+++ b/pkg/platform/vmpool/vmpool-vmspec_test.go
@@ -70,7 +70,7 @@ func TestVMSpec(t *testing.T) {
 	ctx := log.StartTestSpan(context.Background())
 
 	// Define VM Pool
-	vmPool := testutil.VMPoolData[0]
+	vmPool := testutil.VMPoolData()[0]
 	group1 := "testvmpoolvms1"
 	group2 := "testvmpoolvms2"
 

--- a/pkg/plugin/platform/common/cluster-svc-plugin_test.go
+++ b/pkg/plugin/platform/common/cluster-svc-plugin_test.go
@@ -114,7 +114,7 @@ func TestAutoScaleT(t *testing.T) {
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 
-	clusterInst := testutil.ClusterInstData[0]
+	clusterInst := testutil.ClusterInstData()[0]
 
 	policy := edgeproto.AutoScalePolicy{}
 	policy.Key.Organization = clusterInst.Key.Organization
@@ -123,7 +123,7 @@ func TestAutoScaleT(t *testing.T) {
 
 	clusterInst.AutoScalePolicy = policy.Key.Name
 
-	userAlerts := testutil.AlertPolicyData
+	userAlerts := testutil.AlertPolicyData()
 	settings := edgeproto.GetDefaultSettings()
 
 	configExpected := `additionalPrometheusRules:
@@ -186,7 +186,7 @@ func TestAutoScaleT(t *testing.T) {
 
 func testClusterRulesT(t *testing.T, ctx context.Context, clusterInst *edgeproto.ClusterInst, policy *edgeproto.AutoScalePolicy, settings *edgeproto.Settings, alerts []edgeproto.AlertPolicy, expectedAutoProvRules string, expectedAlertPoliciesRules string) {
 	clusterSvc := ClusterSvc{}
-	appInst := testutil.AppInstData[0]
+	appInst := testutil.AppInstData()[0]
 
 	configs, err := clusterSvc.GetAppInstConfigs(ctx, clusterInst, &appInst, policy, settings, alerts)
 	require.Nil(t, err)

--- a/test/testutil/test_data.go
+++ b/test/testutil/test_data.go
@@ -26,40 +26,36 @@ import (
 	"github.com/gogo/protobuf/types"
 )
 
-var FlavorData = []edgeproto.Flavor{
-	edgeproto.Flavor{
+func FlavorData() []edgeproto.Flavor {
+	return []edgeproto.Flavor{{
 		Key: edgeproto.FlavorKey{
 			Name: "x1.tiny",
 		},
 		Ram:   1024,
 		Vcpus: 1,
 		Disk:  1,
-	},
-	edgeproto.Flavor{
+	}, {
 		Key: edgeproto.FlavorKey{
 			Name: "x1.small",
 		},
 		Ram:   2048,
 		Vcpus: 2,
 		Disk:  2,
-	},
-	edgeproto.Flavor{
+	}, {
 		Key: edgeproto.FlavorKey{
 			Name: "x1.medium",
 		},
 		Ram:   4096,
 		Vcpus: 4,
 		Disk:  4,
-	},
-	edgeproto.Flavor{
+	}, {
 		Key: edgeproto.FlavorKey{
 			Name: "x1.large",
 		},
 		Ram:   8192,
 		Vcpus: 10,
 		Disk:  40,
-	},
-	edgeproto.Flavor{
+	}, {
 		Key: edgeproto.FlavorKey{
 			Name: "x1.tiny.gpu",
 		},
@@ -69,82 +65,79 @@ var FlavorData = []edgeproto.Flavor{
 		OptResMap: map[string]string{
 			"gpu": "pci:1",
 		},
-	},
+	}}
 }
 
-var DevData = []string{
-	"AtlanticInc",
-	"Eaiever",
-	"Untomt",
-	"MakerLLC",
+func DevData() []string {
+	return []string{
+		"AtlanticInc",
+		"Eaiever",
+		"Untomt",
+		"MakerLLC",
+	}
 }
-var ClusterKeys = []edgeproto.ClusterKey{
-	edgeproto.ClusterKey{
+
+func ClusterKeys() []edgeproto.ClusterKey {
+	return []edgeproto.ClusterKey{{
 		Name: "Pillimos",
-	},
-	edgeproto.ClusterKey{
+	}, {
 		Name: "Ever.Ai",
-	},
-	edgeproto.ClusterKey{
+	}, {
 		Name: "Untomt",
-	},
-	edgeproto.ClusterKey{
+	}, {
 		Name: "Big-Pillimos",
-	},
-	edgeproto.ClusterKey{
+	}, {
 		Name: "Reservable",
-	},
-	edgeproto.ClusterKey{
+	}, {
 		Name: cloudcommon.DefaultMultiTenantCluster,
-	},
-	edgeproto.ClusterKey{
+	}, {
 		Name: "dockerCluster",
-	},
+	}}
 }
 
-var AppData = []edgeproto.App{
-	edgeproto.App{ // 0
+func AppData() []edgeproto.App {
+	devData := DevData()
+	flavorData := FlavorData()
+	autoProvPolicyData := AutoProvPolicyData()
+	return []edgeproto.App{{ // 0
 		Key: edgeproto.AppKey{
-			Organization: DevData[0],
+			Organization: devData[0],
 			Name:         "Pillimo Go!",
 			Version:      "1.0.0",
 		},
 		ImageType:       edgeproto.ImageType_IMAGE_TYPE_DOCKER,
 		AccessPorts:     "tcp:443,tcp:10002,udp:10002",
 		AccessType:      edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
-		DefaultFlavor:   FlavorData[0].Key,
+		DefaultFlavor:   flavorData[0].Key,
 		AllowServerless: true,
 		ServerlessConfig: &edgeproto.ServerlessConfig{
 			Vcpus: *edgeproto.NewUdec64(0, 500*edgeproto.DecMillis),
 			Ram:   20,
 		},
 		Trusted: true, // This is a Trusted App.
-	},
-	edgeproto.App{ // 1
+	}, { // edgeproto.App // 1
 		Key: edgeproto.AppKey{
-			Organization: DevData[0],
+			Organization: devData[0],
 			Name:         "Pillimo Go!",
 			Version:      "1.0.1",
 		},
 		ImageType:     edgeproto.ImageType_IMAGE_TYPE_DOCKER,
 		AccessPorts:   "tcp:80,tcp:443,tcp:81:tls",
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
-		DefaultFlavor: FlavorData[0].Key,
-	},
-	edgeproto.App{ // 2
+		DefaultFlavor: flavorData[0].Key,
+	}, { // edgeproto.App // 2
 		Key: edgeproto.AppKey{
-			Organization: DevData[0],
+			Organization: devData[0],
 			Name:         "Hunna Stoll Go! Go!",
 			Version:      "0.0.1",
 		},
 		ImageType:     edgeproto.ImageType_IMAGE_TYPE_DOCKER,
 		AccessPorts:   "tcp:443,udp:11111",
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
-		DefaultFlavor: FlavorData[1].Key,
-	},
-	edgeproto.App{ // 3
+		DefaultFlavor: flavorData[1].Key,
+	}, { // edgeproto.App // 3
 		Key: edgeproto.AppKey{
-			Organization: DevData[1],
+			Organization: devData[1],
 			Name:         "AI",
 			Version:      "1.2.0",
 		},
@@ -152,11 +145,10 @@ var AppData = []edgeproto.App{
 		ImagePath:     "http://somerepo/image/path/ai/1.2.0#md5:7e9cfcb763e83573a4b9d9315f56cc5f",
 		AccessPorts:   "tcp:8080",
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
-		DefaultFlavor: FlavorData[1].Key,
-	},
-	edgeproto.App{ // 4
+		DefaultFlavor: flavorData[1].Key,
+	}, { // edgeproto.App // 4
 		Key: edgeproto.AppKey{
-			Organization: DevData[2],
+			Organization: devData[2],
 			Name:         "my reality",
 			Version:      "0.0.1",
 		},
@@ -164,11 +156,10 @@ var AppData = []edgeproto.App{
 		ImagePath:     "http://somerepo/image/path/myreality/0.0.1#md5:7e9cfcb763e83573a4b9d9315f56cc5f",
 		AccessPorts:   "udp:1024",
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
-		DefaultFlavor: FlavorData[2].Key,
-	},
-	edgeproto.App{ // 5
+		DefaultFlavor: flavorData[2].Key,
+	}, { // edgeproto.App // 5
 		Key: edgeproto.AppKey{
-			Organization: DevData[3],
+			Organization: devData[3],
 			Name:         "helmApp",
 			Version:      "0.0.1",
 		},
@@ -176,41 +167,37 @@ var AppData = []edgeproto.App{
 		ImageType:     edgeproto.ImageType_IMAGE_TYPE_HELM,
 		AccessPorts:   "udp:2024",
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
-		DefaultFlavor: FlavorData[2].Key,
-	},
-	edgeproto.App{ // 6
+		DefaultFlavor: flavorData[2].Key,
+	}, { // edgeproto.App // 6
 		Key: edgeproto.AppKey{
-			Organization: DevData[0],
+			Organization: devData[0],
 			Name:         "Nelon",
 			Version:      "0.0.2",
 		},
 		ImageType:     edgeproto.ImageType_IMAGE_TYPE_DOCKER,
 		AccessPorts:   "tcp:80,udp:8001,tcp:065535",
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
-		DefaultFlavor: FlavorData[1].Key,
-	},
-	edgeproto.App{ // 7
+		DefaultFlavor: flavorData[1].Key,
+	}, { // edgeproto.App // 7
 		Key: edgeproto.AppKey{
-			Organization: DevData[0],
+			Organization: devData[0],
 			Name:         "NoPorts",
 			Version:      "1.0.0",
 		},
 		ImageType:     edgeproto.ImageType_IMAGE_TYPE_DOCKER,
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
-		DefaultFlavor: FlavorData[0].Key,
-	},
-	edgeproto.App{ // 8
+		DefaultFlavor: flavorData[0].Key,
+	}, { // edgeproto.App // 8
 		Key: edgeproto.AppKey{
-			Organization: DevData[0],
+			Organization: devData[0],
 			Name:         "PortRangeApp",
 			Version:      "1.0.0",
 		},
 		ImageType:     edgeproto.ImageType_IMAGE_TYPE_DOCKER,
 		AccessPorts:   "tcp:80,tcp:443,udp:10002,tcp:5000-5002", // new port range notation
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
-		DefaultFlavor: FlavorData[0].Key,
-	},
-	edgeproto.App{ // 9
+		DefaultFlavor: flavorData[0].Key,
+	}, { // edgeproto.App // 9
 		Key: edgeproto.AppKey{
 			Organization: edgeproto.OrganizationEdgeCloud,
 			Name:         "AutoDeleteApp",
@@ -218,7 +205,7 @@ var AppData = []edgeproto.App{
 		},
 		ImageType:       edgeproto.ImageType_IMAGE_TYPE_DOCKER,
 		AccessType:      edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
-		DefaultFlavor:   FlavorData[0].Key,
+		DefaultFlavor:   flavorData[0].Key,
 		DelOpt:          edgeproto.DeleteType_AUTO_DELETE,
 		AllowServerless: true,
 		ServerlessConfig: &edgeproto.ServerlessConfig{
@@ -226,36 +213,33 @@ var AppData = []edgeproto.App{
 			Ram:   10,
 		},
 		InternalPorts: true,
-	},
-	edgeproto.App{ // 10
+	}, { // edgeproto.App // 10
 		Key: edgeproto.AppKey{
-			Organization: DevData[1],
+			Organization: devData[1],
 			Name:         "Dev1App",
 			Version:      "0.0.1",
 		},
 		ImageType:     edgeproto.ImageType_IMAGE_TYPE_DOCKER,
 		AccessPorts:   "tcp:443,udp:11111",
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
-		DefaultFlavor: FlavorData[1].Key,
-	},
-	edgeproto.App{ // 11
+		DefaultFlavor: flavorData[1].Key,
+	}, { // edgeproto.App // 11
 		Key: edgeproto.AppKey{
-			Organization: DevData[0],
+			Organization: devData[0],
 			Name:         "Pillimo Go!",
 			Version:      "1.0.2",
 		},
 		ImageType:     edgeproto.ImageType_IMAGE_TYPE_DOCKER,
 		AccessPorts:   "tcp:10003",
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
-		DefaultFlavor: FlavorData[0].Key,
+		DefaultFlavor: flavorData[0].Key,
 		AutoProvPolicies: []string{
-			AutoProvPolicyData[0].Key.Name,
-			AutoProvPolicyData[3].Key.Name,
+			autoProvPolicyData[0].Key.Name,
+			autoProvPolicyData[3].Key.Name,
 		},
-	},
-	edgeproto.App{ // 12
+	}, { // edgeproto.App // 12
 		Key: edgeproto.AppKey{
-			Organization: DevData[0],
+			Organization: devData[0],
 			Name:         "vm lb",
 			Version:      "1.0.2",
 		},
@@ -264,9 +248,8 @@ var AppData = []edgeproto.App{
 		ImagePath:     "http://somerepo/image/path/myreality/0.0.1#md5:7e9cfcb763e83573a4b9d9315f56cc5f",
 		AccessPorts:   "tcp:10003",
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
-		DefaultFlavor: FlavorData[0].Key,
-	},
-	edgeproto.App{ // 13 - EdgeCloud app
+		DefaultFlavor: flavorData[0].Key,
+	}, { // edgeproto.App // 13 - EdgeCloud app
 		Key: edgeproto.AppKey{
 			Organization: edgeproto.OrganizationEdgeCloud,
 			Name:         "SampleApp",
@@ -275,32 +258,30 @@ var AppData = []edgeproto.App{
 		ImageType:       edgeproto.ImageType_IMAGE_TYPE_DOCKER,
 		AccessType:      edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
 		AccessPorts:     "tcp:889",
-		DefaultFlavor:   FlavorData[0].Key,
+		DefaultFlavor:   flavorData[0].Key,
 		AllowServerless: true,
 		ServerlessConfig: &edgeproto.ServerlessConfig{
 			Vcpus: *edgeproto.NewUdec64(0, 500*edgeproto.DecMillis),
 			Ram:   20,
 		},
-	},
-	edgeproto.App{ // 14
+	}, { // edgeproto.App // 14
 		Key: edgeproto.AppKey{
-			Organization: DevData[0],
+			Organization: devData[0],
 			Name:         "Pillimo MT",
 			Version:      "1.0.0",
 		},
 		ImageType:       edgeproto.ImageType_IMAGE_TYPE_DOCKER,
 		AccessPorts:     "tcp:444",
 		AccessType:      edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
-		DefaultFlavor:   FlavorData[0].Key,
+		DefaultFlavor:   flavorData[0].Key,
 		AllowServerless: true,
 		ServerlessConfig: &edgeproto.ServerlessConfig{
 			Vcpus: *edgeproto.NewUdec64(0, 500*edgeproto.DecMillis),
 			Ram:   20,
 		},
-	},
-	edgeproto.App{ // 15
+	}, { // edgeproto.App // 15
 		Key: edgeproto.AppKey{
-			Organization: DevData[0],
+			Organization: devData[0],
 			Name:         "Pillimo Docker!",
 			Version:      "1.0.1",
 		},
@@ -308,265 +289,257 @@ var AppData = []edgeproto.App{
 		ImageType:     edgeproto.ImageType_IMAGE_TYPE_DOCKER,
 		AccessPorts:   "tcp:80,tcp:443,tcp:81:tls",
 		AccessType:    edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
-		DefaultFlavor: FlavorData[0].Key,
-	},
-}
-var OperatorData = []string{
-	"UFGT Inc.",
-	"xmobx",
-	"Zerilu",
-	"Denton telecom",
+		DefaultFlavor: flavorData[0].Key,
+	}}
 }
 
-var OperatorCodeData = []edgeproto.OperatorCode{
-	edgeproto.OperatorCode{
-		Code:         "31170",
-		Organization: "UFGT Inc.",
-	},
-	edgeproto.OperatorCode{
-		Code:         "31026",
-		Organization: "xmobx",
-	},
-	edgeproto.OperatorCode{
-		Code:         "310110",
-		Organization: "Zerilu",
-	},
-	edgeproto.OperatorCode{
-		Code:         "2621",
-		Organization: "Denton telecom",
-	},
-}
-
-var cloudletData = CloudletData()
-
-func CloudletData() []edgeproto.Cloudlet {
-	return []edgeproto.Cloudlet{
-		edgeproto.Cloudlet{
-			Key: edgeproto.CloudletKey{
-				Organization: OperatorData[0],
-				Name:         "San Jose Site",
-			},
-			IpSupport:     edgeproto.IpSupport_IP_SUPPORT_DYNAMIC,
-			NumDynamicIps: 100,
-			Location: dme.Loc{
-				Latitude:  37.338207,
-				Longitude: -121.886330,
-			},
-			PlatformType:                  edgeproto.PlatformType_PLATFORM_TYPE_FAKE,
-			Flavor:                        FlavorData[0].Key,
-			NotifySrvAddr:                 "127.0.0.1:51001",
-			CrmOverride:                   edgeproto.CRMOverride_IGNORE_CRM,
-			PhysicalName:                  "SanJoseSite",
-			Deployment:                    "docker",
-			DefaultResourceAlertThreshold: 80,
-			ResourceQuotas: []edgeproto.ResourceQuota{
-				edgeproto.ResourceQuota{
-					Name:           "GPUs",
-					Value:          10,
-					AlertThreshold: 10,
-				},
-				edgeproto.ResourceQuota{
-					Name:           "RAM",
-					AlertThreshold: 30,
-				},
-				edgeproto.ResourceQuota{
-					Name:           "vCPUs",
-					Value:          99,
-					AlertThreshold: 20,
-				},
-			},
-			ResTagMap: map[string]*edgeproto.ResTagTableKey{
-				"gpu": &Restblkeys[3],
-			},
-			GpuConfig: edgeproto.GPUConfig{
-				Driver: GPUDriverData[0].Key,
-			},
-		},
-		edgeproto.Cloudlet{
-			Key: edgeproto.CloudletKey{
-				Organization: OperatorData[0],
-				Name:         "New York Site",
-			},
-			IpSupport:     edgeproto.IpSupport_IP_SUPPORT_DYNAMIC,
-			NumDynamicIps: 100,
-			Location: dme.Loc{
-				Latitude:  40.712776,
-				Longitude: -74.005974,
-			},
-			PlatformType:                  edgeproto.PlatformType_PLATFORM_TYPE_FAKE,
-			Flavor:                        FlavorData[0].Key,
-			NotifySrvAddr:                 "127.0.0.1:51002",
-			CrmOverride:                   edgeproto.CRMOverride_IGNORE_CRM,
-			PhysicalName:                  "NewYorkSite",
-			Deployment:                    "docker",
-			DefaultResourceAlertThreshold: 80,
-		},
-		edgeproto.Cloudlet{
-			Key: edgeproto.CloudletKey{
-				Organization: OperatorData[1],
-				Name:         "San Francisco Site",
-			},
-			IpSupport:     edgeproto.IpSupport_IP_SUPPORT_DYNAMIC,
-			NumDynamicIps: 100,
-			Location: dme.Loc{
-				Latitude:  37.774929,
-				Longitude: -122.419418,
-			},
-			Flavor:         FlavorData[0].Key,
-			PlatformType:   edgeproto.PlatformType_PLATFORM_TYPE_FAKE,
-			NotifySrvAddr:  "127.0.0.1:51003",
-			InfraApiAccess: edgeproto.InfraApiAccess_RESTRICTED_ACCESS,
-			InfraConfig: edgeproto.InfraConfig{
-				FlavorName:          FlavorData[0].Key.Name,
-				ExternalNetworkName: "testnet",
-			},
-			// CrmOverride not needed because of RestrictedAccess
-			PhysicalName:                  "SanFranciscoSite",
-			Deployment:                    "docker",
-			DefaultResourceAlertThreshold: 80,
-		},
-		edgeproto.Cloudlet{
-			Key: edgeproto.CloudletKey{
-				Organization: OperatorData[2],
-				Name:         "Hawaii Site",
-			},
-			IpSupport:     edgeproto.IpSupport_IP_SUPPORT_DYNAMIC,
-			NumDynamicIps: 10,
-			Location: dme.Loc{
-				Latitude:  21.306944,
-				Longitude: -157.858337,
-			},
-			Flavor:                        FlavorData[0].Key,
-			PlatformType:                  edgeproto.PlatformType_PLATFORM_TYPE_FAKE,
-			NotifySrvAddr:                 "127.0.0.1:51004",
-			CrmOverride:                   edgeproto.CRMOverride_IGNORE_CRM,
-			PhysicalName:                  "HawaiiSite",
-			Deployment:                    "docker",
-			DefaultResourceAlertThreshold: 80,
-		},
+func OperatorData() []string {
+	return []string{
+		"UFGT Inc.",
+		"xmobx",
+		"Zerilu",
+		"Denton telecom",
 	}
 }
 
-var ClusterInstData = []edgeproto.ClusterInst{
-	edgeproto.ClusterInst{ // 0
-		Key: edgeproto.ClusterInstKey{
-			ClusterKey:   ClusterKeys[0],
-			CloudletKey:  cloudletData[0].Key,
-			Organization: DevData[0],
+func OperatorCodeData() []edgeproto.OperatorCode {
+	return []edgeproto.OperatorCode{{
+		Code:         "31170",
+		Organization: "UFGT Inc.",
+	}, {
+		Code:         "31026",
+		Organization: "xmobx",
+	}, {
+		Code:         "310110",
+		Organization: "Zerilu",
+	}, {
+		Code:         "2621",
+		Organization: "Denton telecom",
+	}}
+}
+
+func CloudletData() []edgeproto.Cloudlet {
+	flavorData := FlavorData()
+	operatorData := OperatorData()
+	restblkeys := Restblkeys()
+	gpuDriverData := GPUDriverData()
+	return []edgeproto.Cloudlet{{
+		Key: edgeproto.CloudletKey{
+			Organization: operatorData[0],
+			Name:         "San Jose Site",
 		},
-		Flavor:     FlavorData[0].Key,
+		IpSupport:     edgeproto.IpSupport_IP_SUPPORT_DYNAMIC,
+		NumDynamicIps: 100,
+		Location: dme.Loc{
+			Latitude:  37.338207,
+			Longitude: -121.886330,
+		},
+		PlatformType:                  edgeproto.PlatformType_PLATFORM_TYPE_FAKE,
+		Flavor:                        flavorData[0].Key,
+		NotifySrvAddr:                 "127.0.0.1:51001",
+		CrmOverride:                   edgeproto.CRMOverride_IGNORE_CRM,
+		PhysicalName:                  "SanJoseSite",
+		Deployment:                    "docker",
+		DefaultResourceAlertThreshold: 80,
+		ResourceQuotas: []edgeproto.ResourceQuota{{
+			Name:           "GPUs",
+			Value:          10,
+			AlertThreshold: 10,
+		}, {
+			Name:           "RAM",
+			AlertThreshold: 30,
+		}, {
+			Name:           "vCPUs",
+			Value:          99,
+			AlertThreshold: 20,
+		}},
+		ResTagMap: map[string]*edgeproto.ResTagTableKey{
+			"gpu": &restblkeys[3],
+		},
+		GpuConfig: edgeproto.GPUConfig{
+			Driver: gpuDriverData[0].Key,
+		},
+	}, { // edgeproto.Cloudlet
+		Key: edgeproto.CloudletKey{
+			Organization: operatorData[0],
+			Name:         "New York Site",
+		},
+		IpSupport:     edgeproto.IpSupport_IP_SUPPORT_DYNAMIC,
+		NumDynamicIps: 100,
+		Location: dme.Loc{
+			Latitude:  40.712776,
+			Longitude: -74.005974,
+		},
+		PlatformType:                  edgeproto.PlatformType_PLATFORM_TYPE_FAKE,
+		Flavor:                        flavorData[0].Key,
+		NotifySrvAddr:                 "127.0.0.1:51002",
+		CrmOverride:                   edgeproto.CRMOverride_IGNORE_CRM,
+		PhysicalName:                  "NewYorkSite",
+		Deployment:                    "docker",
+		DefaultResourceAlertThreshold: 80,
+	}, { // edgeproto.Cloudlet
+		Key: edgeproto.CloudletKey{
+			Organization: operatorData[1],
+			Name:         "San Francisco Site",
+		},
+		IpSupport:     edgeproto.IpSupport_IP_SUPPORT_DYNAMIC,
+		NumDynamicIps: 100,
+		Location: dme.Loc{
+			Latitude:  37.774929,
+			Longitude: -122.419418,
+		},
+		Flavor:         flavorData[0].Key,
+		PlatformType:   edgeproto.PlatformType_PLATFORM_TYPE_FAKE,
+		NotifySrvAddr:  "127.0.0.1:51003",
+		InfraApiAccess: edgeproto.InfraApiAccess_RESTRICTED_ACCESS,
+		InfraConfig: edgeproto.InfraConfig{
+			FlavorName:          flavorData[0].Key.Name,
+			ExternalNetworkName: "testnet",
+		},
+		// CrmOverride not needed because of RestrictedAccess
+		PhysicalName:                  "SanFranciscoSite",
+		Deployment:                    "docker",
+		DefaultResourceAlertThreshold: 80,
+	}, { // edgeproto.Cloudlet
+		Key: edgeproto.CloudletKey{
+			Organization: operatorData[2],
+			Name:         "Hawaii Site",
+		},
+		IpSupport:     edgeproto.IpSupport_IP_SUPPORT_DYNAMIC,
+		NumDynamicIps: 10,
+		Location: dme.Loc{
+			Latitude:  21.306944,
+			Longitude: -157.858337,
+		},
+		Flavor:                        flavorData[0].Key,
+		PlatformType:                  edgeproto.PlatformType_PLATFORM_TYPE_FAKE,
+		NotifySrvAddr:                 "127.0.0.1:51004",
+		CrmOverride:                   edgeproto.CRMOverride_IGNORE_CRM,
+		PhysicalName:                  "HawaiiSite",
+		Deployment:                    "docker",
+		DefaultResourceAlertThreshold: 80,
+	}}
+}
+
+func ClusterInstData() []edgeproto.ClusterInst {
+	devData := DevData()
+	flavorData := FlavorData()
+	clusterKeys := ClusterKeys()
+	cloudletData := CloudletData()
+	autoScalePolicyData := AutoScalePolicyData()
+	return []edgeproto.ClusterInst{{ // 0
+		Key: edgeproto.ClusterInstKey{
+			ClusterKey:   clusterKeys[0],
+			CloudletKey:  cloudletData[0].Key,
+			Organization: devData[0],
+		},
+		Flavor:     flavorData[0].Key,
 		IpAccess:   edgeproto.IpAccess_IP_ACCESS_DEDICATED,
 		NumMasters: 1,
 		NumNodes:   2,
-	},
-	edgeproto.ClusterInst{ // 1
+	}, { // edgeproto.ClusterInst // 1
 		Key: edgeproto.ClusterInstKey{
-			ClusterKey:   ClusterKeys[0],
+			ClusterKey:   clusterKeys[0],
 			CloudletKey:  cloudletData[1].Key,
-			Organization: DevData[0],
+			Organization: devData[0],
 		},
-		Flavor:     FlavorData[0].Key,
+		Flavor:     flavorData[0].Key,
 		IpAccess:   edgeproto.IpAccess_IP_ACCESS_SHARED,
 		NumMasters: 1,
 		NumNodes:   2,
-	},
-	edgeproto.ClusterInst{ // 2
+	}, { // edgeproto.ClusterInst // 2
 		Key: edgeproto.ClusterInstKey{
-			ClusterKey:   ClusterKeys[0],
+			ClusterKey:   clusterKeys[0],
 			CloudletKey:  cloudletData[2].Key,
-			Organization: DevData[3],
+			Organization: devData[3],
 		},
-		Flavor:          FlavorData[0].Key,
+		Flavor:          flavorData[0].Key,
 		NumMasters:      1,
 		NumNodes:        2,
-		AutoScalePolicy: AutoScalePolicyData[2].Key.Name,
-	},
-	edgeproto.ClusterInst{ // 3
+		AutoScalePolicy: autoScalePolicyData[2].Key.Name,
+	}, { // edgeproto.ClusterInst // 3
 		Key: edgeproto.ClusterInstKey{
-			ClusterKey:   ClusterKeys[1],
+			ClusterKey:   clusterKeys[1],
 			CloudletKey:  cloudletData[0].Key,
-			Organization: DevData[0],
+			Organization: devData[0],
 		},
-		Flavor:          FlavorData[1].Key,
+		Flavor:          flavorData[1].Key,
 		IpAccess:        edgeproto.IpAccess_IP_ACCESS_DEDICATED,
 		NumMasters:      1,
 		NumNodes:        3,
-		AutoScalePolicy: AutoScalePolicyData[0].Key.Name,
-	},
-	edgeproto.ClusterInst{ // 4
+		AutoScalePolicy: autoScalePolicyData[0].Key.Name,
+	}, { // edgeproto.ClusterInst // 4
 		Key: edgeproto.ClusterInstKey{
-			ClusterKey:   ClusterKeys[1],
+			ClusterKey:   clusterKeys[1],
 			CloudletKey:  cloudletData[1].Key,
-			Organization: DevData[3],
+			Organization: devData[3],
 		},
-		Flavor:     FlavorData[1].Key,
+		Flavor:     flavorData[1].Key,
 		IpAccess:   edgeproto.IpAccess_IP_ACCESS_SHARED,
 		NumMasters: 1,
 		NumNodes:   3,
-	},
-	edgeproto.ClusterInst{ // 5
+	}, { // edgeproto.ClusterInst // 5
 		Key: edgeproto.ClusterInstKey{
-			ClusterKey:   ClusterKeys[2],
+			ClusterKey:   clusterKeys[2],
 			CloudletKey:  cloudletData[2].Key,
-			Organization: DevData[3],
+			Organization: devData[3],
 		},
-		Flavor:     FlavorData[2].Key,
+		Flavor:     flavorData[2].Key,
 		IpAccess:   edgeproto.IpAccess_IP_ACCESS_DEDICATED,
 		NumMasters: 1,
 		NumNodes:   4,
-	},
-	edgeproto.ClusterInst{ // 6
+	}, { // edgeproto.ClusterInst // 6
 		Key: edgeproto.ClusterInstKey{
-			ClusterKey:   ClusterKeys[3],
+			ClusterKey:   clusterKeys[3],
 			CloudletKey:  cloudletData[3].Key,
-			Organization: DevData[3],
+			Organization: devData[3],
 		},
-		Flavor:     FlavorData[2].Key,
+		Flavor:     flavorData[2].Key,
 		NumMasters: 1,
 		NumNodes:   3,
-	},
-	edgeproto.ClusterInst{ // 7
+	}, { // edgeproto.ClusterInst // 7
 		Key: edgeproto.ClusterInstKey{
-			ClusterKey:   ClusterKeys[4],
+			ClusterKey:   clusterKeys[4],
 			CloudletKey:  cloudletData[0].Key,
 			Organization: edgeproto.OrganizationEdgeCloud,
 		},
-		Flavor:     FlavorData[0].Key,
+		Flavor:     flavorData[0].Key,
 		IpAccess:   edgeproto.IpAccess_IP_ACCESS_SHARED,
 		NumMasters: 1,
 		NumNodes:   2,
 		Reservable: true,
-	},
-	edgeproto.ClusterInst{ // 8
+	}, { // edgeproto.ClusterInst // 8
 		Key: edgeproto.ClusterInstKey{
-			ClusterKey:   ClusterKeys[5], // multi-tenant cluster
+			ClusterKey:   clusterKeys[5], // multi-tenant cluster
 			CloudletKey:  cloudletData[0].Key,
 			Organization: edgeproto.OrganizationEdgeCloud,
 		},
-		Flavor:           FlavorData[0].Key,
+		Flavor:           flavorData[0].Key,
 		IpAccess:         edgeproto.IpAccess_IP_ACCESS_SHARED,
 		NumMasters:       1,
 		NumNodes:         5,
-		MasterNodeFlavor: FlavorData[2].Key.Name, // medium
+		MasterNodeFlavor: flavorData[2].Key.Name, // medium
 		MultiTenant:      true,
-	},
-	edgeproto.ClusterInst{ // 9
+	}, { // edgeproto.ClusterInst // 9
 		Key: edgeproto.ClusterInstKey{
-			ClusterKey:   ClusterKeys[6],
+			ClusterKey:   clusterKeys[6],
 			CloudletKey:  cloudletData[1].Key,
-			Organization: DevData[0],
+			Organization: devData[0],
 		},
 		Deployment: cloudcommon.DeploymentTypeDocker,
-		Flavor:     FlavorData[0].Key,
+		Flavor:     flavorData[0].Key,
 		IpAccess:   edgeproto.IpAccess_IP_ACCESS_DEDICATED,
-	},
+	}}
 }
 
 // These are the cluster insts that will be created automatically
 // from appinsts that have not specified a cluster.
-var ClusterInstAutoData = []edgeproto.ClusterInst{
-	// from AppInstData[3] -> AppData[1]
-	edgeproto.ClusterInst{
+func ClusterInstAutoData() []edgeproto.ClusterInst {
+	devData := DevData()
+	flavorData := FlavorData()
+	cloudletData := CloudletData()
+	return []edgeproto.ClusterInst{{
+		// from AppInstData[3] -> AppData[1]
 		Key: edgeproto.ClusterInstKey{
 			ClusterKey: edgeproto.ClusterKey{
 				Name: "reservable0",
@@ -574,16 +547,15 @@ var ClusterInstAutoData = []edgeproto.ClusterInst{
 			CloudletKey:  cloudletData[1].Key,
 			Organization: edgeproto.OrganizationEdgeCloud,
 		},
-		Flavor:     FlavorData[0].Key,
+		Flavor:     flavorData[0].Key,
 		NumMasters: 1,
 		NumNodes:   1,
 		State:      edgeproto.TrackedState_READY,
 		Auto:       true,
 		Reservable: true,
-		ReservedBy: DevData[0],
-	},
-	// from AppInstData[4] -> AppData[2]
-	edgeproto.ClusterInst{
+		ReservedBy: devData[0],
+	}, { // edgeproto.ClusterInst
+		// from AppInstData[4] -> AppData[2]
 		Key: edgeproto.ClusterInstKey{
 			ClusterKey: edgeproto.ClusterKey{
 				Name: "reservable0",
@@ -591,16 +563,15 @@ var ClusterInstAutoData = []edgeproto.ClusterInst{
 			CloudletKey:  cloudletData[2].Key,
 			Organization: edgeproto.OrganizationEdgeCloud,
 		},
-		Flavor:     FlavorData[1].Key,
+		Flavor:     flavorData[1].Key,
 		NumMasters: 1,
 		NumNodes:   1,
 		State:      edgeproto.TrackedState_READY,
 		Auto:       true,
 		Reservable: true,
-		ReservedBy: DevData[0],
-	},
-	// from AppInstData[6] -> AppData[6]
-	edgeproto.ClusterInst{
+		ReservedBy: devData[0],
+	}, { // edgeproto.ClusterInst
+		// from AppInstData[6] -> AppData[6]
 		Key: edgeproto.ClusterInstKey{
 			ClusterKey: edgeproto.ClusterKey{
 				Name: "reservable1",
@@ -608,16 +579,15 @@ var ClusterInstAutoData = []edgeproto.ClusterInst{
 			CloudletKey:  cloudletData[2].Key,
 			Organization: edgeproto.OrganizationEdgeCloud,
 		},
-		Flavor:     FlavorData[1].Key,
+		Flavor:     flavorData[1].Key,
 		NumMasters: 1,
 		NumNodes:   1,
 		State:      edgeproto.TrackedState_READY,
 		Auto:       true,
 		Reservable: true,
-		ReservedBy: DevData[0],
-	},
-	// from AppInstData[12] -> AppData[13]
-	edgeproto.ClusterInst{
+		ReservedBy: devData[0],
+	}, { // edgeproto.ClusterInst
+		// from AppInstData[12] -> AppData[13]
 		Key: edgeproto.ClusterInstKey{
 			ClusterKey: edgeproto.ClusterKey{
 				Name: "reservable0",
@@ -625,816 +595,696 @@ var ClusterInstAutoData = []edgeproto.ClusterInst{
 			CloudletKey:  cloudletData[3].Key,
 			Organization: edgeproto.OrganizationEdgeCloud,
 		},
-		Flavor:     FlavorData[0].Key,
+		Flavor:     flavorData[0].Key,
 		NumMasters: 1,
 		NumNodes:   1,
 		State:      edgeproto.TrackedState_READY,
 		Auto:       true,
 		Reservable: true,
 		ReservedBy: edgeproto.OrganizationEdgeCloud,
-	},
+	}}
 }
-var AppInstData = []edgeproto.AppInst{
-	edgeproto.AppInst{ // 0
+
+func AppInstData() []edgeproto.AppInst {
+	cloudletData := CloudletData()
+	appData := AppData()
+	clusterInstData := ClusterInstData()
+	clusterInstAutoData := ClusterInstAutoData()
+	return []edgeproto.AppInst{{ // 0
 		Key: edgeproto.AppInstKey{
-			AppKey:         AppData[0].Key,
-			ClusterInstKey: *ClusterInstData[0].Key.Virtual(""),
+			AppKey:         appData[0].Key,
+			ClusterInstKey: *clusterInstData[0].Key.Virtual(""),
 		},
 		CloudletLoc: cloudletData[0].Location,
-	},
-	edgeproto.AppInst{ // 1
+	}, { // edgeproto.AppInst // 1
 		Key: edgeproto.AppInstKey{
-			AppKey:         AppData[0].Key,
-			ClusterInstKey: *ClusterInstData[3].Key.Virtual(""),
+			AppKey:         appData[0].Key,
+			ClusterInstKey: *clusterInstData[3].Key.Virtual(""),
 		},
 		CloudletLoc: cloudletData[0].Location,
-	},
-	edgeproto.AppInst{ // 2
+	}, { // edgeproto.AppInst // 2
 		Key: edgeproto.AppInstKey{
-			AppKey:         AppData[0].Key,
-			ClusterInstKey: *ClusterInstData[1].Key.Virtual(""),
+			AppKey:         appData[0].Key,
+			ClusterInstKey: *clusterInstData[1].Key.Virtual(""),
 		},
 		CloudletLoc: cloudletData[1].Location,
-	},
-	edgeproto.AppInst{ // 3
+	}, { // edgeproto.AppInst // 3
 		Key: edgeproto.AppInstKey{
-			AppKey: AppData[1].Key,
+			AppKey: appData[1].Key,
 			// ClusterInst is ClusterInstAutoData[0]
-			ClusterInstKey: *ClusterInstAutoData[0].Key.Virtual(util.K8SSanitize("autocluster" + AppData[1].Key.Name)),
+			ClusterInstKey: *clusterInstAutoData[0].Key.Virtual(util.K8SSanitize("autocluster" + appData[1].Key.Name)),
 		},
 		CloudletLoc: cloudletData[1].Location,
-	},
-	edgeproto.AppInst{ // 4
+	}, { // edgeproto.AppInst // 4
 		Key: edgeproto.AppInstKey{
-			AppKey: AppData[2].Key,
+			AppKey: appData[2].Key,
 			// ClusterInst is ClusterInstAutoData[1]
-			ClusterInstKey: *ClusterInstAutoData[1].Key.Virtual(util.K8SSanitize("autocluster" + AppData[2].Key.Name)),
+			ClusterInstKey: *clusterInstAutoData[1].Key.Virtual(util.K8SSanitize("autocluster" + appData[2].Key.Name)),
 		},
 		CloudletLoc: cloudletData[2].Location,
-	},
-	edgeproto.AppInst{ // 5
+	}, { // edgeproto.AppInst // 5
 		Key: edgeproto.AppInstKey{
-			AppKey:         AppData[5].Key,
-			ClusterInstKey: *ClusterInstData[2].Key.Virtual(""),
+			AppKey:         appData[5].Key,
+			ClusterInstKey: *clusterInstData[2].Key.Virtual(""),
 		},
 		CloudletLoc: cloudletData[2].Location,
-	},
-	edgeproto.AppInst{ // 6
+	}, { // edgeproto.AppInst // 6
 		Key: edgeproto.AppInstKey{
-			AppKey: AppData[6].Key,
+			AppKey: appData[6].Key,
 			// ClusterInst is ClusterInstAutoData[2]
-			ClusterInstKey: *ClusterInstAutoData[2].Key.Virtual(util.K8SSanitize("autocluster" + AppData[6].Key.Name)),
+			ClusterInstKey: *clusterInstAutoData[2].Key.Virtual(util.K8SSanitize("autocluster" + appData[6].Key.Name)),
 		},
 		CloudletLoc: cloudletData[2].Location,
-	},
-	edgeproto.AppInst{ // 7
+	}, { // edgeproto.AppInst // 7
 		Key: edgeproto.AppInstKey{
-			AppKey:         AppData[6].Key,
-			ClusterInstKey: *ClusterInstData[0].Key.Virtual(""),
+			AppKey:         appData[6].Key,
+			ClusterInstKey: *clusterInstData[0].Key.Virtual(""),
 		},
 		CloudletLoc: cloudletData[0].Location,
-	},
-	edgeproto.AppInst{ // 8
+	}, { // edgeproto.AppInst // 8
 		Key: edgeproto.AppInstKey{
-			AppKey:         AppData[7].Key,
-			ClusterInstKey: *ClusterInstData[0].Key.Virtual(""),
+			AppKey:         appData[7].Key,
+			ClusterInstKey: *clusterInstData[0].Key.Virtual(""),
 		},
 		CloudletLoc: cloudletData[0].Location,
-	},
-	edgeproto.AppInst{ // 9
+	}, { // edgeproto.AppInst // 9
 		Key: edgeproto.AppInstKey{
-			AppKey:         AppData[9].Key, //auto-delete app
-			ClusterInstKey: *ClusterInstData[0].Key.Virtual(""),
+			AppKey:         appData[9].Key, //auto-delete app
+			ClusterInstKey: *clusterInstData[0].Key.Virtual(""),
 		},
 		CloudletLoc: cloudletData[0].Location,
-	},
-	edgeproto.AppInst{ // 10
+	}, { // edgeproto.AppInst // 10
 		Key: edgeproto.AppInstKey{
-			AppKey:         AppData[9].Key, //auto-delete app
-			ClusterInstKey: *ClusterInstAutoData[0].Key.Virtual(""),
+			AppKey:         appData[9].Key, //auto-delete app
+			ClusterInstKey: *clusterInstAutoData[0].Key.Virtual(""),
 		},
 		CloudletLoc:     cloudletData[1].Location,
-		RealClusterName: ClusterInstAutoData[0].Key.ClusterKey.Name,
-	},
-	edgeproto.AppInst{ // 11
+		RealClusterName: clusterInstAutoData[0].Key.ClusterKey.Name,
+	}, { // edgeproto.AppInst // 11
 		Key: edgeproto.AppInstKey{
-			AppKey: AppData[12].Key, //vm app with lb
+			AppKey: appData[12].Key, //vm app with lb
 			ClusterInstKey: edgeproto.VirtualClusterInstKey{
 				CloudletKey: cloudletData[0].Key,
 			},
 		},
 		CloudletLoc: cloudletData[1].Location,
-	},
-	edgeproto.AppInst{ // 12 - deploy EdgeCloud app to reservable autocluster
+	}, { // edgeproto.AppInst // 12 - deploy EdgeCloud app to reservable autocluster
 		Key: edgeproto.AppInstKey{
-			AppKey:         AppData[13].Key, // edgecloud sample app
-			ClusterInstKey: *ClusterInstAutoData[3].Key.Virtual(util.K8SSanitize("autocluster" + AppData[13].Key.Name)),
+			AppKey:         appData[13].Key, // edgecloud sample app
+			ClusterInstKey: *clusterInstAutoData[3].Key.Virtual(util.K8SSanitize("autocluster" + appData[13].Key.Name)),
 		},
 		CloudletLoc: cloudletData[3].Location,
-	},
-	edgeproto.AppInst{ // 13
+	}, { // edgeproto.AppInst // 13
 		Key: edgeproto.AppInstKey{
-			AppKey:         AppData[0].Key,
-			ClusterInstKey: *ClusterInstData[8].Key.Virtual("autocluster-mt1"),
+			AppKey:         appData[0].Key,
+			ClusterInstKey: *clusterInstData[8].Key.Virtual("autocluster-mt1"),
 		},
 		CloudletLoc: cloudletData[0].Location,
-	},
-	edgeproto.AppInst{ // 14
+	}, { // edgeproto.AppInst // 14
 		Key: edgeproto.AppInstKey{
-			AppKey:         AppData[9].Key, // sidecar app
-			ClusterInstKey: *ClusterInstData[8].Key.Virtual(""),
+			AppKey:         appData[9].Key, // sidecar app
+			ClusterInstKey: *clusterInstData[8].Key.Virtual(""),
 		},
 		CloudletLoc: cloudletData[0].Location,
-	},
-	edgeproto.AppInst{ // 15
+	}, { // edgeproto.AppInst // 15
 		Key: edgeproto.AppInstKey{
-			AppKey:         AppData[13].Key,
-			ClusterInstKey: *ClusterInstData[8].Key.Virtual("autocluster-mt3"),
+			AppKey:         appData[13].Key,
+			ClusterInstKey: *clusterInstData[8].Key.Virtual("autocluster-mt3"),
 		},
 		CloudletLoc: cloudletData[0].Location,
-	},
-	edgeproto.AppInst{ // 16
+	}, { // edgeproto.AppInst // 16
 		Key: edgeproto.AppInstKey{
-			AppKey:         AppData[14].Key,
-			ClusterInstKey: *ClusterInstData[8].Key.Virtual("autocluster-mt2"),
+			AppKey:         appData[14].Key,
+			ClusterInstKey: *clusterInstData[8].Key.Virtual("autocluster-mt2"),
 		},
 		CloudletLoc: cloudletData[0].Location,
-	},
-	edgeproto.AppInst{ // 17
+	}, { // edgeproto.AppInst // 17
 		Key: edgeproto.AppInstKey{
-			AppKey:         AppData[15].Key,
-			ClusterInstKey: *ClusterInstData[9].Key.Virtual(""),
+			AppKey:         appData[15].Key,
+			ClusterInstKey: *clusterInstData[9].Key.Virtual(""),
 		},
 		CloudletLoc: cloudletData[0].Location,
-	},
+	}}
 }
 
-var AppInstInfoData = []edgeproto.AppInstInfo{
-	edgeproto.AppInstInfo{
-		Key: AppInstData[0].Key,
-	},
-	edgeproto.AppInstInfo{
-		Key: AppInstData[1].Key,
-	},
-	edgeproto.AppInstInfo{
-		Key: AppInstData[2].Key,
-	},
-	edgeproto.AppInstInfo{
-		Key: AppInstData[3].Key,
-	},
-	edgeproto.AppInstInfo{
-		Key: AppInstData[4].Key,
-	},
-	edgeproto.AppInstInfo{
-		Key: AppInstData[5].Key,
-	},
-	edgeproto.AppInstInfo{
-		Key: AppInstData[6].Key,
-	},
-	edgeproto.AppInstInfo{
-		Key: AppInstData[7].Key,
-	},
+func AppInstInfoData() []edgeproto.AppInstInfo {
+	appInstData := AppInstData()
+	return []edgeproto.AppInstInfo{{
+		Key: appInstData[0].Key,
+	}, {
+		Key: appInstData[1].Key,
+	}, {
+		Key: appInstData[2].Key,
+	}, {
+		Key: appInstData[3].Key,
+	}, {
+		Key: appInstData[4].Key,
+	}, {
+		Key: appInstData[5].Key,
+	}, {
+		Key: appInstData[6].Key,
+	}, {
+		Key: appInstData[7].Key,
+	}}
 }
 
 func GetAppInstRefsData() []edgeproto.AppInstRefs {
 	createdAppInsts := CreatedAppInstData()
-	return []edgeproto.AppInstRefs{
-		edgeproto.AppInstRefs{
-			Key: AppData[0].Key,
-			Insts: map[string]uint32{
-				AppInstData[0].Key.GetKeyString():  1,
-				AppInstData[1].Key.GetKeyString():  1,
-				AppInstData[2].Key.GetKeyString():  1,
-				AppInstData[13].Key.GetKeyString(): 1,
-			},
+	appData := AppData()
+	appInstData := AppInstData()
+	return []edgeproto.AppInstRefs{{
+		Key: appData[0].Key,
+		Insts: map[string]uint32{
+			appInstData[0].Key.GetKeyString():  1,
+			appInstData[1].Key.GetKeyString():  1,
+			appInstData[2].Key.GetKeyString():  1,
+			appInstData[13].Key.GetKeyString(): 1,
 		},
-		edgeproto.AppInstRefs{
-			Key: AppData[1].Key,
-			Insts: map[string]uint32{
-				AppInstData[3].Key.GetKeyString(): 1,
-			},
+	}, { // edgeproto.AppInstRefs
+		Key: appData[1].Key,
+		Insts: map[string]uint32{
+			appInstData[3].Key.GetKeyString(): 1,
 		},
-		edgeproto.AppInstRefs{
-			Key: AppData[2].Key,
-			Insts: map[string]uint32{
-				AppInstData[4].Key.GetKeyString(): 1,
-			},
+	}, { // edgeproto.AppInstRefs
+		Key: appData[2].Key,
+		Insts: map[string]uint32{
+			appInstData[4].Key.GetKeyString(): 1,
 		},
-		edgeproto.AppInstRefs{
-			Key:   AppData[3].Key,
-			Insts: map[string]uint32{},
+	}, { // edgeproto.AppInstRefs
+		Key:   appData[3].Key,
+		Insts: map[string]uint32{},
+	}, { // edgeproto.AppInstRefs
+		Key:   appData[4].Key,
+		Insts: map[string]uint32{},
+	}, { // edgeproto.AppInstRefs
+		Key: appData[5].Key,
+		Insts: map[string]uint32{
+			appInstData[5].Key.GetKeyString(): 1,
 		},
-		edgeproto.AppInstRefs{
-			Key:   AppData[4].Key,
-			Insts: map[string]uint32{},
+	}, { // edgeproto.AppInstRefs
+		Key: appData[6].Key,
+		Insts: map[string]uint32{
+			appInstData[6].Key.GetKeyString(): 1,
+			appInstData[7].Key.GetKeyString(): 1,
 		},
-		edgeproto.AppInstRefs{
-			Key: AppData[5].Key,
-			Insts: map[string]uint32{
-				AppInstData[5].Key.GetKeyString(): 1,
-			},
+	}, { // edgeproto.AppInstRefs
+		Key: appData[7].Key,
+		Insts: map[string]uint32{
+			appInstData[8].Key.GetKeyString(): 1,
 		},
-		edgeproto.AppInstRefs{
-			Key: AppData[6].Key,
-			Insts: map[string]uint32{
-				AppInstData[6].Key.GetKeyString(): 1,
-				AppInstData[7].Key.GetKeyString(): 1,
-			},
+	}, { // edgeproto.AppInstRefs
+		Key:   appData[8].Key,
+		Insts: map[string]uint32{},
+	}, { // edgeproto.AppInstRefs
+		Key: appData[9].Key,
+		Insts: map[string]uint32{
+			appInstData[9].Key.GetKeyString():  1,
+			appInstData[10].Key.GetKeyString(): 1,
+			appInstData[14].Key.GetKeyString(): 1,
 		},
-		edgeproto.AppInstRefs{
-			Key: AppData[7].Key,
-			Insts: map[string]uint32{
-				AppInstData[8].Key.GetKeyString(): 1,
-			},
+	}, { // edgeproto.AppInstRefs
+		Key:   appData[10].Key,
+		Insts: map[string]uint32{},
+	}, { // edgeproto.AppInstRefs
+		Key:   appData[11].Key,
+		Insts: map[string]uint32{},
+	}, { // edgeproto.AppInstRefs
+		Key: appData[12].Key,
+		Insts: map[string]uint32{
+			createdAppInsts[11].Key.GetKeyString(): 1,
 		},
-		edgeproto.AppInstRefs{
-			Key:   AppData[8].Key,
-			Insts: map[string]uint32{},
+	}, { // edgeproto.AppInstRefs
+		Key: appData[13].Key,
+		Insts: map[string]uint32{
+			appInstData[12].Key.GetKeyString(): 1,
+			appInstData[15].Key.GetKeyString(): 1,
 		},
-		edgeproto.AppInstRefs{
-			Key: AppData[9].Key,
-			Insts: map[string]uint32{
-				AppInstData[9].Key.GetKeyString():  1,
-				AppInstData[10].Key.GetKeyString(): 1,
-				AppInstData[14].Key.GetKeyString(): 1,
-			},
+	}, { // edgeproto.AppInstRefs
+		Key: appData[14].Key,
+		Insts: map[string]uint32{
+			appInstData[16].Key.GetKeyString(): 1,
 		},
-		edgeproto.AppInstRefs{
-			Key:   AppData[10].Key,
-			Insts: map[string]uint32{},
+	}, { // edgeproto.AppInstRefs
+		Key: appData[15].Key,
+		Insts: map[string]uint32{
+			appInstData[17].Key.GetKeyString(): 1,
 		},
-		edgeproto.AppInstRefs{
-			Key:   AppData[11].Key,
-			Insts: map[string]uint32{},
-		},
-		edgeproto.AppInstRefs{
-			Key: AppData[12].Key,
-			Insts: map[string]uint32{
-				createdAppInsts[11].Key.GetKeyString(): 1,
-			},
-		},
-		edgeproto.AppInstRefs{
-			Key: AppData[13].Key,
-			Insts: map[string]uint32{
-				AppInstData[12].Key.GetKeyString(): 1,
-				AppInstData[15].Key.GetKeyString(): 1,
-			},
-		},
-		edgeproto.AppInstRefs{
-			Key: AppData[14].Key,
-			Insts: map[string]uint32{
-				AppInstData[16].Key.GetKeyString(): 1,
-			},
-		},
-		edgeproto.AppInstRefs{
-			Key: AppData[15].Key,
-			Insts: map[string]uint32{
-				AppInstData[17].Key.GetKeyString(): 1,
-			},
-		},
-	}
+	}}
 }
 
-var CloudletInfoData = []edgeproto.CloudletInfo{
-	edgeproto.CloudletInfo{
+func CloudletInfoData() []edgeproto.CloudletInfo {
+	cloudletData := CloudletData()
+	return []edgeproto.CloudletInfo{{
 		Key:         cloudletData[0].Key,
 		State:       dme.CloudletState_CLOUDLET_STATE_READY,
 		OsMaxRam:    65536,
 		OsMaxVcores: 16,
 		OsMaxVolGb:  500,
-		Flavors: []*edgeproto.FlavorInfo{
-			&edgeproto.FlavorInfo{
-				Name:  "flavor.tiny1",
-				Vcpus: uint64(1),
-				Ram:   uint64(512),
-				Disk:  uint64(10),
-			},
-			&edgeproto.FlavorInfo{
-				Name:  "flavor.tiny2",
-				Vcpus: uint64(1),
-				Ram:   uint64(1024),
-				Disk:  uint64(10),
-			},
-			&edgeproto.FlavorInfo{
-				Name:  "flavor.small",
-				Vcpus: uint64(2),
-				Ram:   uint64(1024),
-				Disk:  uint64(20),
-			},
-			&edgeproto.FlavorInfo{
-				Name:  "flavor.medium",
-				Vcpus: uint64(4),
-				Ram:   uint64(4096),
-				Disk:  uint64(40),
-			},
-			&edgeproto.FlavorInfo{
-				Name:  "flavor.lg-master",
-				Vcpus: uint64(4),
-				Ram:   uint64(8192),
-				Disk:  uint64(60),
-			},
+		Flavors: []*edgeproto.FlavorInfo{{
+			Name:  "flavor.tiny1",
+			Vcpus: uint64(1),
+			Ram:   uint64(512),
+			Disk:  uint64(10),
+		}, {
+			Name:  "flavor.tiny2",
+			Vcpus: uint64(1),
+			Ram:   uint64(1024),
+			Disk:  uint64(10),
+		}, {
+			Name:  "flavor.small",
+			Vcpus: uint64(2),
+			Ram:   uint64(1024),
+			Disk:  uint64(20),
+		}, {
+			Name:  "flavor.medium",
+			Vcpus: uint64(4),
+			Ram:   uint64(4096),
+			Disk:  uint64(40),
+		}, {
+			Name:  "flavor.lg-master",
+			Vcpus: uint64(4),
+			Ram:   uint64(8192),
+			Disk:  uint64(60),
+		}, {
 			// restagtbl/clouldlet resource map tests
-			&edgeproto.FlavorInfo{
-				Name:    "flavor.large",
-				Vcpus:   uint64(10),
-				Ram:     uint64(8192),
-				Disk:    uint64(40),
-				PropMap: map[string]string{"pci_passthrough": "alias=t4:1"},
-			},
-			&edgeproto.FlavorInfo{
-				Name:    "flavor.large2",
-				Vcpus:   uint64(10),
-				Ram:     uint64(8192),
-				Disk:    uint64(40),
-				PropMap: map[string]string{"pci_passthrough": "alias=t4:1", "nas": "ceph-20:1"},
-			},
-			&edgeproto.FlavorInfo{
-				Name:    "flavor.large-pci",
-				Vcpus:   uint64(10),
-				Ram:     uint64(8192),
-				Disk:    uint64(40),
-				PropMap: map[string]string{"pci": "NP4:1"},
-			},
-			&edgeproto.FlavorInfo{
-				Name:    "flavor.large-nvidia",
-				Vcpus:   uint64(10),
-				Ram:     uint64(8192),
-				Disk:    uint64(40),
-				PropMap: map[string]string{"vgpu": "nvidia-63:1"},
-			},
-			&edgeproto.FlavorInfo{
-				Name:    "flavor.large-generic-gpu",
-				Vcpus:   uint64(10),
-				Ram:     uint64(8192),
-				Disk:    uint64(80),
-				PropMap: map[string]string{"vmware": "vgpu=1"},
-			},
+			Name:    "flavor.large",
+			Vcpus:   uint64(10),
+			Ram:     uint64(8192),
+			Disk:    uint64(40),
+			PropMap: map[string]string{"pci_passthrough": "alias=t4:1"},
+		}, {
+			Name:    "flavor.large2",
+			Vcpus:   uint64(10),
+			Ram:     uint64(8192),
+			Disk:    uint64(40),
+			PropMap: map[string]string{"pci_passthrough": "alias=t4:1", "nas": "ceph-20:1"},
+		}, {
+			Name:    "flavor.large-pci",
+			Vcpus:   uint64(10),
+			Ram:     uint64(8192),
+			Disk:    uint64(40),
+			PropMap: map[string]string{"pci": "NP4:1"},
+		}, {
+			Name:    "flavor.large-nvidia",
+			Vcpus:   uint64(10),
+			Ram:     uint64(8192),
+			Disk:    uint64(40),
+			PropMap: map[string]string{"vgpu": "nvidia-63:1"},
+		}, {
+			Name:    "flavor.large-generic-gpu",
+			Vcpus:   uint64(10),
+			Ram:     uint64(8192),
+			Disk:    uint64(80),
+			PropMap: map[string]string{"vmware": "vgpu=1"},
+		}, {
 			// A typical case where two flavors are identical in their
 			// nominal resources, and differ only by gpu vs vgpu
 			// These cases require a fully qualifed request in the mex flavors optresmap
-			&edgeproto.FlavorInfo{
-				Name:    "flavor.m4.large-gpu",
-				Vcpus:   uint64(12),
-				Ram:     uint64(4096),
-				Disk:    uint64(20),
-				PropMap: map[string]string{"pci_passthrough": "alias=t4gpu:1"},
-			},
-			&edgeproto.FlavorInfo{
-				Name:    "flavor.m4.large-vgpu",
-				Vcpus:   uint64(12),
-				Ram:     uint64(4096),
-				Disk:    uint64(20),
-				PropMap: map[string]string{"resources": "VGPU=1"},
-			},
-		},
+			Name:    "flavor.m4.large-gpu",
+			Vcpus:   uint64(12),
+			Ram:     uint64(4096),
+			Disk:    uint64(20),
+			PropMap: map[string]string{"pci_passthrough": "alias=t4gpu:1"},
+		}, {
+			Name:    "flavor.m4.large-vgpu",
+			Vcpus:   uint64(12),
+			Ram:     uint64(4096),
+			Disk:    uint64(20),
+			PropMap: map[string]string{"resources": "VGPU=1"},
+		}},
 		ResourcesSnapshot: edgeproto.InfraResourcesSnapshot{
-			Info: []edgeproto.InfraResource{
-				edgeproto.InfraResource{
-					Name:          "RAM",
-					Value:         uint64(1024),
-					InfraMaxValue: uint64(102400),
-				},
-				edgeproto.InfraResource{
-					Name:          "vCPUs",
-					Value:         uint64(10),
-					InfraMaxValue: uint64(109),
-				},
-				edgeproto.InfraResource{
-					Name:          "Disk",
-					Value:         uint64(20),
-					InfraMaxValue: uint64(5000),
-				},
-				edgeproto.InfraResource{
-					Name:          "GPUs",
-					Value:         uint64(6),
-					InfraMaxValue: uint64(20),
-				},
-				edgeproto.InfraResource{
-					Name:          "External IPs",
-					Value:         uint64(2),
-					InfraMaxValue: uint64(10),
-				},
-			},
+			Info: []edgeproto.InfraResource{{
+				Name:          "RAM",
+				Value:         uint64(1024),
+				InfraMaxValue: uint64(102400),
+			}, {
+				Name:          "vCPUs",
+				Value:         uint64(10),
+				InfraMaxValue: uint64(109),
+			}, {
+				Name:          "Disk",
+				Value:         uint64(20),
+				InfraMaxValue: uint64(5000),
+			}, {
+				Name:          "GPUs",
+				Value:         uint64(6),
+				InfraMaxValue: uint64(20),
+			}, {
+				Name:          "External IPs",
+				Value:         uint64(2),
+				InfraMaxValue: uint64(10),
+			}},
 		},
 		CompatibilityVersion: cloudcommon.GetCRMCompatibilityVersion(),
 		Properties: map[string]string{
 			"supports-mt": "true", // cloudcommon.CloudletSupportsMT
 		},
-	},
-	edgeproto.CloudletInfo{
+	}, { // edgeproto.CloudletInfo
 		Key:         cloudletData[1].Key,
 		State:       dme.CloudletState_CLOUDLET_STATE_READY,
 		OsMaxRam:    65536,
 		OsMaxVcores: 16,
 		OsMaxVolGb:  500,
-		Flavors: []*edgeproto.FlavorInfo{
-			&edgeproto.FlavorInfo{
-				Name:  "flavor.small1",
-				Vcpus: uint64(2),
-				Ram:   uint64(2048),
-				Disk:  uint64(10),
-			},
-			&edgeproto.FlavorInfo{
-				Name:  "flavor.small2",
-				Vcpus: uint64(2),
-				Ram:   uint64(1024),
-				Disk:  uint64(20),
-			},
-			&edgeproto.FlavorInfo{
-				Name:  "flavor.medium1",
-				Vcpus: uint64(2),
-				Ram:   uint64(4096),
-				Disk:  uint64(40),
-			},
-		},
+		Flavors: []*edgeproto.FlavorInfo{{
+			Name:  "flavor.small1",
+			Vcpus: uint64(2),
+			Ram:   uint64(2048),
+			Disk:  uint64(10),
+		}, {
+			Name:  "flavor.small2",
+			Vcpus: uint64(2),
+			Ram:   uint64(1024),
+			Disk:  uint64(20),
+		}, {
+			Name:  "flavor.medium1",
+			Vcpus: uint64(2),
+			Ram:   uint64(4096),
+			Disk:  uint64(40),
+		}},
 		ResourcesSnapshot: edgeproto.InfraResourcesSnapshot{
-			Info: []edgeproto.InfraResource{
-				edgeproto.InfraResource{
-					Name:          "RAM",
-					Value:         uint64(1024),
-					InfraMaxValue: uint64(61440),
-				},
-				edgeproto.InfraResource{
-					Name:          "vCPUs",
-					Value:         uint64(10),
-					InfraMaxValue: uint64(100),
-				},
-				edgeproto.InfraResource{
-					Name:          "Disk",
-					Value:         uint64(20),
-					InfraMaxValue: uint64(5000),
-				},
-				edgeproto.InfraResource{
-					Name:          "External IPs",
-					Value:         uint64(2),
-					InfraMaxValue: uint64(10),
-				},
-			},
+			Info: []edgeproto.InfraResource{{
+				Name:          "RAM",
+				Value:         uint64(1024),
+				InfraMaxValue: uint64(61440),
+			}, {
+				Name:          "vCPUs",
+				Value:         uint64(10),
+				InfraMaxValue: uint64(100),
+			}, {
+				Name:          "Disk",
+				Value:         uint64(20),
+				InfraMaxValue: uint64(5000),
+			}, {
+				Name:          "External IPs",
+				Value:         uint64(2),
+				InfraMaxValue: uint64(10),
+			}},
 		},
 		CompatibilityVersion: cloudcommon.GetCRMCompatibilityVersion(),
-	},
-	edgeproto.CloudletInfo{
+	}, { // edgeproto.CloudletInfo
 		Key:         cloudletData[2].Key,
 		State:       dme.CloudletState_CLOUDLET_STATE_READY,
 		OsMaxRam:    65536,
 		OsMaxVcores: 16,
 		OsMaxVolGb:  500,
-		Flavors: []*edgeproto.FlavorInfo{
-			&edgeproto.FlavorInfo{
-				Name:  "flavor.medium1",
-				Vcpus: uint64(4),
-				Ram:   uint64(8192),
-				Disk:  uint64(80),
-			},
-			&edgeproto.FlavorInfo{
-				Name:  "flavor.medium2",
-				Vcpus: uint64(4),
-				Ram:   uint64(4096),
-				Disk:  uint64(40),
-			},
-			&edgeproto.FlavorInfo{
-				Name:  "flavor.medium3",
-				Vcpus: uint64(4),
-				Ram:   uint64(2048),
-				Disk:  uint64(20),
-			},
-		},
+		Flavors: []*edgeproto.FlavorInfo{{
+			Name:  "flavor.medium1",
+			Vcpus: uint64(4),
+			Ram:   uint64(8192),
+			Disk:  uint64(80),
+		}, {
+			Name:  "flavor.medium2",
+			Vcpus: uint64(4),
+			Ram:   uint64(4096),
+			Disk:  uint64(40),
+		}, {
+			Name:  "flavor.medium3",
+			Vcpus: uint64(4),
+			Ram:   uint64(2048),
+			Disk:  uint64(20),
+		}},
 		ResourcesSnapshot: edgeproto.InfraResourcesSnapshot{
-			Info: []edgeproto.InfraResource{
-				edgeproto.InfraResource{
-					Name:          "RAM",
-					Value:         uint64(1024),
-					InfraMaxValue: uint64(61440),
-				},
-				edgeproto.InfraResource{
-					Name:          "vCPUs",
-					Value:         uint64(10),
-					InfraMaxValue: uint64(100),
-				},
-				edgeproto.InfraResource{
-					Name:          "Disk",
-					Value:         uint64(20),
-					InfraMaxValue: uint64(5000),
-				},
-				edgeproto.InfraResource{
-					Name:          "External IPs",
-					Value:         uint64(2),
-					InfraMaxValue: uint64(10),
-				},
-			},
+			Info: []edgeproto.InfraResource{{
+				Name:          "RAM",
+				Value:         uint64(1024),
+				InfraMaxValue: uint64(61440),
+			}, {
+				Name:          "vCPUs",
+				Value:         uint64(10),
+				InfraMaxValue: uint64(100),
+			}, {
+				Name:          "Disk",
+				Value:         uint64(20),
+				InfraMaxValue: uint64(5000),
+			}, {
+				Name:          "External IPs",
+				Value:         uint64(2),
+				InfraMaxValue: uint64(10),
+			}},
 		},
 		CompatibilityVersion: cloudcommon.GetCRMCompatibilityVersion(),
-	},
-	edgeproto.CloudletInfo{
+	}, { // edgeproto.CloudletInfo
 		Key:         cloudletData[3].Key,
 		State:       dme.CloudletState_CLOUDLET_STATE_READY,
 		OsMaxRam:    65536,
 		OsMaxVcores: 16,
 		OsMaxVolGb:  500,
-		Flavors: []*edgeproto.FlavorInfo{
-			&edgeproto.FlavorInfo{
-				Name:  "flavor.large",
-				Vcpus: uint64(8),
-				Ram:   uint64(101024),
-				Disk:  uint64(100),
-			},
-			&edgeproto.FlavorInfo{
-				Name:  "flavor.medium",
-				Vcpus: uint64(4),
-				Ram:   uint64(1),
-				Disk:  uint64(1),
-			},
-		},
+		Flavors: []*edgeproto.FlavorInfo{{
+			Name:  "flavor.large",
+			Vcpus: uint64(8),
+			Ram:   uint64(101024),
+			Disk:  uint64(100),
+		}, {
+			Name:  "flavor.medium",
+			Vcpus: uint64(4),
+			Ram:   uint64(1),
+			Disk:  uint64(1),
+		}},
 		ResourcesSnapshot: edgeproto.InfraResourcesSnapshot{
-			Info: []edgeproto.InfraResource{
-				edgeproto.InfraResource{
-					Name:          "RAM",
-					Value:         uint64(1024),
-					InfraMaxValue: uint64(1024000),
-				},
-				edgeproto.InfraResource{
-					Name:          "vCPUs",
-					Value:         uint64(10),
-					InfraMaxValue: uint64(100),
-				},
-				edgeproto.InfraResource{
-					Name:          "Disk",
-					Value:         uint64(20),
-					InfraMaxValue: uint64(5000),
-				},
-				edgeproto.InfraResource{
-					Name:          "External IPs",
-					Value:         uint64(2),
-					InfraMaxValue: uint64(10),
-				},
-			},
+			Info: []edgeproto.InfraResource{{
+				Name:          "RAM",
+				Value:         uint64(1024),
+				InfraMaxValue: uint64(1024000),
+			}, {
+				Name:          "vCPUs",
+				Value:         uint64(10),
+				InfraMaxValue: uint64(100),
+			}, {
+				Name:          "Disk",
+				Value:         uint64(20),
+				InfraMaxValue: uint64(5000),
+			}, {
+				Name:          "External IPs",
+				Value:         uint64(2),
+				InfraMaxValue: uint64(10),
+			}},
 		},
 		CompatibilityVersion: cloudcommon.GetCRMCompatibilityVersion(),
-	},
+	}}
 }
 
 // To figure out what resources are used on each Cloudlet,
 // see ClusterInstData to see what clusters are instantiated on what Cloudlet.
-var CloudletRefsData = []edgeproto.CloudletRefs{
-	// ClusterInstData[0,3,7,8]:
-	edgeproto.CloudletRefs{
+func CloudletRefsData() []edgeproto.CloudletRefs {
+	cloudletData := CloudletData()
+	clusterInstData := ClusterInstData()
+	return []edgeproto.CloudletRefs{{
+		// ClusterInstData[0,3,7,8]:
 		Key: cloudletData[0].Key,
-		ClusterInsts: []edgeproto.ClusterInstRefKey{
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[0].Key.ClusterKey,
-				Organization: ClusterInstData[0].Key.Organization,
-			},
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[3].Key.ClusterKey,
-				Organization: ClusterInstData[3].Key.Organization,
-			},
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[7].Key.ClusterKey,
-				Organization: ClusterInstData[7].Key.Organization,
-			},
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[8].Key.ClusterKey,
-				Organization: ClusterInstData[8].Key.Organization,
-			},
-		},
+		ClusterInsts: []edgeproto.ClusterInstRefKey{{
+			ClusterKey:   clusterInstData[0].Key.ClusterKey,
+			Organization: clusterInstData[0].Key.Organization,
+		}, {
+			ClusterKey:   clusterInstData[3].Key.ClusterKey,
+			Organization: clusterInstData[3].Key.Organization,
+		}, {
+			ClusterKey:   clusterInstData[7].Key.ClusterKey,
+			Organization: clusterInstData[7].Key.Organization,
+		}, {
+			ClusterKey:   clusterInstData[8].Key.ClusterKey,
+			Organization: clusterInstData[8].Key.Organization,
+		}},
 		UsedDynamicIps: 2,
-	},
-	// ClusterInstData[1,4,9]:
-	edgeproto.CloudletRefs{
+	}, { // edgeproto.CloudletRefs
+		// ClusterInstData[1,4,9]:
 		Key: cloudletData[1].Key,
-		ClusterInsts: []edgeproto.ClusterInstRefKey{
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[1].Key.ClusterKey,
-				Organization: ClusterInstData[1].Key.Organization,
-			},
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[4].Key.ClusterKey,
-				Organization: ClusterInstData[4].Key.Organization,
-			},
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[9].Key.ClusterKey,
-				Organization: ClusterInstData[9].Key.Organization,
-			},
-		},
+		ClusterInsts: []edgeproto.ClusterInstRefKey{{
+			ClusterKey:   clusterInstData[1].Key.ClusterKey,
+			Organization: clusterInstData[1].Key.Organization,
+		}, {
+			ClusterKey:   clusterInstData[4].Key.ClusterKey,
+			Organization: clusterInstData[4].Key.Organization,
+		}, {
+			ClusterKey:   clusterInstData[9].Key.ClusterKey,
+			Organization: clusterInstData[9].Key.Organization,
+		}},
 		UsedDynamicIps: 1,
-	},
-	// ClusterInstData[2,5]:
-	edgeproto.CloudletRefs{
+	}, { // edgeproto.CloudletRefs
+		// ClusterInstData[2,5]:
 		Key: cloudletData[2].Key,
-		ClusterInsts: []edgeproto.ClusterInstRefKey{
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[2].Key.ClusterKey,
-				Organization: ClusterInstData[2].Key.Organization,
-			},
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[5].Key.ClusterKey,
-				Organization: ClusterInstData[5].Key.Organization,
-			},
-		},
+		ClusterInsts: []edgeproto.ClusterInstRefKey{{
+			ClusterKey:   clusterInstData[2].Key.ClusterKey,
+			Organization: clusterInstData[2].Key.Organization,
+		}, {
+			ClusterKey:   clusterInstData[5].Key.ClusterKey,
+			Organization: clusterInstData[5].Key.Organization,
+		}},
 		UsedDynamicIps: 1,
-	},
-	// ClusterInstData[6]:
-	edgeproto.CloudletRefs{
+	}, { // edgeproto.CloudletRefs
+		// ClusterInstData[6]:
 		Key: cloudletData[3].Key,
-		ClusterInsts: []edgeproto.ClusterInstRefKey{
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[6].Key.ClusterKey,
-				Organization: ClusterInstData[6].Key.Organization,
-			},
-		},
-	},
+		ClusterInsts: []edgeproto.ClusterInstRefKey{{
+			ClusterKey:   clusterInstData[6].Key.ClusterKey,
+			Organization: clusterInstData[6].Key.Organization,
+		}},
+	}}
 }
 
 // These Refs are after creating both cluster insts and app insts.
 // Some of the app insts trigger creating auto-clusterinsts,
 // and ports are reserved with the creation of app insts.
-var CloudletRefsWithAppInstsData = []edgeproto.CloudletRefs{
-	// ClusterInstData[0,3,7,8]: (dedicated,dedicated,shared,shared)
-	// AppInstData[0,1] -> ports[tcp:443;tcp:443]:
-	// AppInstData[13,14,15,16] -> App[0,9,13,14] -> ports[tcp:443,tcp:10002,udp:10002;;tcp:889;tcp:444]
-	edgeproto.CloudletRefs{
+func CloudletRefsWithAppInstsData() []edgeproto.CloudletRefs {
+	cloudletData := CloudletData()
+	clusterInstData := ClusterInstData()
+	clusterInstAutoData := ClusterInstAutoData()
+	appInstData := AppInstData()
+	return []edgeproto.CloudletRefs{{
+		// ClusterInstData[0,3,7,8]: (dedicated,dedicated,shared,shared)
+		// AppInstData[0,1] -> ports[tcp:443;tcp:443]:
+		// AppInstData[13,14,15,16] -> App[0,9,13,14] -> ports[tcp:443,tcp:10002,udp:10002;;tcp:889;tcp:444]
 		Key: cloudletData[0].Key,
-		ClusterInsts: []edgeproto.ClusterInstRefKey{
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[0].Key.ClusterKey,
-				Organization: ClusterInstData[0].Key.Organization,
-			},
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[3].Key.ClusterKey,
-				Organization: ClusterInstData[3].Key.Organization,
-			},
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[7].Key.ClusterKey,
-				Organization: ClusterInstData[7].Key.Organization,
-			},
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[8].Key.ClusterKey,
-				Organization: ClusterInstData[8].Key.Organization,
-			},
-		},
+		ClusterInsts: []edgeproto.ClusterInstRefKey{{
+			ClusterKey:   clusterInstData[0].Key.ClusterKey,
+			Organization: clusterInstData[0].Key.Organization,
+		}, {
+			ClusterKey:   clusterInstData[3].Key.ClusterKey,
+			Organization: clusterInstData[3].Key.Organization,
+		}, {
+			ClusterKey:   clusterInstData[7].Key.ClusterKey,
+			Organization: clusterInstData[7].Key.Organization,
+		}, {
+			ClusterKey:   clusterInstData[8].Key.ClusterKey,
+			Organization: clusterInstData[8].Key.Organization,
+		}},
 		RootLbPorts: map[int32]int32{443: 1, 10002: 3, 889: 1, 444: 1},
-		VmAppInsts: []edgeproto.AppInstRefKey{
-			edgeproto.AppInstRefKey{
-				AppKey: AppInstData[11].Key.AppKey,
-				ClusterInstKey: edgeproto.ClusterInstRefKey{
-					ClusterKey:   AppInstData[11].Key.ClusterInstKey.ClusterKey,
-					Organization: AppInstData[11].Key.ClusterInstKey.Organization,
-				},
+		VmAppInsts: []edgeproto.AppInstRefKey{{
+			AppKey: appInstData[11].Key.AppKey,
+			ClusterInstKey: edgeproto.ClusterInstRefKey{
+				ClusterKey:   appInstData[11].Key.ClusterInstKey.ClusterKey,
+				Organization: appInstData[11].Key.ClusterInstKey.Organization,
 			},
-		},
+		}},
 		UsedDynamicIps: 2,
-	},
-	// ClusterInstData[1,4,9], ClusterInstAutoData[0]: (shared,shared,dedicated,shared)
-	// AppInstData[2,3] -> ports[tcp:443;tcp:80,tcp:443,tcp:81,udp:10002]
-	edgeproto.CloudletRefs{
+	}, { // edgeproto.CloudletRefs
+		// ClusterInstData[1,4,9], ClusterInstAutoData[0]: (shared,shared,dedicated,shared)
+		// AppInstData[2,3] -> ports[tcp:443;tcp:80,tcp:443,tcp:81,udp:10002]
 		Key: cloudletData[1].Key,
-		ClusterInsts: []edgeproto.ClusterInstRefKey{
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[1].Key.ClusterKey,
-				Organization: ClusterInstData[1].Key.Organization,
-			},
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[4].Key.ClusterKey,
-				Organization: ClusterInstData[4].Key.Organization,
-			},
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstAutoData[0].Key.ClusterKey,
-				Organization: ClusterInstAutoData[0].Key.Organization,
-			},
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[9].Key.ClusterKey,
-				Organization: ClusterInstData[9].Key.Organization,
-			},
-		},
+		ClusterInsts: []edgeproto.ClusterInstRefKey{{
+			ClusterKey:   clusterInstData[1].Key.ClusterKey,
+			Organization: clusterInstData[1].Key.Organization,
+		}, {
+			ClusterKey:   clusterInstData[4].Key.ClusterKey,
+			Organization: clusterInstData[4].Key.Organization,
+		}, {
+			ClusterKey:   clusterInstAutoData[0].Key.ClusterKey,
+			Organization: clusterInstAutoData[0].Key.Organization,
+		}, {
+			ClusterKey:   clusterInstData[9].Key.ClusterKey,
+			Organization: clusterInstData[9].Key.Organization,
+		}},
 		RootLbPorts:            map[int32]int32{80: 1, 81: 1, 443: 1, 10000: 1, 10002: 3},
 		ReservedAutoClusterIds: 1,
 		UsedDynamicIps:         1,
-	},
-	// ClusterInstData[2,5], ClusterInstAutoData[1,2]: (shared,dedicated,shared,shared)
-	// AppInstData[4,5,6] -> ports[tcp:443,udp:11111;udp:2024;tcp:80,udp:8001,tcp:65535]
-	edgeproto.CloudletRefs{
+	}, { // edgeproto.CloudletRefs
+		// ClusterInstData[2,5], ClusterInstAutoData[1,2]: (shared,dedicated,shared,shared)
+		// AppInstData[4,5,6] -> ports[tcp:443,udp:11111;udp:2024;tcp:80,udp:8001,tcp:65535]
 		Key: cloudletData[2].Key,
-		ClusterInsts: []edgeproto.ClusterInstRefKey{
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[2].Key.ClusterKey,
-				Organization: ClusterInstData[2].Key.Organization,
-			},
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[5].Key.ClusterKey,
-				Organization: ClusterInstData[5].Key.Organization,
-			},
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstAutoData[1].Key.ClusterKey,
-				Organization: ClusterInstAutoData[1].Key.Organization,
-			},
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstAutoData[2].Key.ClusterKey,
-				Organization: ClusterInstAutoData[2].Key.Organization,
-			},
-		},
+		ClusterInsts: []edgeproto.ClusterInstRefKey{{
+			ClusterKey:   clusterInstData[2].Key.ClusterKey,
+			Organization: clusterInstData[2].Key.Organization,
+		}, {
+			ClusterKey:   clusterInstData[5].Key.ClusterKey,
+			Organization: clusterInstData[5].Key.Organization,
+		}, {
+			ClusterKey:   clusterInstAutoData[1].Key.ClusterKey,
+			Organization: clusterInstAutoData[1].Key.Organization,
+		}, {
+			ClusterKey:   clusterInstAutoData[2].Key.ClusterKey,
+			Organization: clusterInstAutoData[2].Key.Organization,
+		}},
 		UsedDynamicIps:         1,
 		RootLbPorts:            map[int32]int32{443: 1, 11111: 2, 2024: 2, 80: 1, 8001: 2, 65535: 1},
 		ReservedAutoClusterIds: 3,
-	},
-	// ClusterInstData[6]: (no app insts on this clusterinst) (shared),
-	// ClusterInstAutoData[3]: (shared)
-	// AppInstData[12] -> ports[tcp:889]
-	edgeproto.CloudletRefs{
+	}, { // edgeproto.CloudletRefs
+		// ClusterInstData[6]: (no app insts on this clusterinst) (shared),
+		// ClusterInstAutoData[3]: (shared)
+		// AppInstData[12] -> ports[tcp:889]
 		Key: cloudletData[3].Key,
-		ClusterInsts: []edgeproto.ClusterInstRefKey{
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstData[6].Key.ClusterKey,
-				Organization: ClusterInstData[6].Key.Organization,
-			},
-			edgeproto.ClusterInstRefKey{
-				ClusterKey:   ClusterInstAutoData[3].Key.ClusterKey,
-				Organization: ClusterInstAutoData[3].Key.Organization,
-			},
-		},
+		ClusterInsts: []edgeproto.ClusterInstRefKey{{
+			ClusterKey:   clusterInstData[6].Key.ClusterKey,
+			Organization: clusterInstData[6].Key.Organization,
+		}, {
+			ClusterKey:   clusterInstAutoData[3].Key.ClusterKey,
+			Organization: clusterInstAutoData[3].Key.Organization,
+		}},
 		RootLbPorts:            map[int32]int32{889: 1},
 		ReservedAutoClusterIds: 1,
-	},
+	}}
 }
 
-var CloudletPoolData = []edgeproto.CloudletPool{
-	edgeproto.CloudletPool{
+func CloudletPoolData() []edgeproto.CloudletPool {
+	operatorData := OperatorData()
+	cloudletData := CloudletData()
+	return []edgeproto.CloudletPool{{
 		Key: edgeproto.CloudletPoolKey{
-			Organization: OperatorData[1],
+			Organization: operatorData[1],
 			Name:         "private",
 		},
 		Cloudlets: []edgeproto.CloudletKey{
 			cloudletData[2].Key,
 		},
-	},
-	edgeproto.CloudletPool{
+	}, { // edgeproto.CloudletPool
 		Key: edgeproto.CloudletPoolKey{
-			Organization: OperatorData[2],
+			Organization: operatorData[2],
 			Name:         "test-and-dev",
 		},
 		Cloudlets: []edgeproto.CloudletKey{
 			cloudletData[3].Key,
 		},
-	},
-	edgeproto.CloudletPool{
+	}, { // edgeproto.CloudletPool
 		Key: edgeproto.CloudletPoolKey{
-			Organization: OperatorData[2],
+			Organization: operatorData[2],
 			Name:         "enterprise",
 		},
 		Cloudlets: []edgeproto.CloudletKey{
 			cloudletData[3].Key,
 		},
-	},
+	}}
 }
 
-var Restblkeys = []edgeproto.ResTagTableKey{
-	edgeproto.ResTagTableKey{
+func Restblkeys() []edgeproto.ResTagTableKey {
+	return []edgeproto.ResTagTableKey{{
 		Name:         "gpu",
 		Organization: "UFGT Inc.",
-	},
-	edgeproto.ResTagTableKey{
+	}, {
 		Name:         "nas",
 		Organization: "UFGT Inc.",
-	},
-	edgeproto.ResTagTableKey{
+	}, {
 		Name:         "nic",
 		Organization: "UFGT Inc.",
-	},
-	edgeproto.ResTagTableKey{
+	}, {
 		Name:         "gput4",
 		Organization: "UFGT Inc.",
-	},
+	}}
 }
 
-var ResTagTableData = []edgeproto.ResTagTable{
-
-	edgeproto.ResTagTable{
-		Key:  Restblkeys[0],
+func ResTagTableData() []edgeproto.ResTagTable {
+	restblkeys := Restblkeys()
+	return []edgeproto.ResTagTable{{
+		Key:  restblkeys[0],
 		Tags: map[string]string{"vmware": "vgpu=1"},
-	},
-
-	edgeproto.ResTagTable{
-		Key:  Restblkeys[1],
+	}, {
+		Key:  restblkeys[1],
 		Tags: map[string]string{"vcpu": "nvidia-72", "pci-passthru": "NP4:2"},
-	},
-
-	edgeproto.ResTagTable{
-		Key:  Restblkeys[2],
+	}, {
+		Key:  restblkeys[2],
 		Tags: map[string]string{"vcpu": "nvidia-63", "pci-passthru": "T4:1"},
-	},
-	edgeproto.ResTagTable{
-		Key:  Restblkeys[3],
+	}, {
+		Key:  restblkeys[3],
 		Tags: map[string]string{"pci": "t4:1"},
-	},
+	}}
 }
 
-var AlertData = []edgeproto.Alert{
-	edgeproto.Alert{
+func AlertData() []edgeproto.Alert {
+	clusterInstData := ClusterInstData()
+	appInstData := AppInstData()
+	return []edgeproto.Alert{{
 		Labels: map[string]string{
 			"alertname":   "AutoScaleUp",
-			"cloudletorg": ClusterInstData[0].Key.CloudletKey.Organization,
-			"cloudlet":    ClusterInstData[0].Key.CloudletKey.Name,
-			"cluster":     ClusterInstData[0].Key.ClusterKey.Name,
-			"clusterorg":  ClusterInstData[0].Key.Organization,
+			"cloudletorg": clusterInstData[0].Key.CloudletKey.Organization,
+			"cloudlet":    clusterInstData[0].Key.CloudletKey.Name,
+			"cluster":     clusterInstData[0].Key.ClusterKey.Name,
+			"clusterorg":  clusterInstData[0].Key.Organization,
 			"severity":    "none",
 		},
 		Annotations: map[string]string{
@@ -1446,14 +1296,13 @@ var AlertData = []edgeproto.Alert{
 			Nanos:   2343569,
 		},
 		Value: 1,
-	},
-	edgeproto.Alert{
+	}, { // edgeproto.Alert
 		Labels: map[string]string{
 			"alertname":   "AutoScaleDown",
-			"cloudletorg": ClusterInstData[0].Key.CloudletKey.Organization,
-			"cloudlet":    ClusterInstData[0].Key.CloudletKey.Name,
-			"cluster":     ClusterInstData[0].Key.ClusterKey.Name,
-			"clusterorg":  ClusterInstData[0].Key.Organization,
+			"cloudletorg": clusterInstData[0].Key.CloudletKey.Organization,
+			"cloudlet":    clusterInstData[0].Key.CloudletKey.Name,
+			"cluster":     clusterInstData[0].Key.ClusterKey.Name,
+			"clusterorg":  clusterInstData[0].Key.Organization,
 			"severity":    "none",
 		},
 		Annotations: map[string]string{
@@ -1465,14 +1314,13 @@ var AlertData = []edgeproto.Alert{
 			Nanos:   642398,
 		},
 		Value: 1,
-	},
-	edgeproto.Alert{
+	}, { // edgeproto.Alert
 		Labels: map[string]string{
 			"alertname":   "AutoScaleUp",
-			"cloudletorg": ClusterInstData[1].Key.CloudletKey.Organization,
-			"cloudlet":    ClusterInstData[1].Key.CloudletKey.Name,
-			"cluster":     ClusterInstData[1].Key.ClusterKey.Name,
-			"clusterorg":  ClusterInstData[1].Key.Organization,
+			"cloudletorg": clusterInstData[1].Key.CloudletKey.Organization,
+			"cloudlet":    clusterInstData[1].Key.CloudletKey.Name,
+			"cluster":     clusterInstData[1].Key.ClusterKey.Name,
+			"clusterorg":  clusterInstData[1].Key.Organization,
 			"severity":    "critical",
 		},
 		Annotations: map[string]string{
@@ -1484,17 +1332,16 @@ var AlertData = []edgeproto.Alert{
 			Nanos:   42398457,
 		},
 		Value: 1,
-	},
-	edgeproto.Alert{
+	}, { // edgeproto.Alert
 		Labels: map[string]string{
 			"alertname":   "AppInstDown",
-			"app":         AppInstData[0].Key.AppKey.Name,
-			"appver":      AppInstData[0].Key.AppKey.Version,
-			"apporg":      AppInstData[0].Key.AppKey.Organization,
-			"cloudletorg": ClusterInstData[7].Key.CloudletKey.Organization,
-			"cloudlet":    ClusterInstData[7].Key.CloudletKey.Name,
-			"cluster":     ClusterInstData[7].Key.ClusterKey.Name,
-			"clusterorg":  ClusterInstData[7].Key.Organization,
+			"app":         appInstData[0].Key.AppKey.Name,
+			"appver":      appInstData[0].Key.AppKey.Version,
+			"apporg":      appInstData[0].Key.AppKey.Organization,
+			"cloudletorg": clusterInstData[7].Key.CloudletKey.Organization,
+			"cloudlet":    clusterInstData[7].Key.CloudletKey.Name,
+			"cluster":     clusterInstData[7].Key.ClusterKey.Name,
+			"clusterorg":  clusterInstData[7].Key.Organization,
 			"status":      "1",
 		},
 		State: "firing",
@@ -1502,17 +1349,16 @@ var AlertData = []edgeproto.Alert{
 			Seconds: 1257894002,
 			Nanos:   42398457,
 		},
-	},
-	edgeproto.Alert{
+	}, { // edgeproto.Alert
 		Labels: map[string]string{
 			"alertname":   "AppInstDown",
-			"app":         AppInstData[0].Key.AppKey.Name,
-			"appver":      AppInstData[0].Key.AppKey.Version,
-			"apporg":      AppInstData[0].Key.AppKey.Organization,
-			"cloudletorg": AppInstData[0].Key.ClusterInstKey.CloudletKey.Organization,
-			"cloudlet":    AppInstData[0].Key.ClusterInstKey.CloudletKey.Name,
-			"cluster":     AppInstData[0].Key.ClusterInstKey.ClusterKey.Name,
-			"clusterorg":  AppInstData[0].Key.ClusterInstKey.Organization,
+			"app":         appInstData[0].Key.AppKey.Name,
+			"appver":      appInstData[0].Key.AppKey.Version,
+			"apporg":      appInstData[0].Key.AppKey.Organization,
+			"cloudletorg": appInstData[0].Key.ClusterInstKey.CloudletKey.Organization,
+			"cloudlet":    appInstData[0].Key.ClusterInstKey.CloudletKey.Name,
+			"cluster":     appInstData[0].Key.ClusterInstKey.ClusterKey.Name,
+			"clusterorg":  appInstData[0].Key.ClusterInstKey.Organization,
 			"status":      "2",
 		},
 		State: "firing",
@@ -1520,649 +1366,589 @@ var AlertData = []edgeproto.Alert{
 			Seconds: 1257894002,
 			Nanos:   42398457,
 		},
-	},
+	}}
 }
 
-var AutoScalePolicyData = []edgeproto.AutoScalePolicy{
-	edgeproto.AutoScalePolicy{
+func AutoScalePolicyData() []edgeproto.AutoScalePolicy {
+	devData := DevData()
+	return []edgeproto.AutoScalePolicy{{
 		Key: edgeproto.PolicyKey{
 			Name:         "auto-scale-policy",
-			Organization: DevData[0],
+			Organization: devData[0],
 		},
 		MinNodes:           1,
 		MaxNodes:           3,
 		ScaleUpCpuThresh:   80,
 		ScaleDownCpuThresh: 20,
 		TriggerTimeSec:     60,
-	},
-	edgeproto.AutoScalePolicy{
+	}, { // edgeproto.AutoScalePolicy
 		Key: edgeproto.PolicyKey{
 			Name:         "auto-scale-policy",
-			Organization: DevData[1],
+			Organization: devData[1],
 		},
 		MinNodes:           4,
 		MaxNodes:           8,
 		ScaleUpCpuThresh:   60,
 		ScaleDownCpuThresh: 40,
 		TriggerTimeSec:     30,
-	},
-	edgeproto.AutoScalePolicy{
+	}, { // edgeproto.AutoScalePolicy
 		Key: edgeproto.PolicyKey{
 			Name:         "auto-scale-policy",
-			Organization: DevData[3],
+			Organization: devData[3],
 		},
 		MinNodes:           1,
 		MaxNodes:           3,
 		ScaleUpCpuThresh:   90,
 		ScaleDownCpuThresh: 10,
 		TriggerTimeSec:     60,
-	},
+	}}
 }
 
-var AutoProvPolicyData = []edgeproto.AutoProvPolicy{
-	edgeproto.AutoProvPolicy{
+func AutoProvPolicyData() []edgeproto.AutoProvPolicy {
+	devData := DevData()
+	return []edgeproto.AutoProvPolicy{{
 		Key: edgeproto.PolicyKey{
 			Name:         "auto-prov-policy",
-			Organization: DevData[0],
+			Organization: devData[0],
 		},
 		DeployClientCount:   2,
 		DeployIntervalCount: 2,
-	},
-	edgeproto.AutoProvPolicy{
+	}, { // edgeproto.AutoProvPolicy
 		Key: edgeproto.PolicyKey{
 			Name:         "auto-prov-policy",
-			Organization: DevData[1],
+			Organization: devData[1],
 		},
 		DeployClientCount:   1,
 		DeployIntervalCount: 1,
-	},
-	edgeproto.AutoProvPolicy{
+	}, { // edgeproto.AutoProvPolicy
 		Key: edgeproto.PolicyKey{
 			Name:         "auto-prov-policy",
-			Organization: DevData[3],
+			Organization: devData[3],
 		},
 		DeployClientCount:   20,
 		DeployIntervalCount: 4,
-	},
-	edgeproto.AutoProvPolicy{
+	}, { // edgeproto.AutoProvPolicy
 		Key: edgeproto.PolicyKey{
 			Name:         "auto-prov-policy2",
-			Organization: DevData[0],
+			Organization: devData[0],
 		},
 		DeployClientCount:   10,
 		DeployIntervalCount: 10,
-	},
+	}}
 }
 
-var TrustPolicyData = []edgeproto.TrustPolicy{
-	edgeproto.TrustPolicy{
+func TrustPolicyData() []edgeproto.TrustPolicy {
+	cloudletData := CloudletData()
+	return []edgeproto.TrustPolicy{{
 		Key: edgeproto.PolicyKey{
 			Name:         "trust-policy0",
 			Organization: cloudletData[2].Key.Organization,
 		},
-		OutboundSecurityRules: []edgeproto.SecurityRule{
-			edgeproto.SecurityRule{
-				Protocol:     "TCP",
-				RemoteCidr:   "8.100.0.0/16",
-				PortRangeMin: 443,
-				PortRangeMax: 443,
-			},
-			edgeproto.SecurityRule{
-				Protocol:     "UDP",
-				RemoteCidr:   "0.0.0.0/0",
-				PortRangeMin: 53,
-				PortRangeMax: 53,
-			},
-		},
-	},
-	edgeproto.TrustPolicy{
+		OutboundSecurityRules: []edgeproto.SecurityRule{{
+			Protocol:     "TCP",
+			RemoteCidr:   "8.100.0.0/16",
+			PortRangeMin: 443,
+			PortRangeMax: 443,
+		}, {
+			Protocol:     "UDP",
+			RemoteCidr:   "0.0.0.0/0",
+			PortRangeMin: 53,
+			PortRangeMax: 53,
+		}},
+	}, { // edgeproto.TrustPolicy
 		Key: edgeproto.PolicyKey{
 			Name:         "trust-policy1",
 			Organization: cloudletData[2].Key.Organization,
 		},
-		OutboundSecurityRules: []edgeproto.SecurityRule{
-			edgeproto.SecurityRule{
-				Protocol:     "TCP",
-				RemoteCidr:   "8.100.0.0/16",
-				PortRangeMin: 443,
-				PortRangeMax: 443,
-			},
-			edgeproto.SecurityRule{
-				Protocol:     "UDP",
-				RemoteCidr:   "0.0.0.0/0",
-				PortRangeMin: 53,
-				PortRangeMax: 53,
-			},
-		},
-	},
-	edgeproto.TrustPolicy{
+		OutboundSecurityRules: []edgeproto.SecurityRule{{
+			Protocol:     "TCP",
+			RemoteCidr:   "8.100.0.0/16",
+			PortRangeMin: 443,
+			PortRangeMax: 443,
+		}, {
+			Protocol:     "UDP",
+			RemoteCidr:   "0.0.0.0/0",
+			PortRangeMin: 53,
+			PortRangeMax: 53,
+		}},
+	}, { // edgeproto.TrustPolicy
 		Key: edgeproto.PolicyKey{
 			Name:         "trust-policy2",
 			Organization: cloudletData[2].Key.Organization,
 		},
-		OutboundSecurityRules: []edgeproto.SecurityRule{
-			edgeproto.SecurityRule{
-				Protocol:   "ICMP",
-				RemoteCidr: "0.0.0.0/0",
-			},
-			edgeproto.SecurityRule{
-				Protocol:     "TCP",
-				RemoteCidr:   "10.0.0.0/8",
-				PortRangeMin: 1,
-				PortRangeMax: 65535,
-			},
-		},
-	},
+		OutboundSecurityRules: []edgeproto.SecurityRule{{
+			Protocol:   "ICMP",
+			RemoteCidr: "0.0.0.0/0",
+		}, {
+			Protocol:     "TCP",
+			RemoteCidr:   "10.0.0.0/8",
+			PortRangeMin: 1,
+			PortRangeMax: 65535,
+		}},
+	}}
 }
 
-var TrustPolicyErrorData = []edgeproto.TrustPolicy{
-	// Failure case, max port > min port
-	edgeproto.TrustPolicy{
+func TrustPolicyErrorData() []edgeproto.TrustPolicy {
+	cloudletData := CloudletData()
+	return []edgeproto.TrustPolicy{{
+		// Failure case, max port > min port
 		Key: edgeproto.PolicyKey{
 			Name:         "trust-policy3",
 			Organization: cloudletData[2].Key.Organization,
 		},
-		OutboundSecurityRules: []edgeproto.SecurityRule{
-			edgeproto.SecurityRule{
-				Protocol:     "TCP",
-				RemoteCidr:   "10.1.0.0/16",
-				PortRangeMin: 201,
-				PortRangeMax: 110,
-			},
-		},
-	},
-	// Failure case, bad CIDR
-	edgeproto.TrustPolicy{
+		OutboundSecurityRules: []edgeproto.SecurityRule{{
+			Protocol:     "TCP",
+			RemoteCidr:   "10.1.0.0/16",
+			PortRangeMin: 201,
+			PortRangeMax: 110,
+		}},
+	}, { // edgeproto.TrustPolicy
+		// Failure case, bad CIDR
 		Key: edgeproto.PolicyKey{
 			Name:         "trust-policy4",
 			Organization: cloudletData[2].Key.Organization,
 		},
-		OutboundSecurityRules: []edgeproto.SecurityRule{
-			edgeproto.SecurityRule{
-				Protocol:     "TCP",
-				RemoteCidr:   "10.0.0.0/50",
-				PortRangeMin: 22,
-				PortRangeMax: 22,
-			},
-		},
-	},
-	// Failure case, missing min port but max port present
-	edgeproto.TrustPolicy{
+		OutboundSecurityRules: []edgeproto.SecurityRule{{
+			Protocol:     "TCP",
+			RemoteCidr:   "10.0.0.0/50",
+			PortRangeMin: 22,
+			PortRangeMax: 22,
+		}},
+	}, { // edgeproto.TrustPolicy
+		// Failure case, missing min port but max port present
 		Key: edgeproto.PolicyKey{
 			Name:         "trust-policy5",
 			Organization: cloudletData[2].Key.Organization,
 		},
-		OutboundSecurityRules: []edgeproto.SecurityRule{
-			edgeproto.SecurityRule{
-				Protocol:     "TCP",
-				RemoteCidr:   "47.186.0.0/16",
-				PortRangeMax: 22,
-			},
-		},
-	},
+		OutboundSecurityRules: []edgeproto.SecurityRule{{
+			Protocol:     "TCP",
+			RemoteCidr:   "47.186.0.0/16",
+			PortRangeMax: 22,
+		}},
+	}}
 }
 
-var TrustPolicyExceptionData = []edgeproto.TrustPolicyException{
-	edgeproto.TrustPolicyException{
+func TrustPolicyExceptionData() []edgeproto.TrustPolicyException {
+	devData := DevData()
+	operatorData := OperatorData()
+	return []edgeproto.TrustPolicyException{{
 		Key: edgeproto.TrustPolicyExceptionKey{
 			AppKey: edgeproto.AppKey{
-				Organization: DevData[0],
+				Organization: devData[0],
 				Name:         "Pillimo Go!",
 				Version:      "1.0.0",
 			},
 			CloudletPoolKey: edgeproto.CloudletPoolKey{
-				Organization: OperatorData[2],
+				Organization: operatorData[2],
 				Name:         "test-and-dev",
 			},
 			Name: "trust-policyexception1",
 		},
 		State: edgeproto.TrustPolicyExceptionState_TRUST_POLICY_EXCEPTION_STATE_APPROVAL_REQUESTED,
-		OutboundSecurityRules: []edgeproto.SecurityRule{
-			edgeproto.SecurityRule{
-				Protocol:     "TCP",
-				RemoteCidr:   "10.1.0.0/16",
-				PortRangeMin: 201,
-				PortRangeMax: 210,
-			},
-		},
-	},
-	edgeproto.TrustPolicyException{
+		OutboundSecurityRules: []edgeproto.SecurityRule{{
+			Protocol:     "TCP",
+			RemoteCidr:   "10.1.0.0/16",
+			PortRangeMin: 201,
+			PortRangeMax: 210,
+		}},
+	}, { // edgeproto.TrustPolicyException
 		Key: edgeproto.TrustPolicyExceptionKey{
 			AppKey: edgeproto.AppKey{
-				Organization: DevData[0],
+				Organization: devData[0],
 				Name:         "Pillimo Go!",
 				Version:      "1.0.0",
 			},
 			CloudletPoolKey: edgeproto.CloudletPoolKey{
-				Organization: OperatorData[2],
+				Organization: operatorData[2],
 				Name:         "test-and-dev",
 			},
 			Name: "trust-policyexception2",
 		},
 		State: edgeproto.TrustPolicyExceptionState_TRUST_POLICY_EXCEPTION_STATE_APPROVAL_REQUESTED,
-		OutboundSecurityRules: []edgeproto.SecurityRule{
-			edgeproto.SecurityRule{
-				Protocol:     "TCP",
-				RemoteCidr:   "10.0.0.0/8",
-				PortRangeMin: 22,
-				PortRangeMax: 22,
-			},
-		},
-	},
-	edgeproto.TrustPolicyException{
+		OutboundSecurityRules: []edgeproto.SecurityRule{{
+			Protocol:     "TCP",
+			RemoteCidr:   "10.0.0.0/8",
+			PortRangeMin: 22,
+			PortRangeMax: 22,
+		}},
+	}, { // edgeproto.TrustPolicyException
 		Key: edgeproto.TrustPolicyExceptionKey{
 			AppKey: edgeproto.AppKey{
-				Organization: DevData[0],
+				Organization: devData[0],
 				Name:         "Pillimo Go!",
 				Version:      "1.0.0",
 			},
 			CloudletPoolKey: edgeproto.CloudletPoolKey{
-				Organization: OperatorData[2],
+				Organization: operatorData[2],
 				Name:         "test-and-dev",
 			},
 			Name: "trust-policyexception3",
 		},
 		State: edgeproto.TrustPolicyExceptionState_TRUST_POLICY_EXCEPTION_STATE_APPROVAL_REQUESTED,
-		OutboundSecurityRules: []edgeproto.SecurityRule{
-			edgeproto.SecurityRule{
-				Protocol:     "TCP",
-				RemoteCidr:   "47.186.0.0/16",
-				PortRangeMin: 22,
-				PortRangeMax: 22,
-			},
-		},
-	},
+		OutboundSecurityRules: []edgeproto.SecurityRule{{
+			Protocol:     "TCP",
+			RemoteCidr:   "47.186.0.0/16",
+			PortRangeMin: 22,
+			PortRangeMax: 22,
+		}},
+	}}
 }
 
-var TrustPolicyExceptionErrorData = []edgeproto.TrustPolicyException{
-	// Failure case, max port > min port
-	edgeproto.TrustPolicyException{
+func TrustPolicyExceptionErrorData() []edgeproto.TrustPolicyException {
+	devData := DevData()
+	operatorData := OperatorData()
+	return []edgeproto.TrustPolicyException{{
+		// Failure case, max port > min port
 		Key: edgeproto.TrustPolicyExceptionKey{
 			AppKey: edgeproto.AppKey{
-				Organization: DevData[0],
+				Organization: devData[0],
 				Name:         "Pillimo Go!",
 				Version:      "1.0.0",
 			},
 			CloudletPoolKey: edgeproto.CloudletPoolKey{
-				Organization: OperatorData[2],
+				Organization: operatorData[2],
 				Name:         "test-and-dev",
 			},
 			Name: "trust-policyexception11",
 		},
-		OutboundSecurityRules: []edgeproto.SecurityRule{
-			edgeproto.SecurityRule{
-				Protocol:     "TCP",
-				RemoteCidr:   "10.1.0.0/16",
-				PortRangeMin: 201,
-				PortRangeMax: 110,
-			},
-		},
-	},
-	// Failure case, bad CIDR
-	edgeproto.TrustPolicyException{
+		OutboundSecurityRules: []edgeproto.SecurityRule{{
+			Protocol:     "TCP",
+			RemoteCidr:   "10.1.0.0/16",
+			PortRangeMin: 201,
+			PortRangeMax: 110,
+		}},
+	}, { // edgeproto.TrustPolicyException
+		// Failure case, bad CIDR
 		Key: edgeproto.TrustPolicyExceptionKey{
 			AppKey: edgeproto.AppKey{
-				Organization: DevData[0],
+				Organization: devData[0],
 				Name:         "Pillimo Go!",
 				Version:      "2.0.0",
 			},
 			CloudletPoolKey: edgeproto.CloudletPoolKey{
-				Organization: OperatorData[2],
+				Organization: operatorData[2],
 				Name:         "test-and-dev",
 			},
 			Name: "trust-policyexception12",
 		},
-		OutboundSecurityRules: []edgeproto.SecurityRule{
-			edgeproto.SecurityRule{
-				Protocol:     "TCP",
-				RemoteCidr:   "10.0.0.0/50",
-				PortRangeMin: 22,
-				PortRangeMax: 22,
-			},
-		},
-	},
-	// Failure case, missing min port but max port present
-	edgeproto.TrustPolicyException{
+		OutboundSecurityRules: []edgeproto.SecurityRule{{
+			Protocol:     "TCP",
+			RemoteCidr:   "10.0.0.0/50",
+			PortRangeMin: 22,
+			PortRangeMax: 22,
+		}},
+	}, { // edgeproto.TrustPolicyException
+		// Failure case, missing min port but max port present
 		Key: edgeproto.TrustPolicyExceptionKey{
 			AppKey: edgeproto.AppKey{
-				Organization: DevData[0],
+				Organization: devData[0],
 				Name:         "Pillimo Go!",
 				Version:      "3.0.0",
 			},
 			CloudletPoolKey: edgeproto.CloudletPoolKey{
-				Organization: OperatorData[2],
+				Organization: operatorData[2],
 				Name:         "test-and-dev",
 			},
 			Name: "trust-policyexception13",
 		},
-		OutboundSecurityRules: []edgeproto.SecurityRule{
-			edgeproto.SecurityRule{
-				Protocol:     "TCP",
-				RemoteCidr:   "47.186.0.0/16",
-				PortRangeMax: 22,
-			},
-		},
-	},
-	// Failure case, App does not exist
-	edgeproto.TrustPolicyException{
+		OutboundSecurityRules: []edgeproto.SecurityRule{{
+			Protocol:     "TCP",
+			RemoteCidr:   "47.186.0.0/16",
+			PortRangeMax: 22,
+		}},
+	}, { // edgeproto.TrustPolicyException
+		// Failure case, App does not exist
 		Key: edgeproto.TrustPolicyExceptionKey{
 			AppKey: edgeproto.AppKey{
-				Organization: DevData[0],
+				Organization: devData[0],
 				Name:         "Pillimo does not exist!",
 				Version:      "13.0.0",
 			},
 			CloudletPoolKey: edgeproto.CloudletPoolKey{
-				Organization: OperatorData[2],
+				Organization: operatorData[2],
 				Name:         "test-and-dev",
 			},
 			Name: "trust-policyexception13",
 		},
-		OutboundSecurityRules: []edgeproto.SecurityRule{
-			edgeproto.SecurityRule{
-				Protocol:     "TCP",
-				RemoteCidr:   "47.186.0.0/16",
-				PortRangeMin: 22,
-				PortRangeMax: 22,
-			},
-		},
-	},
-	// Failure case, CloudletPoolKey does not exist
-	edgeproto.TrustPolicyException{
+		OutboundSecurityRules: []edgeproto.SecurityRule{{
+			Protocol:     "TCP",
+			RemoteCidr:   "47.186.0.0/16",
+			PortRangeMin: 22,
+			PortRangeMax: 22,
+		}},
+	}, { // edgeproto.TrustPolicyException
+		// Failure case, CloudletPoolKey does not exist
 		Key: edgeproto.TrustPolicyExceptionKey{
 			AppKey: edgeproto.AppKey{
-				Organization: DevData[0],
+				Organization: devData[0],
 				Name:         "Pillimo Go!",
 				Version:      "1.0.0",
 			},
 			CloudletPoolKey: edgeproto.CloudletPoolKey{
-				Organization: OperatorData[2],
+				Organization: operatorData[2],
 				Name:         "test-and-dev-does-not-exist",
 			},
 			Name: "trust-policyexception13",
 		},
-		OutboundSecurityRules: []edgeproto.SecurityRule{
-			edgeproto.SecurityRule{
-				Protocol:     "TCP",
-				RemoteCidr:   "47.186.0.0/16",
-				PortRangeMin: 22,
-				PortRangeMax: 22,
-			},
-		},
-	},
+		OutboundSecurityRules: []edgeproto.SecurityRule{{
+			Protocol:     "TCP",
+			RemoteCidr:   "47.186.0.0/16",
+			PortRangeMin: 22,
+			PortRangeMax: 22,
+		}},
+	}}
 }
 
-var AppInstClientKeyData = []edgeproto.AppInstClientKey{
-	edgeproto.AppInstClientKey{
-		AppInstKey: AppInstData[0].Key,
-	},
-	edgeproto.AppInstClientKey{
-		AppInstKey: AppInstData[3].Key,
-	},
+func AppInstClientKeyData() []edgeproto.AppInstClientKey {
+	appInstData := AppInstData()
+	return []edgeproto.AppInstClientKey{{
+		AppInstKey: appInstData[0].Key,
+	}, {
+		AppInstKey: appInstData[3].Key,
+	}}
 }
 
-var AppInstClientData = []edgeproto.AppInstClient{
-	edgeproto.AppInstClient{
-		ClientKey: AppInstClientKeyData[0],
+func AppInstClientData() []edgeproto.AppInstClient {
+	appInstClientKeyData := AppInstClientKeyData()
+	return []edgeproto.AppInstClient{{
+		ClientKey: appInstClientKeyData[0],
 		Location: dme.Loc{
 			Latitude:  1.0,
 			Longitude: 1.0,
 		},
-	},
-	edgeproto.AppInstClient{
-		ClientKey: AppInstClientKeyData[0],
+	}, { // edgeproto.AppInstClient
+		ClientKey: appInstClientKeyData[0],
 		Location: dme.Loc{
 			Latitude:  1.0,
 			Longitude: 2.0,
 		},
-	},
-	edgeproto.AppInstClient{
-		ClientKey: AppInstClientKeyData[0],
+	}, { // edgeproto.AppInstClient
+		ClientKey: appInstClientKeyData[0],
 		Location: dme.Loc{
 			Latitude:  1.0,
 			Longitude: 3.0,
 		},
-	},
-	edgeproto.AppInstClient{
-		ClientKey: AppInstClientKeyData[1],
+	}, { // edgeproto.AppInstClient
+		ClientKey: appInstClientKeyData[1],
 		Location: dme.Loc{
 			Latitude:  1.0,
 			Longitude: 2.0,
 		},
-	},
+	}}
 }
-var PlarformDeviceClientDataKeys = []edgeproto.DeviceKey{
-	edgeproto.DeviceKey{
+
+func PlatformDeviceClientDataKeys() []edgeproto.DeviceKey {
+	return []edgeproto.DeviceKey{{
 		UniqueIdType: "platos",
 		UniqueId:     "1",
-	},
-	edgeproto.DeviceKey{
+	}, {
 		UniqueIdType: "platos",
 		UniqueId:     "2",
-	},
-	edgeproto.DeviceKey{
+	}, {
 		UniqueIdType: "Mex",
 		UniqueId:     "1",
-	},
-	edgeproto.DeviceKey{
+	}, {
 		UniqueIdType: "GSAFKDF:platos:platosEnablementLayer",
 		UniqueId:     "1",
-	},
-	edgeproto.DeviceKey{
+	}, {
 		UniqueIdType: "SAMSUNG:CaseDeviceTest",
 		UniqueId:     "1",
-	},
+	}}
 }
 
-var PlarformDeviceClientData = []edgeproto.Device{
-	edgeproto.Device{
-		Key: PlarformDeviceClientDataKeys[0],
+func PlatformDeviceClientData() []edgeproto.Device {
+	platformDeviceClientDataKeys := PlatformDeviceClientDataKeys()
+	return []edgeproto.Device{{
+		Key: platformDeviceClientDataKeys[0],
 		// 2009-11-10 23:00:00 +0000 UTC
 		FirstSeen: GetTimestamp(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)),
-	},
-	edgeproto.Device{
-		Key: PlarformDeviceClientDataKeys[1],
+	}, { // edgeproto.Device
+		Key: platformDeviceClientDataKeys[1],
 		// 2009-11-10 23:00:00 +0000 UTC
 		FirstSeen: GetTimestamp(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)),
-	},
-	edgeproto.Device{
-		Key: PlarformDeviceClientDataKeys[2],
+	}, { // edgeproto.Device
+		Key: platformDeviceClientDataKeys[2],
 		// 2009-12-10 23:00:00 +0000 UTC
 		FirstSeen: GetTimestamp(time.Date(2009, time.December, 10, 23, 0, 0, 0, time.UTC)),
-	},
-	edgeproto.Device{
-		Key: PlarformDeviceClientDataKeys[3],
+	}, { // edgeproto.Device
+		Key: platformDeviceClientDataKeys[3],
 		// 2009-10-10 23:30:00 +0000 UTC
 		FirstSeen: GetTimestamp(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)),
-	},
-	edgeproto.Device{
-		Key: PlarformDeviceClientDataKeys[4],
+	}, { // edgeproto.Device
+		Key: platformDeviceClientDataKeys[4],
 		// 2009-12-10 23:30:00 +0000 UTC
 		FirstSeen: GetTimestamp(time.Date(2009, time.December, 10, 23, 0, 0, 0, time.UTC)),
-	},
+	}}
 }
 
-var VMPoolData = []edgeproto.VMPool{
-	edgeproto.VMPool{
+func VMPoolData() []edgeproto.VMPool {
+	operatorData := OperatorData()
+	return []edgeproto.VMPool{{
 		Key: edgeproto.VMPoolKey{
-			Organization: OperatorData[0],
+			Organization: operatorData[0],
 			Name:         "San Jose Site",
 		},
-		Vms: []edgeproto.VM{
-			edgeproto.VM{
-				Name: "vm1",
-				NetInfo: edgeproto.VMNetInfo{
-					ExternalIp: "192.168.1.101",
-					InternalIp: "192.168.100.101",
-				},
-				Flavor: &edgeproto.FlavorInfo{
-					Name:  "vm1-flavor",
-					Vcpus: uint64(2),
-					Ram:   uint64(2048),
-					Disk:  uint64(20),
-				},
+		Vms: []edgeproto.VM{{
+			Name: "vm1",
+			NetInfo: edgeproto.VMNetInfo{
+				ExternalIp: "192.168.1.101",
+				InternalIp: "192.168.100.101",
 			},
-			edgeproto.VM{
-				Name: "vm2",
-				NetInfo: edgeproto.VMNetInfo{
-					ExternalIp: "192.168.1.102",
-					InternalIp: "192.168.100.102",
-				},
-				Flavor: &edgeproto.FlavorInfo{
-					Name:  "vm2-flavor",
-					Vcpus: uint64(2),
-					Ram:   uint64(2048),
-					Disk:  uint64(20),
-				},
+			Flavor: &edgeproto.FlavorInfo{
+				Name:  "vm1-flavor",
+				Vcpus: uint64(2),
+				Ram:   uint64(2048),
+				Disk:  uint64(20),
 			},
-			edgeproto.VM{
-				Name: "vm3",
-				NetInfo: edgeproto.VMNetInfo{
-					InternalIp: "192.168.100.103",
-				},
-				Flavor: &edgeproto.FlavorInfo{
-					Name:  "vm3-flavor",
-					Vcpus: uint64(2),
-					Ram:   uint64(2048),
-					Disk:  uint64(20),
-				},
+		}, {
+			Name: "vm2",
+			NetInfo: edgeproto.VMNetInfo{
+				ExternalIp: "192.168.1.102",
+				InternalIp: "192.168.100.102",
 			},
-			edgeproto.VM{
-				Name: "vm4",
-				NetInfo: edgeproto.VMNetInfo{
-					InternalIp: "192.168.100.104",
-				},
-				Flavor: &edgeproto.FlavorInfo{
-					Name:  "vm4-flavor",
-					Vcpus: uint64(2),
-					Ram:   uint64(2048),
-					Disk:  uint64(20),
-				},
+			Flavor: &edgeproto.FlavorInfo{
+				Name:  "vm2-flavor",
+				Vcpus: uint64(2),
+				Ram:   uint64(2048),
+				Disk:  uint64(20),
 			},
-			edgeproto.VM{
-				Name: "vm5",
-				NetInfo: edgeproto.VMNetInfo{
-					InternalIp: "192.168.100.105",
-				},
-				Flavor: &edgeproto.FlavorInfo{
-					Name:  "vm5-flavor",
-					Vcpus: uint64(3),
-					Ram:   uint64(4096),
-					Disk:  uint64(50),
-				},
+		}, {
+			Name: "vm3",
+			NetInfo: edgeproto.VMNetInfo{
+				InternalIp: "192.168.100.103",
 			},
-		},
-	},
-	edgeproto.VMPool{
+			Flavor: &edgeproto.FlavorInfo{
+				Name:  "vm3-flavor",
+				Vcpus: uint64(2),
+				Ram:   uint64(2048),
+				Disk:  uint64(20),
+			},
+		}, {
+			Name: "vm4",
+			NetInfo: edgeproto.VMNetInfo{
+				InternalIp: "192.168.100.104",
+			},
+			Flavor: &edgeproto.FlavorInfo{
+				Name:  "vm4-flavor",
+				Vcpus: uint64(2),
+				Ram:   uint64(2048),
+				Disk:  uint64(20),
+			},
+		}, {
+			Name: "vm5",
+			NetInfo: edgeproto.VMNetInfo{
+				InternalIp: "192.168.100.105",
+			},
+			Flavor: &edgeproto.FlavorInfo{
+				Name:  "vm5-flavor",
+				Vcpus: uint64(3),
+				Ram:   uint64(4096),
+				Disk:  uint64(50),
+			},
+		}},
+	}, { // edgeproto.VMPool
 		Key: edgeproto.VMPoolKey{
-			Organization: OperatorData[0],
+			Organization: operatorData[0],
 			Name:         "New York Site",
 		},
-		Vms: []edgeproto.VM{
-			edgeproto.VM{
-				Name: "vm1",
-				NetInfo: edgeproto.VMNetInfo{
-					ExternalIp: "192.168.1.101",
-					InternalIp: "192.168.100.101",
-				},
-				Flavor: &edgeproto.FlavorInfo{
-					Name:  "vm1-flavor",
-					Vcpus: uint64(2),
-					Ram:   uint64(2048),
-					Disk:  uint64(20),
-				},
+		Vms: []edgeproto.VM{{
+			Name: "vm1",
+			NetInfo: edgeproto.VMNetInfo{
+				ExternalIp: "192.168.1.101",
+				InternalIp: "192.168.100.101",
 			},
-			edgeproto.VM{
-				Name: "vm2",
-				NetInfo: edgeproto.VMNetInfo{
-					ExternalIp: "192.168.1.102",
-					InternalIp: "192.168.100.102",
-				},
-				Flavor: &edgeproto.FlavorInfo{
-					Name:  "vm2-flavor",
-					Vcpus: uint64(2),
-					Ram:   uint64(2048),
-					Disk:  uint64(20),
-				},
+			Flavor: &edgeproto.FlavorInfo{
+				Name:  "vm1-flavor",
+				Vcpus: uint64(2),
+				Ram:   uint64(2048),
+				Disk:  uint64(20),
 			},
-			edgeproto.VM{
-				Name: "vm3",
-				NetInfo: edgeproto.VMNetInfo{
-					InternalIp: "192.168.100.103",
-				},
-				Flavor: &edgeproto.FlavorInfo{
-					Name:  "vm3-flavor",
-					Vcpus: uint64(2),
-					Ram:   uint64(2048),
-					Disk:  uint64(20),
-				},
+		}, {
+			Name: "vm2",
+			NetInfo: edgeproto.VMNetInfo{
+				ExternalIp: "192.168.1.102",
+				InternalIp: "192.168.100.102",
 			},
-		},
-	},
-	edgeproto.VMPool{
+			Flavor: &edgeproto.FlavorInfo{
+				Name:  "vm2-flavor",
+				Vcpus: uint64(2),
+				Ram:   uint64(2048),
+				Disk:  uint64(20),
+			},
+		}, {
+			Name: "vm3",
+			NetInfo: edgeproto.VMNetInfo{
+				InternalIp: "192.168.100.103",
+			},
+			Flavor: &edgeproto.FlavorInfo{
+				Name:  "vm3-flavor",
+				Vcpus: uint64(2),
+				Ram:   uint64(2048),
+				Disk:  uint64(20),
+			},
+		}},
+	}, { // edgeproto.VMPool
 		Key: edgeproto.VMPoolKey{
-			Organization: OperatorData[1],
+			Organization: operatorData[1],
 			Name:         "San Francisco Site",
 		},
-		Vms: []edgeproto.VM{
-			edgeproto.VM{
-				Name: "vm1",
-				NetInfo: edgeproto.VMNetInfo{
-					InternalIp: "192.168.100.101",
-				},
-				Flavor: &edgeproto.FlavorInfo{
-					Name:  "vm1-flavor",
-					Vcpus: uint64(2),
-					Ram:   uint64(2048),
-					Disk:  uint64(20),
-				},
+		Vms: []edgeproto.VM{{
+			Name: "vm1",
+			NetInfo: edgeproto.VMNetInfo{
+				InternalIp: "192.168.100.101",
 			},
-			edgeproto.VM{
-				Name: "vm2",
-				NetInfo: edgeproto.VMNetInfo{
-					InternalIp: "192.168.100.102",
-				},
-				Flavor: &edgeproto.FlavorInfo{
-					Name:  "vm2-flavor",
-					Vcpus: uint64(2),
-					Ram:   uint64(2048),
-					Disk:  uint64(20),
-				},
+			Flavor: &edgeproto.FlavorInfo{
+				Name:  "vm1-flavor",
+				Vcpus: uint64(2),
+				Ram:   uint64(2048),
+				Disk:  uint64(20),
 			},
-		},
-	},
+		}, {
+			Name: "vm2",
+			NetInfo: edgeproto.VMNetInfo{
+				InternalIp: "192.168.100.102",
+			},
+			Flavor: &edgeproto.FlavorInfo{
+				Name:  "vm2-flavor",
+				Vcpus: uint64(2),
+				Ram:   uint64(2048),
+				Disk:  uint64(20),
+			},
+		}},
+	}}
 }
 
-var GPUDriverData = []edgeproto.GPUDriver{
-	edgeproto.GPUDriver{
+func GPUDriverData() []edgeproto.GPUDriver {
+	operatorData := OperatorData()
+	return []edgeproto.GPUDriver{{
 		Key: edgeproto.GPUDriverKey{
-			Organization: OperatorData[0],
+			Organization: operatorData[0],
 			Name:         "nvidia-450",
 		},
-	},
-	edgeproto.GPUDriver{
+	}, { // edgeproto.GPUDriver
 		Key: edgeproto.GPUDriverKey{
 			Name: "nvidia-490",
 		},
-	},
-	edgeproto.GPUDriver{
+	}, { // edgeproto.GPUDriver
 		Key: edgeproto.GPUDriverKey{
-			Organization: OperatorData[1],
+			Organization: operatorData[1],
 			Name:         "nvidia-999",
 		},
-	},
-	edgeproto.GPUDriver{
+	}, { // edgeproto.GPUDriver
 		Key: edgeproto.GPUDriverKey{
-			Organization: OperatorData[0],
+			Organization: operatorData[0],
 			Name:         "nvidia-vgpu",
 		},
-	},
+	}}
 }
 
-var AlertPolicyData = []edgeproto.AlertPolicy{
-	edgeproto.AlertPolicy{ // Warning alert with no labels/annotations
+func AlertPolicyData() []edgeproto.AlertPolicy {
+	devData := DevData()
+	return []edgeproto.AlertPolicy{{
+		// Warning alert with no labels/annotations
 		Key: edgeproto.AlertPolicyKey{
 			Name:         "testAlert1",
-			Organization: DevData[0],
+			Organization: devData[0],
 		},
 		CpuUtilizationLimit:  80,
 		MemUtilizationLimit:  70,
@@ -2170,20 +1956,20 @@ var AlertPolicyData = []edgeproto.AlertPolicy{
 		Severity:             "warning",
 		Description:          "Sample description",
 		TriggerTime:          edgeproto.Duration(30 * time.Second),
-	},
-	edgeproto.AlertPolicy{ // Warning alert with Active Connections
+	}, { // edgeproto.AlertPolicy
+		// Warning alert with Active Connections
 		Key: edgeproto.AlertPolicyKey{
 			Name:         "testAlert2",
-			Organization: DevData[0],
+			Organization: devData[0],
 		},
 		ActiveConnLimit: 10,
 		Severity:        "info",
 		TriggerTime:     edgeproto.Duration(5 * time.Minute),
-	},
-	edgeproto.AlertPolicy{ // Error alert with extra labels
+	}, { // edgeproto.AlertPolicy
+		// Error alert with extra labels
 		Key: edgeproto.AlertPolicyKey{
 			Name:         "testAlert3",
-			Organization: DevData[1],
+			Organization: devData[1],
 		},
 		CpuUtilizationLimit: 100,
 		Severity:            "error",
@@ -2196,21 +1982,21 @@ var AlertPolicyData = []edgeproto.AlertPolicy{
 			"testAnnotation1": "description1",
 			"testAnnotation2": "description2",
 		},
-	},
-	edgeproto.AlertPolicy{ // Warning alert with two triggers and no description
+	}, { // edgeproto.AlertPolicy
+		// Warning alert with two triggers and no description
 		Key: edgeproto.AlertPolicyKey{
 			Name:         "testAlert4",
-			Organization: DevData[1],
+			Organization: devData[1],
 		},
 		CpuUtilizationLimit: 80,
 		MemUtilizationLimit: 80,
 		Severity:            "warning",
 		TriggerTime:         edgeproto.Duration(30 * time.Second),
-	},
-	edgeproto.AlertPolicy{ // Warning alert with two triggers description and title annotations
+	}, { // edgeproto.AlertPolicy
+		// Warning alert with two triggers description and title annotations
 		Key: edgeproto.AlertPolicyKey{
 			Name:         "testAlert5",
-			Organization: DevData[1],
+			Organization: devData[1],
 		},
 		CpuUtilizationLimit: 80,
 		MemUtilizationLimit: 80,
@@ -2221,101 +2007,85 @@ var AlertPolicyData = []edgeproto.AlertPolicy{
 			"title":       "CustomAlertName",
 			"description": "Custom Description",
 		},
-	},
+	}}
 }
 
-var NetworkData = []edgeproto.Network{
-	edgeproto.Network{
+func NetworkData() []edgeproto.Network {
+	cloudletData := CloudletData()
+	return []edgeproto.Network{{
 		Key: edgeproto.NetworkKey{
 			Name:        "network0",
 			CloudletKey: cloudletData[2].Key,
 		},
 		ConnectionType: edgeproto.NetworkConnectionType_CONNECT_TO_LOAD_BALANCER,
-		Routes: []edgeproto.Route{
-			edgeproto.Route{
-				DestinationCidr: "3.100.0.0/16",
-				NextHopIp:       "3.100.0.1",
-			},
-			edgeproto.Route{
-				DestinationCidr: "3.100.10.0/24",
-				NextHopIp:       "3.100.10.1",
-			},
-		},
-	},
-	edgeproto.Network{
+		Routes: []edgeproto.Route{{
+			DestinationCidr: "3.100.0.0/16",
+			NextHopIp:       "3.100.0.1",
+		}, {
+			DestinationCidr: "3.100.10.0/24",
+			NextHopIp:       "3.100.10.1",
+		}},
+	}, { // edgeproto.Network
 		Key: edgeproto.NetworkKey{
 			Name:        "network1",
 			CloudletKey: cloudletData[2].Key,
 		},
 		ConnectionType: edgeproto.NetworkConnectionType_CONNECT_TO_CLUSTER_NODES,
-		Routes: []edgeproto.Route{
-			edgeproto.Route{
-				DestinationCidr: "4.100.0.0/16",
-				NextHopIp:       "4.100.0.1",
-			},
-			edgeproto.Route{
-				DestinationCidr: "4.100.10.0/24",
-				NextHopIp:       "4.100.10.1",
-			},
-		},
-	},
-	edgeproto.Network{
+		Routes: []edgeproto.Route{{
+			DestinationCidr: "4.100.0.0/16",
+			NextHopIp:       "4.100.0.1",
+		}, {
+			DestinationCidr: "4.100.10.0/24",
+			NextHopIp:       "4.100.10.1",
+		}},
+	}, { // edgeproto.Network
 		Key: edgeproto.NetworkKey{
 			Name:        "network2",
 			CloudletKey: cloudletData[2].Key,
 		},
 		ConnectionType: edgeproto.NetworkConnectionType_CONNECT_TO_ALL,
-		Routes: []edgeproto.Route{
-			edgeproto.Route{
-				DestinationCidr: "5.100.0.0/16",
-				NextHopIp:       "5.100.0.1",
-			},
-		},
-	},
+		Routes: []edgeproto.Route{{
+			DestinationCidr: "5.100.0.0/16",
+			NextHopIp:       "5.100.0.1",
+		}},
+	}}
 }
 
-var NetworkErrorData = []edgeproto.Network{
-	// bad cidr
-	edgeproto.Network{
+func NetworkErrorData() []edgeproto.Network {
+	cloudletData := CloudletData()
+	return []edgeproto.Network{{
+		// bad cidr
 		Key: edgeproto.NetworkKey{
 			Name:        "networkbadcidr",
 			CloudletKey: cloudletData[2].Key,
 		},
 		ConnectionType: edgeproto.NetworkConnectionType_CONNECT_TO_CLUSTER_NODES,
-		Routes: []edgeproto.Route{
-			edgeproto.Route{
-				DestinationCidr: "abcd",
-				NextHopIp:       "3.100.0.1",
-			},
-		},
-	},
-	// bad next hop ip
-	edgeproto.Network{
+		Routes: []edgeproto.Route{{
+			DestinationCidr: "abcd",
+			NextHopIp:       "3.100.0.1",
+		}},
+	}, { // edgeproto.Network
+		// bad next hop ip
 		Key: edgeproto.NetworkKey{
 			Name:        "networkbadroute",
 			CloudletKey: cloudletData[2].Key,
 		},
 		ConnectionType: edgeproto.NetworkConnectionType_CONNECT_TO_LOAD_BALANCER,
-		Routes: []edgeproto.Route{
-			edgeproto.Route{
-				DestinationCidr: "4.100.0.0/16",
-				NextHopIp:       "xyz",
-			},
-		},
-	},
-	// missing connection type
-	edgeproto.Network{
+		Routes: []edgeproto.Route{{
+			DestinationCidr: "4.100.0.0/16",
+			NextHopIp:       "xyz",
+		}},
+	}, { // edgeproto.Network
+		// missing connection type
 		Key: edgeproto.NetworkKey{
 			Name:        "networknoconntype",
 			CloudletKey: cloudletData[2].Key,
 		},
-		Routes: []edgeproto.Route{
-			edgeproto.Route{
-				DestinationCidr: "4.100.0.0/16",
-				NextHopIp:       "4.100.0.0/16",
-			},
-		},
-	},
+		Routes: []edgeproto.Route{{
+			DestinationCidr: "4.100.0.0/16",
+			NextHopIp:       "4.100.0.0/16",
+		}},
+	}}
 }
 
 func GetTimestamp(t time.Time) *types.Timestamp {
@@ -2327,7 +2097,7 @@ func IsAutoClusterAutoDeleteApp(key *edgeproto.AppInstKey) bool {
 	if !strings.HasPrefix(key.ClusterInstKey.ClusterKey.Name, "autocluster") && !strings.HasPrefix(key.ClusterInstKey.ClusterKey.Name, "reservable") {
 		return false
 	}
-	for _, app := range AppData {
+	for _, app := range AppData() {
 		if app.Key.Matches(&key.AppKey) {
 			return app.DelOpt == edgeproto.DeleteType_AUTO_DELETE
 		}
@@ -2340,16 +2110,17 @@ func IsAutoClusterAutoDeleteApp(key *edgeproto.AppInstKey) bool {
 // created and processed by the Controller, given that the controller
 // may modify certain fields during create.
 func CreatedAppInstData() []edgeproto.AppInst {
+	clusterInstAutoData := ClusterInstAutoData()
 	insts := []edgeproto.AppInst{}
-	for ii, appInst := range AppInstData {
+	for ii, appInst := range AppInstData() {
 		switch ii {
 		case 3:
 			// grab expected autocluster real name
-			appInst.RealClusterName = ClusterInstAutoData[0].Key.ClusterKey.Name
+			appInst.RealClusterName = clusterInstAutoData[0].Key.ClusterKey.Name
 		case 4:
-			appInst.RealClusterName = ClusterInstAutoData[1].Key.ClusterKey.Name
+			appInst.RealClusterName = clusterInstAutoData[1].Key.ClusterKey.Name
 		case 6:
-			appInst.RealClusterName = ClusterInstAutoData[2].Key.ClusterKey.Name
+			appInst.RealClusterName = clusterInstAutoData[2].Key.ClusterKey.Name
 		case 11:
 			appInst.Key.ClusterInstKey.Organization = appInst.Key.AppKey.Organization
 			appInst.Key.ClusterInstKey.ClusterKey.Name = "defaultclust"


### PR DESCRIPTION
This makes the global test data immutable, to avoid issues with one test modifying it and messing it up for subsequent tests. We had already done this for the CloudletData, this just carries forth that change to all data.
