### PR TITLE
fix frm notify filtering

### DIFF
--- a/cmd/controller/main_test.go
+++ b/cmd/controller/main_test.go
@@ -148,8 +148,8 @@ func testC(t *testing.T) {
 	autoScalePolicyClient := edgeproto.NewAutoScalePolicyApiClient(conn)
 	autoProvPolicyClient := edgeproto.NewAutoProvPolicyApiClient(conn)
 
-	crmClient.WaitForConnect(1)
-	dmeClient.WaitForConnect(1)
+	require.Nil(t, crmClient.WaitForConnect(1))
+	require.Nil(t, dmeClient.WaitForConnect(1))
 	for ii, _ := range testutil.CloudletInfoData() {
 		err := apis.cloudletInfoApi.cache.WaitForCloudletState(ctx, &testutil.CloudletInfoData()[ii].Key, dme.CloudletState_CLOUDLET_STATE_READY, time.Second)
 		require.Nil(t, err)

--- a/cmd/crm/crm_server_test.go
+++ b/cmd/crm/crm_server_test.go
@@ -381,7 +381,7 @@ func TestCRM(t *testing.T) {
 		ctrlMgr.Stop()
 	}()
 
-	notifyClient.WaitForConnect(1)
+	require.Nil(t, notifyClient.WaitForConnect(1))
 	stats := notify.Stats{}
 	notifyClient.GetStats(&stats)
 	require.Equal(t, uint64(1), stats.Connects)

--- a/cmd/dme/dme-notify_test.go
+++ b/cmd/dme/dme-notify_test.go
@@ -153,8 +153,7 @@ func TestNotify(t *testing.T) {
 	count := len(dmetest.DeviceData) - 1 // Since one is a duplicate
 	// verify that devices are in local cache
 	assert.Equal(t, count, len(dmecommon.PlatformClientsCache.Objs))
-	serverHandler.WaitForDevices(count)
-	assert.Equal(t, count, len(serverHandler.DeviceCache.Objs))
+	require.Nil(t, serverHandler.WaitForDevices(count))
 	// Delete all elements from local cache directly
 	for _, data := range dmecommon.PlatformClientsCache.Objs {
 		obj := data.Obj

--- a/cmd/shepherd/shepherd_update_test.go
+++ b/cmd/shepherd/shepherd_update_test.go
@@ -22,13 +22,13 @@ import (
 	"testing"
 	"time"
 
-	intprocess "github.com/edgexr/edge-cloud-platform/pkg/process"
-	"github.com/edgexr/edge-cloud-platform/pkg/shepherd_test"
+	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
-	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/notify"
+	intprocess "github.com/edgexr/edge-cloud-platform/pkg/process"
+	"github.com/edgexr/edge-cloud-platform/pkg/shepherd_test"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
@@ -89,7 +89,7 @@ func TestShepherdUpdate(t *testing.T) {
 	start()
 	defer stop()
 
-	crmServer.WaitServerCount(1)
+	require.Nil(t, crmServer.WaitServerCount(1))
 
 	// test settings update
 

--- a/pkg/notify/app.notify.go
+++ b/pkg/notify/app.notify.go
@@ -95,11 +95,11 @@ func (s *AppSend) UpdateAll(ctx context.Context) {
 	if !s.sendrecv.isRemoteWanted(s.MessageName) {
 		return
 	}
-	if !s.UpdateAllOk() { // to be implemented by hand
-		return
-	}
 	s.Mux.Lock()
 	s.handler.GetAllKeys(ctx, func(key *edgeproto.AppKey, modRev int64) {
+		if !s.UpdateAllOkLocked(key) { // to be implemented by hand
+			return
+		}
 		s.Keys[*key] = AppSendContext{
 			ctx:    ctx,
 			modRev: modRev,

--- a/pkg/notify/appinst.notify.go
+++ b/pkg/notify/appinst.notify.go
@@ -96,11 +96,11 @@ func (s *AppInstSend) UpdateAll(ctx context.Context) {
 	if !s.sendrecv.isRemoteWanted(s.MessageName) {
 		return
 	}
-	if !s.UpdateAllOk() { // to be implemented by hand
-		return
-	}
 	s.Mux.Lock()
 	s.handler.GetAllKeys(ctx, func(key *edgeproto.AppInstKey, modRev int64) {
+		if !s.UpdateAllOkLocked(key) { // to be implemented by hand
+			return
+		}
 		s.Keys[*key] = AppInstSendContext{
 			ctx:    ctx,
 			modRev: modRev,

--- a/pkg/notify/cloudlet.notify.go
+++ b/pkg/notify/cloudlet.notify.go
@@ -440,11 +440,11 @@ func (s *GPUDriverSend) UpdateAll(ctx context.Context) {
 	if !s.sendrecv.isRemoteWanted(s.MessageName) {
 		return
 	}
-	if !s.UpdateAllOk() { // to be implemented by hand
-		return
-	}
 	s.Mux.Lock()
 	s.handler.GetAllKeys(ctx, func(key *edgeproto.GPUDriverKey, modRev int64) {
+		if !s.UpdateAllOkLocked(key) { // to be implemented by hand
+			return
+		}
 		s.Keys[*key] = GPUDriverSendContext{
 			ctx:    ctx,
 			modRev: modRev,
@@ -801,11 +801,11 @@ func (s *CloudletSend) UpdateAll(ctx context.Context) {
 	if !s.sendrecv.isRemoteWanted(s.MessageName) {
 		return
 	}
-	if !s.UpdateAllOk() { // to be implemented by hand
-		return
-	}
 	s.Mux.Lock()
 	s.handler.GetAllKeys(ctx, func(key *edgeproto.CloudletKey, modRev int64) {
+		if !s.UpdateAllOkLocked(key) { // to be implemented by hand
+			return
+		}
 		s.Keys[*key] = CloudletSendContext{
 			ctx:    ctx,
 			modRev: modRev,

--- a/pkg/notify/clusterinst.notify.go
+++ b/pkg/notify/clusterinst.notify.go
@@ -96,11 +96,11 @@ func (s *ClusterInstSend) UpdateAll(ctx context.Context) {
 	if !s.sendrecv.isRemoteWanted(s.MessageName) {
 		return
 	}
-	if !s.UpdateAllOk() { // to be implemented by hand
-		return
-	}
 	s.Mux.Lock()
 	s.handler.GetAllKeys(ctx, func(key *edgeproto.ClusterInstKey, modRev int64) {
+		if !s.UpdateAllOkLocked(key) { // to be implemented by hand
+			return
+		}
 		s.Keys[*key] = ClusterInstSendContext{
 			ctx:    ctx,
 			modRev: modRev,

--- a/pkg/notify/notify_server.go
+++ b/pkg/notify/notify_server.go
@@ -312,7 +312,7 @@ func (s *Server) negotiate(ctx context.Context, stream edgeproto.NotifyApi_Strea
 	s.sendrecv.setRemoteWanted(req.WantObjs)
 	s.sendrecv.filterCloudletKeys = req.FilterCloudletKey
 	s.sendrecv.filterFederatedCloudlet = req.FilterFederatedCloudlet
-	if s.sendrecv.filterCloudletKeys || s.sendrecv.filterFederatedCloudlet {
+	if s.sendrecv.filterCloudletKeys {
 		s.sendrecv.sendAllEnd = false
 		s.sendrecv.manualSendAllEnd = true
 	} else {

--- a/pkg/notify/notify_tree_test.go
+++ b/pkg/notify/notify_tree_test.go
@@ -77,7 +77,7 @@ func TestNotifyTree(t *testing.T) {
 
 	// wait till everything is connected
 	for _, n := range clients {
-		n.client.WaitForConnect(1)
+		require.Nil(t, n.client.WaitForConnect(1))
 	}
 
 	// crms need to send cloudletInfo up to trigger sending of

--- a/pkg/notify/trustpolicyexception.notify.go
+++ b/pkg/notify/trustpolicyexception.notify.go
@@ -95,11 +95,11 @@ func (s *TrustPolicyExceptionSend) UpdateAll(ctx context.Context) {
 	if !s.sendrecv.isRemoteWanted(s.MessageName) {
 		return
 	}
-	if !s.UpdateAllOk() { // to be implemented by hand
-		return
-	}
 	s.Mux.Lock()
 	s.handler.GetAllKeys(ctx, func(key *edgeproto.TrustPolicyExceptionKey, modRev int64) {
+		if !s.UpdateAllOkLocked(key) { // to be implemented by hand
+			return
+		}
 		s.Keys[*key] = TrustPolicyExceptionSendContext{
 			ctx:    ctx,
 			modRev: modRev,

--- a/pkg/notify/vmpool.notify.go
+++ b/pkg/notify/vmpool.notify.go
@@ -96,11 +96,11 @@ func (s *VMPoolSend) UpdateAll(ctx context.Context) {
 	if !s.sendrecv.isRemoteWanted(s.MessageName) {
 		return
 	}
-	if !s.UpdateAllOk() { // to be implemented by hand
-		return
-	}
 	s.Mux.Lock()
 	s.handler.GetAllKeys(ctx, func(key *edgeproto.VMPoolKey, modRev int64) {
+		if !s.UpdateAllOkLocked(key) { // to be implemented by hand
+			return
+		}
 		s.Keys[*key] = VMPoolSendContext{
 			ctx:    ctx,
 			modRev: modRev,

--- a/tools/protoc-gen-notify/gennotify.go
+++ b/tools/protoc-gen-notify/gennotify.go
@@ -238,13 +238,13 @@ func (s *{{.Name}}Send) UpdateAll(ctx context.Context) {
 	if !s.sendrecv.isRemoteWanted(s.MessageName) {
 		return
 	}
-{{- if .CustomUpdate}}
-	if !s.UpdateAllOk() { // to be implemented by hand
-		return
-	}
-{{- end}}
 	s.Mux.Lock()
 	s.handler.GetAllKeys(ctx, func(key *{{.KeyType}}, modRev int64) {
+{{- if .CustomUpdate}}
+		if !s.UpdateAllOkLocked(key) { // to be implemented by hand
+			return
+		}
+{{- end}}
 		s.Keys[*key] = {{.Name}}SendContext{
 			ctx: ctx,
 			modRev: modRev,


### PR DESCRIPTION
The FRM notify unit-test failed intermittently. Upon investigation, I found there were some bugs with the message filtering for FRMs.

FRM filtering was modeled after CRM cloudlet filtering but differs in a few ways. For CRM cloudlet filtering, there is an extra init phase, so no filterable data is sent until after the CRM sends back a CloudletInfo with Ready state. So the "send all" phase is delayed until after CloudletInfo Ready. In contrast, FRM follows a standard send all phase upon connection.

As a reminder for how notify filtering works, upon initial connection establishment, there is a "send all" phase, where the server sends all data to the client. This is filtered by the UpdateAllOk() funcs. After that, incremental changes are filtered by the UpdateOk() funcs. These hand-written UpdateOk funcs implement the CRM and FRM filtering.

This changset fixes a few bugs:
1. In notify_server,go, negotiate() incorrectly delayed the sendAll phase for filterFederatedCloudlet. This is only used when a sendAllEnd is manually triggered after the extra CRM Init phase, but does not apply to FRM. For FRM, this caused pruning of deleted objects to fail after reconnect, because of a missing sendAllEnd message.
2. In notify_customupdate.go, the UpdateAllOk() functions for AppInst, Cloudlet, and ClusterInst were incorrect in the FRM case. If you look at the UpdateOk() functions, in the FRM case we filter by the FederatedOrganization field. But in the UpdateAllOk() functions, there is no filtering. So if an AppInst gets sent as part of sendAll, it does not get filtered by UpdateAllOk(). If it gets sent after sendAll, it will get filtered by UpdateOk(). In order to make these two consistent, I needed to change UpdateAllOk to be per object.
3. Unrelated to FRM, App UpdateAllOk() was inconsistent with App UpdateOk. The UpdateOk func was not doing any filtering, but UpdateAllOk was doing filtering based on Cloudlet. The intent is to always send all App changes so UpdateAllOk is changed to not filter.
