### PR TITLE
auto-generated file changes for edge-proto timestamp comments

### DIFF
--- a/api/dme-proto/loc.pb.go
+++ b/api/dme-proto/loc.pb.go
@@ -27,7 +27,9 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // grpc-gateway converts google.protobuf.Timestamp into an RFC3339-type string
 // which is a waste of a conversion, so we define our own
 type Timestamp struct {
-	Seconds              int64    `protobuf:"varint,1,opt,name=seconds,proto3" json:"seconds,omitempty"`
+	// Time in seconds since epoch
+	Seconds int64 `protobuf:"varint,1,opt,name=seconds,proto3" json:"seconds,omitempty"`
+	// Added non-negative sub-second time in nanoseconds
 	Nanos                int32    `protobuf:"varint,2,opt,name=nanos,proto3" json:"nanos,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/pkg/gencmd/loc.cmd.go
+++ b/pkg/gencmd/loc.cmd.go
@@ -21,7 +21,10 @@ var TimestampOptionalArgs = []string{
 	"nanos",
 }
 var TimestampAliasArgs = []string{}
-var TimestampComments = map[string]string{}
+var TimestampComments = map[string]string{
+	"seconds": "Time in seconds since epoch",
+	"nanos":   "Added non-negative sub-second time in nanoseconds",
+}
 var TimestampSpecialArgs = map[string]string{}
 var LocRequiredArgs = []string{}
 var LocOptionalArgs = []string{


### PR DESCRIPTION
Auto-generated file changes due to https://github.com/edgexr/edge-proto/pull/4