### PR TITLE
speed up influxq unit test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ install-internal-linux:
 UNIT_TEST_LOG ?= /tmp/edge-cloud-unit-test.log
 
 unit-test:
-	go test ./... > $(UNIT_TEST_LOG) || \
+	go test -timeout=3m ./... > $(UNIT_TEST_LOG) || \
 		((grep -A6 "\--- FAIL:" $(UNIT_TEST_LOG) || \
 		grep -A20 "panic: " $(UNIT_TEST_LOG) || \
 		grep -A2 "FATAL" $(UNIT_TEST_LOG)) && \

--- a/cmd/controller/influxq_client/influxq.go
+++ b/cmd/controller/influxq_client/influxq.go
@@ -56,6 +56,8 @@ type InfluxQ struct {
 	ErrBatch  uint64
 	ErrPoint  uint64
 	Qfull     uint64
+	QWrites   uint64
+	DatWrites uint64
 	initRP    bool
 	initRPDur time.Duration
 }
@@ -207,6 +209,9 @@ func (q *InfluxQ) RunPush() {
 			log.DebugLog(log.DebugLevelMetrics, "write batch points",
 				"err", err)
 			atomic.AddUint64(&q.ErrBatch, 1)
+		} else {
+			atomic.AddUint64(&q.QWrites, 1)
+			atomic.AddUint64(&q.DatWrites, uint64(len(data)))
 		}
 	}
 	q.wg.Done()


### PR DESCRIPTION
This speeds up the influxq unit test from ~8s to ~4s. There are still some long sleeps necessary for the continuous queries to kick in, not sure why it seems that influxd needs 2 seconds before it starts compiling metrics into the new database.
