### PR TITLE
add in missing e2e-test files

### DIFF
--- a/test/e2e-tests/data-regional/get_fqdnlist_platos.yml
+++ b/test/e2e-tests/data-regional/get_fqdnlist_platos.yml
@@ -1,0 +1,20 @@
+# Copyright 2022 MobiledgeX, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+registerclientrequest:
+  orgname: platos
+  appname: PlatosEnablingLayer
+  appvers: "1.0"
+fqdnlistrequest:
+

--- a/test/e2e-tests/data-regional/register_platos.yml
+++ b/test/e2e-tests/data-regional/register_platos.yml
@@ -1,0 +1,21 @@
+# Copyright 2022 MobiledgeX, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+registerclientrequest:
+  orgname: platos
+  appname: PlatosEnablingLayer
+  appvers: "1.0"
+  uniqueidtype: "platos"
+  uniqueid: "123"
+

--- a/test/e2e-tests/data-regional/register_platos_device.yml
+++ b/test/e2e-tests/data-regional/register_platos_device.yml
@@ -1,0 +1,22 @@
+# Copyright 2022 MobiledgeX, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+registerclientrequest:
+  carriername: dmuus
+  orgname: AcmeAppCo
+  appname: someapplication1
+  appvers: "1.0"
+  authtoken: "GENTOKEN:authtoken_private.pem"
+  uniqueidtype: "GSAFKDF:platos:PlatosEnablingLayer"
+  uniqueid: "123"

--- a/test/e2e-tests/testfiles-regional/register_platos.yml
+++ b/test/e2e-tests/testfiles-regional/register_platos.yml
@@ -1,0 +1,31 @@
+# Copyright 2022 MobiledgeX, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##
+tests:
+
+- name: send register api with platos-built device
+  apifile: "{{datadir}}/register_platos_device.yml"
+  actions: [dmeapi-register]
+
+- name: send register api with platos enabling layer
+  apifile: "{{datadir}}/register_platos.yml"
+  actions: [dmeapi-register]
+
+- name: check device show to have both of the devices
+  actions: [ctrlapi-deviceshow]
+  compareyaml:
+    yaml1: "{{outputdir}}/show-commands.yml"
+    yaml2: "{{datadir}}/device_show.yml"
+    filetype: deviceshow


### PR DESCRIPTION
Adds in missing test files from #35. For some reason all the files that I renamed from "platios" to "platos" had the original file deleted but the newly named file was not added. I'm sure I did something wrong along the way, but I didn't notice until now.