### PR TITLE
fix harbor robot auth type and secret

### DIFF
--- a/pkg/mc/orm/appstore_sync_test.go
+++ b/pkg/mc/orm/appstore_sync_test.go
@@ -291,6 +291,9 @@ func TestAppStoreApi(t *testing.T) {
 	gm.initData()
 	hm.initData()
 
+	// for consistency in counts, make sure edgecloud org project exists
+	harborCreateProject(ctx, &harborEdgeCloudOrg)
+
 	// Create new users & orgs from MC
 	for _, v := range testEntries {
 		mcClientCreate(t, v, mcClient, uri)

--- a/pkg/mc/orm/harbor_sync.go
+++ b/pkg/mc/orm/harbor_sync.go
@@ -30,6 +30,8 @@ func (s *AppStoreSync) syncHarborProjects(ctx context.Context) {
 		s.syncErr(ctx, err)
 		return
 	}
+	orgsT[harborEdgeCloudOrg.Name] = &harborEdgeCloudOrg
+
 	projects, err := harborGetProjects(ctx)
 	if err != nil {
 		s.syncErr(ctx, err)


### PR DESCRIPTION
A few more fixes for Harbor and MC integration.
- Harbor's robot account auth is via basic auth, not api key
- Robot create doesn't write the secret, the explicit secret put is required
- Add edgecloudorg as a project in Harbor, this will hold the edge-cloud images for deploying crm and shepherd to the cloudlets. That way cloudlets don't have access to the set of images used to deploy the platform, since crm and shepherd are copied into the platform's docker registry. Although we actually need to switch from using the full edge-cloud image to using separate crm and shepherd images.
- Add needed robot APIs to the mock test