### PR TITLE
unit-test: fix wait-last-event failure

### DIFF
--- a/pkg/mc/orm/ctrl_test.go
+++ b/pkg/mc/orm/ctrl_test.go
@@ -1455,6 +1455,8 @@ func testControllerClientRun(t *testing.T, ctx context.Context, clientRun mctest
 		ds.EnableMidstreamFailure(api, syncChan)
 		ds.ShowDummyCount = 3
 
+		numEvents := de.GetNumEvents()
+
 		appInst := &ormapi.RegionAppInst{}
 		appInst.Region = ctrl.Region
 		appInst.AppInst.Key.AppKey.Organization = org1
@@ -1469,7 +1471,8 @@ func testControllerClientRun(t *testing.T, ctx context.Context, clientRun mctest
 
 		// wait for event
 		var lastEvent *node.EventData
-		matches := de.WaitLastEventMatches(func(event *node.EventData) bool {
+		matches := de.WaitLastEventMatches(numEvents, func(event *node.EventData) bool {
+			log.DebugLog(log.DebugLevelInfo, "Check event", "event", *event)
 			lastEvent = event
 			if event.Name != apiUri {
 				return false


### PR DESCRIPTION
This fixes an intermittent unit-test failure in pkg/mc/orm TestController. In the test, after an AppInstCreate that is failed mid-stream, we check that the audit log is as expected. The problem is that there is some other thread in the test also generating events (ping), and so if we run the AppInstCreate, then expect the last event to be for AppInstCreate, it's possible a ping event has happened after the AppInstCreate, so we'll never see the AppInstCreate event if we're only looking at the last event.

The fix is to just search all events from right before we ran the AppInstCreate. There is no bug in the server code, this is just a unit-test code issue.