### PR TITLE
Switch to Cloudflare API tokens for letsencrypt certs

### DIFF
--- a/pkg/vault/letsencrypt-plugin/docker/Makefile
+++ b/pkg/vault/letsencrypt-plugin/docker/Makefile
@@ -1,7 +1,7 @@
 TAG ?= $(shell date +'%Y-%m-%d')
 
-IMAGE = mobiledgex/certgen
-REGISTRY = harbor.mobiledgex.net
+IMAGE = edgexr/certgen
+REGISTRY = ghcr.io
 
 build:
 	docker build -t $(IMAGE):$(TAG) .


### PR DESCRIPTION
Cloudflare has deprecated API keys and recommends API tokens everywhere.
