### PR TITLE
alertmgr-sidecar get noreply email from Vault

### DIFF
--- a/cmd/dme/dme-main.go
+++ b/cmd/dme/dme-main.go
@@ -126,7 +126,13 @@ func (s *server) FindCloudlet(ctx context.Context, req *dme.FindCloudletRequest)
 		if qos != "DEFAULT" {
 			var protocol string
 			var asAddr string
-			ips, _ := net.LookupIP(reply.Fqdn)
+			var ips []net.IP
+			if os.Getenv("E2ETEST_TLS") != "" {
+				// avoid IP lookup, it hangs and causes API call to timeout
+				log.SpanLog(ctx, log.DebugLevelDmereq, "Avoid Ip lookup for e2e test")
+			} else {
+				ips, _ = net.LookupIP(reply.Fqdn)
+			}
 			for _, ip := range ips {
 				if ipv4 := ip.To4(); ipv4 != nil {
 					log.SpanLog(ctx, log.DebugLevelDmereq, "Looked up IPv4 address", "reply.Fqdn", reply.Fqdn, "ipv4", ipv4)

--- a/pkg/mc/orm/alertmgr/alertmgr_testdata.go
+++ b/pkg/mc/orm/alertmgr/alertmgr_testdata.go
@@ -15,10 +15,10 @@
 package alertmgr
 
 import (
-	"github.com/edgexr/edge-cloud-platform/api/ormapi"
-	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	dme "github.com/edgexr/edge-cloud-platform/api/dme-proto"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/api/ormapi"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 )
 
 var TestInitInfo = AlertmgrInitInfo{

--- a/pkg/mc/orm/user.go
+++ b/pkg/mc/orm/user.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/edgexr/edge-cloud-platform/api/ormapi"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/mc/ormutil"
 	"github.com/edgexr/edge-cloud-platform/pkg/mc/rbac"
@@ -870,7 +871,7 @@ func PasswordResetRequest(c echo.Context) error {
 	if err := ValidEmailRequest(c, &req); err != nil {
 		return err
 	}
-	noreply, err := getNoreply(ctx)
+	noreply, err := cloudcommon.GetNoreply(serverConfig.vaultConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/process/process_vault.go
+++ b/pkg/process/process_vault.go
@@ -54,13 +54,15 @@ type VaultData struct {
 var defaultVaultAddress = "http://127.0.0.1:8200"
 
 type VaultRoles struct {
-	NotifyRootRoleID   string `json:"notifyrootroleid"`
-	NotifyRootSecretID string `json:"notifyrootsecretid"`
-	MCRoleID           string `json:"mcroleid"`
-	MCSecretID         string `json:"mcsecretid"`
-	RotatorRoleID      string `json:"rotatorroleid"`
-	RotatorSecretID    string `json:"rotatorsecretid"`
-	RegionRoles        map[string]*VaultRegionRoles
+	NotifyRootRoleID        string `json:"notifyrootroleid"`
+	NotifyRootSecretID      string `json:"notifyrootsecretid"`
+	MCRoleID                string `json:"mcroleid"`
+	MCSecretID              string `json:"mcsecretid"`
+	RotatorRoleID           string `json:"rotatorroleid"`
+	RotatorSecretID         string `json:"rotatorsecretid"`
+	AlertMgrSidecarRoleID   string `json:"alertmgrsidecarroleid"`
+	AlertMgrSidecarSecretID string `json:"alertmgrsidecarsecretid"`
+	RegionRoles             map[string]*VaultRegionRoles
 }
 
 type VaultRegionRoles struct {
@@ -162,6 +164,7 @@ func (p *Vault) Setup(opts ...StartOp) error {
 	p.GetAppRole("", "notifyroot", &vroles.NotifyRootRoleID, &vroles.NotifyRootSecretID, &err)
 	p.GetAppRole("", "mcorm", &vroles.MCRoleID, &vroles.MCSecretID, &err)
 	p.GetAppRole("", "rotator", &vroles.RotatorRoleID, &vroles.RotatorSecretID, &err)
+	p.GetAppRole("", "alertmgrsidecar", &vroles.AlertMgrSidecarRoleID, &vroles.AlertMgrSidecarSecretID, &err)
 	p.PutSecret("", "mcorm", mcormSecret+"-old", &err)
 	p.PutSecret("", "mcorm", mcormSecret, &err)
 

--- a/pkg/vault/setup.sh
+++ b/pkg/vault/setup.sh
@@ -258,4 +258,22 @@ vault write auth/approle/role/rotator period="720h" policies="rotator"
 vault read auth/approle/role/rotator/role-id
 vault write -f auth/approle/role/rotator/secret-id
 
+# alertmanager-sidecar approle
+cat > $TMP/alertmgrsidecar-pol.hcl <<EOF
+path "auth/approle/login" {
+  capabilities = [ "create", "read" ]
+}
+
+path "secret/data/accounts/noreplyemail" {
+  capabilities = [ "read" ]
+}
+EOF
+
+vault policy write alertmgrsidecar $TMP/alertmgrsidecar-pol.hcl
+rm $TMP/alertmgrsidecar-pol.hcl
+vault write auth/approle/role/alertmgrsidecar period="720h" policies="alertmgrsidecar"
+# get alertmgrsidecar app roleID and generate secretID
+vault read auth/approle/role/alertmgrsidecar/role-id
+vault write -f auth/approle/role/alertmgrsidecar/secret-id
+
 rm -Rf $TMP


### PR DESCRIPTION
This changes the alertmgr-sidecar to pull the noreply email information from Vault, rather than expect it as env vars. This is to avoid a chicken-and-the-egg problem with the k8s operator which brings up the platform from scratch. The previous process in that bringup was to start Vault, then read the noreplyemail from Vault to be able to start alertmgr-sidecar. But since Vault has just started, the noreply email data was not there. And it won't be there until the user adds it. This causes the ansible task to read the data from Vault to fail, and the operator to fail.

Instead, the operator should start Vault and alertmgr-sidecar without any dependency on the data, and alertmgr-sidecar should attempt to read the data from Vault itself. Until the user puts the data in Vault, the alertmgr-sidecar will "crash" and restart. This follows the kubernetes-approach. In this way, ansible will not fail, and kubernetes will just restart alertmgr-sidecar until the noreply email info is present.

For backwards compatibility, if there is an error getting the data from Vault, try to get it from the env vars.

Also, e2e-tests were failing due to DME API call timeouts. It looks like an IP lookup was causing delays. This lookup will never work in e2e tests, so disabled it for e2e tests.