### PR TITLE
fix e2e-test program regression from #24 and #25

### DIFF
--- a/test/e2e-tests/cmd/e2e-tests/e2e-tests.go
+++ b/test/e2e-tests/cmd/e2e-tests/e2e-tests.go
@@ -59,7 +59,7 @@ func init() {
 	stopOnFail = flag.Bool("stop", false, "stop on failures")
 	verbose = flag.Bool("verbose", false, "prints full output screen")
 	notimestamp = flag.Bool("notimestamp", false, "no timestamp on outputdir, logs will be appended to by subsequent runs")
-	runextra = flag.Bool("extra", false, "run extra tests (may take much longer)")
+	runextra = flag.Bool("runextra", false, "run extra tests (may take much longer)")
 }
 
 // a list of tests, which may include another file which has tests.  Looping can
@@ -316,7 +316,7 @@ func runTests(ctx context.Context, dirName, fileName, progName string, depth int
 				runerr = e2e.RunTestSpec(ctx, &testConfig, testSpec, mods, *stopOnFail)
 			}
 			took := time.Since(startT).String()
-			if err == nil {
+			if runerr == nil {
 				fmt.Fprintf(stdout, "PASS  %s\n", took)
 				numPassed += 1
 			} else {

--- a/test/e2e-tests/pkg/e2e/setup-mex.go
+++ b/test/e2e-tests/pkg/e2e/setup-mex.go
@@ -566,9 +566,6 @@ func StartProcesses(processName string, args []string, outputDir string) bool {
 	for _, p := range Deployment.ElasticSearchs {
 		StartLocalPar(processName, outputDir, p, portsInUse, &wg, &failed, opts...)
 	}
-	for _, p := range Deployment.Jaegers {
-		StartLocalPar(processName, outputDir, p, portsInUse, &wg, &failed, opts...)
-	}
 	for _, p := range Deployment.RedisCaches {
 		StartLocalPar(processName, outputDir, p, portsInUse, &wg, &failed, opts...)
 	}
@@ -576,6 +573,14 @@ func StartProcesses(processName string, args []string, outputDir string) bool {
 		StartLocalPar(processName, outputDir, p, portsInUse, &wg, &failed, opts...)
 	}
 	// wait for databases
+	wg.Wait()
+	if failed {
+		return false
+	}
+	// wait for jaeger which depends on elastic search
+	for _, p := range Deployment.Jaegers {
+		StartLocalPar(processName, outputDir, p, portsInUse, &wg, &failed, opts...)
+	}
 	wg.Wait()
 	if failed {
 		return false

--- a/test/e2e-tests/testfiles/region_ratelimittest.yml
+++ b/test/e2e-tests/testfiles/region_ratelimittest.yml
@@ -55,7 +55,7 @@ tests:
   actions: [dmeapi-findcloudlet]
 
 - name: sleep, allow time token bucket to refill
-  actions: [sleep=2]
+  actions: [sleep=2.2]
 
 - name: FindCloudlet3 FlowRateLimit (will be successful)
   apifile: "{{datadir2}}/find_cloudlet_app1.yml"


### PR DESCRIPTION
Push #24 incorrectly was checking `err` instead of `runerr` from RunTestSpec in the e2e-tests program, so was silently ignoring errors.
Push #25 to start e2e-test processes in parallel caused jaeger to fail to start since it needs elastic search up, but was being started in parallel with ES. That failure was missed because of the bug from #24.
I also saw one failure which looks to be a timing error due to running tests inline, so extended the sleep by a little bit.