### PR TITLE
unit-test: fix general timing issues

### DIFF
--- a/cmd/controller/influxq_client/influxq_test.go
+++ b/cmd/controller/influxq_client/influxq_test.go
@@ -315,7 +315,7 @@ func WaitCounter(t *testing.T, counter *uint64, count uint64) {
 		if *counter == count {
 			break
 		}
-		time.Sleep(5 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 	}
 	require.Equal(t, count, *counter)
 }

--- a/cmd/dme/dme-location_test.go
+++ b/cmd/dme/dme-location_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	dmecommon "github.com/edgexr/edge-cloud-platform/pkg/dme-common"
 	dmetest "github.com/edgexr/edge-cloud-platform/pkg/dme-testutil"
@@ -36,7 +37,7 @@ func TestVerifyLoc(t *testing.T) {
 	eehandler, err := initEdgeEventsPlugin(ctx, "standalone")
 	require.Nil(t, err, "init edge events plugin")
 	dmecommon.SetupMatchEngine(eehandler)
-	dmecommon.InitAppInstClients()
+	dmecommon.InitAppInstClients(time.Minute)
 	defer dmecommon.StopAppInstClients()
 	operatorApiGw, _ = initOperator(ctx, "standalone")
 	setupJwks()

--- a/cmd/dme/dme-main.go
+++ b/cmd/dme/dme-main.go
@@ -742,7 +742,7 @@ func main() {
 	dmecommon.EEStats.Start()
 	defer dmecommon.EEStats.Stop()
 
-	dmecommon.InitAppInstClients()
+	dmecommon.InitAppInstClients(time.Duration(dmecommon.Settings.AppinstClientCleanupInterval))
 	defer dmecommon.StopAppInstClients()
 
 	initRateLimitMgr()

--- a/cmd/dme/dme-notify_test.go
+++ b/cmd/dme/dme-notify_test.go
@@ -20,10 +20,10 @@ import (
 	"testing"
 	"time"
 
-	dmecommon "github.com/edgexr/edge-cloud-platform/pkg/dme-common"
 	dme "github.com/edgexr/edge-cloud-platform/api/dme-proto"
-	dmetest "github.com/edgexr/edge-cloud-platform/pkg/dme-testutil"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	dmecommon "github.com/edgexr/edge-cloud-platform/pkg/dme-common"
+	dmetest "github.com/edgexr/edge-cloud-platform/pkg/dme-testutil"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/notify"
 	"github.com/stretchr/testify/assert"
@@ -46,7 +46,7 @@ func TestNotify(t *testing.T) {
 	require.Nil(t, err, "init edge events plugin")
 	dmecommon.SetupMatchEngine(eehandler)
 	initRateLimitMgr()
-	dmecommon.InitAppInstClients()
+	dmecommon.InitAppInstClients(time.Minute)
 	defer dmecommon.StopAppInstClients()
 	apps := dmetest.GenerateApps()
 	appInsts := dmetest.GenerateAppInsts()

--- a/cmd/dme/match-engine_test.go
+++ b/cmd/dme/match-engine_test.go
@@ -17,11 +17,12 @@ package main
 import (
 	"fmt"
 	"testing"
+	"time"
 
-	dmecommon "github.com/edgexr/edge-cloud-platform/pkg/dme-common"
 	dme "github.com/edgexr/edge-cloud-platform/api/dme-proto"
-	dmetest "github.com/edgexr/edge-cloud-platform/pkg/dme-testutil"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	dmecommon "github.com/edgexr/edge-cloud-platform/pkg/dme-common"
+	dmetest "github.com/edgexr/edge-cloud-platform/pkg/dme-testutil"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
@@ -39,7 +40,7 @@ func TestAddRemove(t *testing.T) {
 	eehandler, err := initEdgeEventsPlugin(ctx, "standalone")
 	require.Nil(t, err, "init edge events plugin")
 	dmecommon.SetupMatchEngine(eehandler)
-	dmecommon.InitAppInstClients()
+	dmecommon.InitAppInstClients(time.Minute)
 	defer dmecommon.StopAppInstClients()
 
 	setupJwks()

--- a/pkg/dme-common/appclient.go
+++ b/pkg/dme-common/appclient.go
@@ -40,12 +40,12 @@ var clientsMap *ClientsMap
 var ClientSender *notify.AppInstClientSend
 var AppInstClientKeyCache edgeproto.AppInstClientKeyCache
 
-func InitAppInstClients() {
+func InitAppInstClients(timeout time.Duration) {
 	clientsMap = new(ClientsMap)
 	clientsMap.clientsByApp = make(map[edgeproto.AppKey][]edgeproto.AppInstClient)
 	clientsMap.stopCleanupThread = make(chan struct{})
 	clientsMap.updateAppinstClientTimeout = make(chan bool)
-	clientsMap.cleanupTimeout = time.Duration(Settings.AppinstClientCleanupInterval)
+	clientsMap.cleanupTimeout = timeout
 	clientsMap.waitGrp.Add(1)
 	go clientsMap.timeoutAppInstClients()
 }

--- a/pkg/dme-common/appclient_test.go
+++ b/pkg/dme-common/appclient_test.go
@@ -19,8 +19,8 @@ import (
 	"time"
 
 	dme "github.com/edgexr/edge-cloud-platform/api/dme-proto"
-	dmetest "github.com/edgexr/edge-cloud-platform/pkg/dme-testutil"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	dmetest "github.com/edgexr/edge-cloud-platform/pkg/dme-testutil"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
@@ -33,7 +33,7 @@ func TestAddClients(t *testing.T) {
 	ctx := log.StartTestSpan(context.Background())
 	Settings.MaxTrackedDmeClients = 2
 
-	InitAppInstClients()
+	InitAppInstClients(time.Minute)
 	defer StopAppInstClients()
 
 	// need to grab lock to avoid concurrent access with cleanup thread

--- a/pkg/platform/fake/fake.go
+++ b/pkg/platform/fake/fake.go
@@ -678,6 +678,16 @@ func (s *Platform) HasTrustPolicyException(ctx context.Context, tpeKey *edgeprot
 	return found
 }
 
+func (s *Platform) WaitHasTrustPolicyException(ctx context.Context, tpeKey *edgeproto.TrustPolicyExceptionKey, clusterInst *edgeproto.ClusterInst) bool {
+	for ii := 0; ii < 10; ii++ {
+		if s.HasTrustPolicyException(ctx, tpeKey, clusterInst) {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return s.HasTrustPolicyException(ctx, tpeKey, clusterInst)
+}
+
 func (s *Platform) TrustPolicyExceptionCount(ctx context.Context) int {
 	s.mux.Lock()
 	defer s.mux.Unlock()


### PR DESCRIPTION
This fixes a bunch of intermittent unit-test failures due to timing issues.
- influxq_test: need more time to wait
- crm_server_test: need retries with delay on TPE checks, some had them but all need them
- dme-common/appclient_test: for unit-tests, appclient thread iteration delay was 0s, so sometimes caused differences in expected stats counts. Change to 1m to avoid thread running and messing up expected stats.