### PR TITLE
make mc email SMTP port configurable

### DIFF
--- a/pkg/mc/orm/emails.go
+++ b/pkg/mc/orm/emails.go
@@ -263,10 +263,11 @@ func sendVerifyEmail(c echo.Context, username string, req *ormapi.EmailRequest) 
 }
 
 type emailAccount struct {
-	Email string `json:"email"`
-	User  string `json:"user"`
-	Pass  string `json:"pass"`
-	Smtp  string `json:"smtp"`
+	Email    string `json:"email"`
+	User     string `json:"user"`
+	Pass     string `json:"pass"`
+	Smtp     string `json:"smtp"`
+	SmtpPort string `json:"smtpport"`
 }
 
 func getNoreply(ctx context.Context) (*emailAccount, error) {
@@ -277,6 +278,9 @@ func getNoreply(ctx context.Context) (*emailAccount, error) {
 	if err != nil {
 		return nil, err
 	}
+	if noreply.SmtpPort == "" {
+		noreply.SmtpPort = "587"
+	}
 	return &noreply, nil
 }
 
@@ -284,7 +288,7 @@ func getNoreply(ctx context.Context) (*emailAccount, error) {
 func sendEmail(from *emailAccount, to string, contents *bytes.Buffer) error {
 	auth := smtp.PlainAuth("", from.User, from.Pass, from.Smtp)
 
-	client, err := smtp.Dial(from.Smtp + ":587")
+	client, err := smtp.Dial(from.Smtp + ":" + from.SmtpPort)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Running MC in Open Telekom Cloud (OTC) blocks outgoing SMTP requests on port 587. This change makes that port configurable by adding the smtp port to the sender email information stored in Vault. For Open Telekom Cloud, the port should be 2525, which is an alternate SendGrid SMTP port.
