### PR TITLE
clean up for stream-api and redis unit tests

### DIFF
--- a/cmd/controller/alert_api_test.go
+++ b/cmd/controller/alert_api_test.go
@@ -212,7 +212,7 @@ func testinit(ctx context.Context, t *testing.T, opts ...TestOp) *testServices {
 	nodeMgr.CloudletLookup = cloudletLookup
 	if options.LocalRedis {
 		// Since it is a single node, config file is not required
-		procOpts := []process.StartOp{process.WithNoConfig()}
+		procOpts := []process.StartOp{process.WithNoConfig(), process.WithCleanStartup()}
 		redisLocal, err := StartLocalRedisServer(procOpts...)
 		require.Nil(t, err, "start redis server")
 		svcs.RedisLocalSrv = redisLocal

--- a/cmd/controller/stream_api_test.go
+++ b/cmd/controller/stream_api_test.go
@@ -34,15 +34,18 @@ func TestStreamObjs(t *testing.T) {
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 
-	// Test with dummy server
-	testSvcs := testinit(ctx, t)
-	testStreamObjsWithServer(t, ctx)
-	testfinish(testSvcs)
-
-	// Test with local server
-	testSvcs = testinit(ctx, t, WithLocalRedis())
-	testStreamObjsWithServer(t, ctx)
-	testfinish(testSvcs)
+	t.Run("dummy-server", func(t *testing.T) {
+		// Test with dummy server
+		testSvcs := testinit(ctx, t)
+		defer testfinish(testSvcs)
+		testStreamObjsWithServer(t, ctx)
+	})
+	t.Run("local-server", func(t *testing.T) {
+		// Test with local server
+		testSvcs := testinit(ctx, t, WithLocalRedis())
+		defer testfinish(testSvcs)
+		testStreamObjsWithServer(t, ctx)
+	})
 }
 
 func testStreamObjsWithServer(t *testing.T, ctx context.Context) {


### PR DESCRIPTION
For the stream api test, if it fails in the middle of the test it doesn't clean up properly because the clean up func was not deferred. And for the testinit func, if the database file is left behind it can mess up the next test run, so make sure to clean it up at startup.