### PR TITLE
change MC response json newline truncation

### DIFF
--- a/pkg/mc/orm/auditlog.go
+++ b/pkg/mc/orm/auditlog.go
@@ -104,12 +104,6 @@ func logger(next echo.HandlerFunc) echo.HandlerFunc {
 			bd := middleware.BodyDump(func(c echo.Context, reqB, resB []byte) {
 				reqBody = reqB
 				resBody = resB
-				// new versions of echo use json.Encode to write json,
-				// which adds an extra newline to the output.
-				// For logging, remove this extra newline.
-				if len(resBody) > 0 && resBody[len(resBody)-1] == '\n' {
-					resBody = resBody[:len(resBody)-1]
-				}
 			})
 			next = bd(next)
 		}

--- a/test/e2e-tests/data/mc_admin_eventsshow_exp.yml
+++ b/test/e2e-tests/data/mc_admin_eventsshow_exp.yml
@@ -181,7 +181,8 @@
       region: local
       remote-ip: 127.0.0.1
       request: '{"Cloudlet":{"key":{"name":"dmuus-cloud-1","organization":"dmuus"}},"Region":"local"}'
-      response: '{"data":{"message":"Cloudlet is back to normal operation"}}'
+      response: |
+        {"data":{"message":"Cloudlet is back to normal operation"}}
       spanid: ""
       status: "200"
       traceid: ""
@@ -224,7 +225,7 @@
       region: local
       remote-ip: 127.0.0.1
       request: '{"Cloudlet":{"key":{"name":"dmuus-cloud-1","organization":"dmuus"},"maintenance_state":"MaintenanceStart"},"Region":"local"}'
-      response: |-
+      response: |
         {"data":{"message":"Starting AutoProv failover"}}
         {"data":{"message":"Created AppInst {\"app_key\":{\"organization\":\"AcmeAppCo\",\"name\":\"autoprovHA\",\"version\":\"1.0\"},\"cluster_inst_key\":{\"cluster_key\":{\"name\":\"autocluster-autoprov\"},\"cloudlet_key\":{\"organization\":\"azure\",\"name\":\"azure-cloud-4\"},\"organization\":\"edgecloudorg\"}} to meet policy autoprovHA min constraint 2"}}
         {"data":{"message":"AutoProv failover completed"}}
@@ -390,7 +391,7 @@
       region: locala
       remote-ip: 127.0.0.1
       request: '{"AppInst":{"flavor":{"name":"x1.small"},"key":{"app_key":{"name":"someapplication1","organization":"AcmeAppCo","version":"1.0"},"cluster_inst_key":{"cloudlet_key":{"name":"dmuus-cloud-4","organization":"dmuus"},"cluster_key":{"name":"SmallCluster"},"organization":"AcmeAppCo"}}},"Region":"locala"}'
-      response: |-
+      response: |
         {"data":{"message":"Creating"}}
         {"data":{"message":"Creating App Inst"}}
         {"data":{"message":"Ready"}}
@@ -421,7 +422,7 @@
       region: locala
       remote-ip: 127.0.0.1
       request: '{"AppInst":{"flavor":{"name":"x1.small"},"key":{"app_key":{"name":"someapplication1","organization":"AcmeAppCo","version":"1.0"},"cluster_inst_key":{"cloudlet_key":{"name":"dmuus-cloud-3","organization":"dmuus"},"cluster_key":{"name":"SmallCluster"},"organization":"AcmeAppCo"}}},"Region":"locala"}'
-      response: |-
+      response: |
         {"data":{"message":"Creating"}}
         {"data":{"message":"Creating App Inst"}}
         {"data":{"message":"Ready"}}

--- a/test/e2e-tests/data/mc_user1_eventsshow_exp.yml
+++ b/test/e2e-tests/data/mc_user1_eventsshow_exp.yml
@@ -41,7 +41,7 @@
       region: local
       remote-ip: 127.0.0.1
       request: '{"AppInst":{"flavor":{"name":"x1.small"},"key":{"app_key":{"name":"ep1","organization":"user3org","version":"1.0"},"cluster_inst_key":{"cloudlet_key":{"name":"enterprise-1","organization":"enterprise"},"cluster_key":{"name":"SmallCluster"},"organization":"user3org"}}},"Region":"local"}'
-      response: |-
+      response: |
         {"data":{"message":"Creating"}}
         {"data":{"message":"Creating App Inst"}}
         {"data":{"message":"Ready"}}

--- a/test/e2e-tests/data/mc_user2_eventsshow_exp.yml
+++ b/test/e2e-tests/data/mc_user2_eventsshow_exp.yml
@@ -159,7 +159,7 @@
       region: locala
       remote-ip: 127.0.0.1
       request: '{"AppInst":{"flavor":{"name":"x1.small"},"key":{"app_key":{"name":"someapplication1","organization":"AcmeAppCo","version":"1.0"},"cluster_inst_key":{"cloudlet_key":{"name":"dmuus-cloud-4","organization":"dmuus"},"cluster_key":{"name":"SmallCluster"},"organization":"AcmeAppCo"}}},"Region":"locala"}'
-      response: |-
+      response: |
         {"data":{"message":"Creating"}}
         {"data":{"message":"Creating App Inst"}}
         {"data":{"message":"Ready"}}
@@ -190,7 +190,7 @@
       region: locala
       remote-ip: 127.0.0.1
       request: '{"AppInst":{"flavor":{"name":"x1.small"},"key":{"app_key":{"name":"someapplication1","organization":"AcmeAppCo","version":"1.0"},"cluster_inst_key":{"cloudlet_key":{"name":"dmuus-cloud-3","organization":"dmuus"},"cluster_key":{"name":"SmallCluster"},"organization":"AcmeAppCo"}}},"Region":"locala"}'
-      response: |-
+      response: |
         {"data":{"message":"Creating"}}
         {"data":{"message":"Creating App Inst"}}
         {"data":{"message":"Ready"}}
@@ -455,7 +455,7 @@
       region: locala
       remote-ip: 127.0.0.1
       request: '{"AppInst":{"flavor":{"name":"x1.small"},"key":{"app_key":{"name":"someapplication1","organization":"AcmeAppCo","version":"1.0"},"cluster_inst_key":{"cloudlet_key":{"name":"dmuus-cloud-4","organization":"dmuus"},"cluster_key":{"name":"SmallCluster"},"organization":"AcmeAppCo"}}},"Region":"locala"}'
-      response: |-
+      response: |
         {"data":{"message":"Creating"}}
         {"data":{"message":"Creating App Inst"}}
         {"data":{"message":"Ready"}}
@@ -486,7 +486,7 @@
       region: locala
       remote-ip: 127.0.0.1
       request: '{"AppInst":{"flavor":{"name":"x1.small"},"key":{"app_key":{"name":"someapplication1","organization":"AcmeAppCo","version":"1.0"},"cluster_inst_key":{"cloudlet_key":{"name":"dmuus-cloud-3","organization":"dmuus"},"cluster_key":{"name":"SmallCluster"},"organization":"AcmeAppCo"}}},"Region":"locala"}'
-      response: |-
+      response: |
         {"data":{"message":"Creating"}}
         {"data":{"message":"Creating App Inst"}}
         {"data":{"message":"Ready"}}


### PR DESCRIPTION
This changes the way the extra newline added to json responses is removed. This makes the behavior exactly the same as before the echo package was upgrade and the json encoding changed, such that the QA tests don't fail. The previous fix in auditlog.go was causing some of the QA tests to fail.