### PR TITLE
mc generate ldap creds, fix harbor fqdn

### DIFF
--- a/pkg/mc/orm/harbor.go
+++ b/pkg/mc/orm/harbor.go
@@ -499,7 +499,7 @@ func harborEnsureApiKey(ctx context.Context, harborHostPort string) error {
 	// will not overwrite existing secret, avoids race condition with another
 	// process calling GetHarborApiKey.
 	err = cloudcommon.PutRegistryAuth(ctx, harborHostPort, auth, serverConfig.vaultConfig, 0)
-	if err != nil && strings.Contains(err.Error(), "check-and-set parameter did not match the current version") {
+	if vault.IsCheckAndSetError(err) {
 		// already exists
 		err = nil
 	}
@@ -650,7 +650,7 @@ func harborInit(ctx context.Context) error {
 		}
 	}
 
-	harborHostPort := "docker." + serverConfig.DomainName
+	harborHostPort := serverConfig.HarborAddr
 	log.SpanLog(ctx, log.DebugLevelApi, "harbor init", "hostport", harborHostPort)
 
 	// ensure api key is present in Vault

--- a/pkg/mc/orm/server.go
+++ b/pkg/mc/orm/server.go
@@ -260,6 +260,10 @@ func RunServer(config *ServerConfig) (retserver *Server, reterr error) {
 	log.SpanLog(ctx, log.DebugLevelInfo, "vault auth", "type", config.vaultConfig.Auth.Type())
 	server.initJWKDone = make(chan struct{}, 1)
 	InitVault(config.vaultConfig, server.done, server.initJWKDone)
+	err = initLdapAuth(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	switch serverConfig.BillingPlatform {
 	case "fake":

--- a/pkg/vault/getdata.go
+++ b/pkg/vault/getdata.go
@@ -17,6 +17,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -85,6 +86,13 @@ func PutDataCAS(config *Config, path string, data interface{}, checkAndSet int) 
 		return fmt.Errorf("Failed to unmarshal json to vault data: %v", err)
 	}
 	return PutKV(client, path, vaultData)
+}
+
+func IsCheckAndSetError(err error) bool {
+	if err != nil && strings.Contains(err.Error(), "check-and-set parameter did not match the current version") {
+		return true
+	}
+	return false
 }
 
 func GetEnvVars(config *Config, path string) (map[string]string, error) {

--- a/pkg/vault/setup.sh
+++ b/pkg/vault/setup.sh
@@ -217,6 +217,10 @@ path "secret/data/registry/*" {
   capabilities = [ "read", "create", "update" ]
 }
 
+path "secret/data/accounts/mcldap" {
+  capabilities = [ "create", "update", "read" ]
+}
+
 path "pki-global/issue/*" {
   capabilities = [ "read", "update" ]
 }


### PR DESCRIPTION
For deployment, have MC generate LDAP credentials if there are none specified.

Also, fix reference to harbor address for registry lookup.