### PR TITLE
change plugin to direct import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,6 @@ generate: check-go-vers $(APICOMMENTS) gen-vers
 
 gobuild: check-go-vers gen-vers
 	go build ./...
-	go build -buildmode=plugin -o ${GOPATH}/plugins/platforms.so pkg/plugin/platform/*.go
-	go build -buildmode=plugin -o ${GOPATH}/plugins/edgeevents.so pkg/plugin/edgeevents/*.go
 	go vet ./...
 
 build: generate gobuild

--- a/cmd/crm/main.go
+++ b/cmd/crm/main.go
@@ -25,20 +25,19 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/edgexr/edge-cloud-platform/pkg/accessapi"
-	"github.com/edgexr/edge-cloud-platform/pkg/crmutil"
-	"github.com/edgexr/edge-cloud-platform/pkg/process"
-	"github.com/edgexr/edge-cloud-platform/pkg/redundancy"
-
 	dme "github.com/edgexr/edge-cloud-platform/api/dme-proto"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	accessapicloudlet "github.com/edgexr/edge-cloud-platform/pkg/accessapi-cloudlet"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
+	"github.com/edgexr/edge-cloud-platform/pkg/crmutil"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/notify"
 	pf "github.com/edgexr/edge-cloud-platform/pkg/platform"
 	pfutils "github.com/edgexr/edge-cloud-platform/pkg/platform/utils"
+	"github.com/edgexr/edge-cloud-platform/pkg/process"
 	proxycerts "github.com/edgexr/edge-cloud-platform/pkg/proxy/certs"
+	"github.com/edgexr/edge-cloud-platform/pkg/redundancy"
 	"github.com/edgexr/edge-cloud-platform/pkg/tls"
 	"github.com/edgexr/edge-cloud-platform/pkg/util"
 	opentracing "github.com/opentracing/opentracing-go"
@@ -259,7 +258,7 @@ func main() {
 
 		updateCloudletStatus(edgeproto.UpdateTask, "Initializing platform")
 
-		accessApi := accessapi.NewControllerClient(nodeMgr.AccessApiClient)
+		accessApi := accessapicloudlet.NewControllerClient(nodeMgr.AccessApiClient)
 		pc := pf.PlatformConfig{
 			CloudletKey:         &myCloudletInfo.Key,
 			PhysicalName:        *physicalName,
@@ -373,7 +372,7 @@ func main() {
 		)
 		if err == nil {
 			log.SpanLog(ctx, log.DebugLevelInfra, "Get rootLB certs", "key", myCloudletInfo.Key)
-			proxycerts.Init(ctx, platform, accessapi.NewControllerClient(nodeMgr.AccessApiClient))
+			proxycerts.Init(ctx, platform, accessapicloudlet.NewControllerClient(nodeMgr.AccessApiClient))
 			pfType := pf.GetType(cloudlet.PlatformType.String())
 			proxycerts.GetRootLbCerts(ctx, &myCloudletInfo.Key, wildcardName, &nodeMgr, pfType, rootlb, *commercialCerts, &highAvailabilityManager)
 			// setup debug func to trigger refresh of rootlb certs

--- a/cmd/shepherd/shepherd.go
+++ b/cmd/shepherd/shepherd.go
@@ -26,7 +26,7 @@ import (
 
 	dme "github.com/edgexr/edge-cloud-platform/api/dme-proto"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
-	"github.com/edgexr/edge-cloud-platform/pkg/accessapi"
+	accessapicloudlet "github.com/edgexr/edge-cloud-platform/pkg/accessapi-cloudlet"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
 	"github.com/edgexr/edge-cloud-platform/pkg/k8smgmt"
@@ -470,7 +470,7 @@ func start() {
 		log.FatalLog("access key client is not enabled")
 	}
 
-	accessApi := accessapi.NewControllerClient(nodeMgr.AccessApiClient)
+	accessApi := accessapicloudlet.NewControllerClient(nodeMgr.AccessApiClient)
 
 	clientTlsConfig, err := nodeMgr.InternalPki.GetClientTlsConfig(ctx,
 		nodeMgr.CommonName(),

--- a/pkg/accessapi-cloudlet/controllerclient.go
+++ b/pkg/accessapi-cloudlet/controllerclient.go
@@ -23,25 +23,8 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/chefauth"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform"
 	"github.com/edgexr/edge-cloud-platform/pkg/vault"
-)
-
-// AccessData types
-const (
-	GetCloudletAccessVars   = "get-cloudlet-access-vars"
-	GetRegistryAuth         = "get-registry-auth"
-	SignSSHKey              = "sign-ssh-key"
-	GetSSHPublicKey         = "get-ssh-public-key"
-	GetOldSSHKey            = "get-old-ssh-key"
-	GetChefAuthKey          = "get-chef-auth-key"
-	CreateOrUpdateDNSRecord = "create-or-update-dns-record"
-	GetDNSRecords           = "get-dns-records"
-	DeleteDNSRecord         = "delete-dns-record"
-	GetSessionTokens        = "get-session-tokens"
-	GetPublicCert           = "get-public-cert"
-	GetKafkaCreds           = "get-kafka-creds"
-	GetGCSCreds             = "get-gcs-creds"
-	GetFederationAPIKey     = "get-federation-apikey"
 )
 
 // ControllerClient implements platform.AccessApi for cloudlet
@@ -62,7 +45,7 @@ func NewControllerClient(client edgeproto.CloudletAccessApiClient) *ControllerCl
 
 func (s *ControllerClient) GetCloudletAccessVars(ctx context.Context) (map[string]string, error) {
 	req := &edgeproto.AccessDataRequest{
-		Type: GetCloudletAccessVars,
+		Type: platform.GetCloudletAccessVars,
 	}
 	reply, err := s.client.GetAccessData(ctx, req)
 	if err != nil {
@@ -75,7 +58,7 @@ func (s *ControllerClient) GetCloudletAccessVars(ctx context.Context) (map[strin
 
 func (s *ControllerClient) GetRegistryAuth(ctx context.Context, imgUrl string) (*cloudcommon.RegistryAuth, error) {
 	req := &edgeproto.AccessDataRequest{
-		Type: GetRegistryAuth,
+		Type: platform.GetRegistryAuth,
 		Data: []byte(imgUrl),
 	}
 	reply, err := s.client.GetAccessData(ctx, req)
@@ -89,7 +72,7 @@ func (s *ControllerClient) GetRegistryAuth(ctx context.Context, imgUrl string) (
 
 func (s *ControllerClient) SignSSHKey(ctx context.Context, publicKey string) (string, error) {
 	req := &edgeproto.AccessDataRequest{
-		Type: SignSSHKey,
+		Type: platform.SignSSHKey,
 		Data: []byte(publicKey),
 	}
 	reply, err := s.client.GetAccessData(ctx, req)
@@ -101,7 +84,7 @@ func (s *ControllerClient) SignSSHKey(ctx context.Context, publicKey string) (st
 
 func (s *ControllerClient) GetSSHPublicKey(ctx context.Context) (string, error) {
 	req := &edgeproto.AccessDataRequest{
-		Type: GetSSHPublicKey,
+		Type: platform.GetSSHPublicKey,
 	}
 	reply, err := s.client.GetAccessData(ctx, req)
 	if err != nil {
@@ -112,7 +95,7 @@ func (s *ControllerClient) GetSSHPublicKey(ctx context.Context) (string, error) 
 
 func (s *ControllerClient) GetOldSSHKey(ctx context.Context) (*vault.MEXKey, error) {
 	req := &edgeproto.AccessDataRequest{
-		Type: GetOldSSHKey,
+		Type: platform.GetOldSSHKey,
 	}
 	reply, err := s.client.GetAccessData(ctx, req)
 	if err != nil {
@@ -125,7 +108,7 @@ func (s *ControllerClient) GetOldSSHKey(ctx context.Context) (*vault.MEXKey, err
 
 func (s *ControllerClient) GetChefAuthKey(ctx context.Context) (*chefauth.ChefAuthKey, error) {
 	req := &edgeproto.AccessDataRequest{
-		Type: GetChefAuthKey,
+		Type: platform.GetChefAuthKey,
 	}
 	reply, err := s.client.GetAccessData(ctx, req)
 	if err != nil {
@@ -138,7 +121,7 @@ func (s *ControllerClient) GetChefAuthKey(ctx context.Context) (*chefauth.ChefAu
 
 func (s *ControllerClient) GetPublicCert(ctx context.Context, commonName string) (*vault.PublicCert, error) {
 	req := &edgeproto.AccessDataRequest{
-		Type: GetPublicCert,
+		Type: platform.GetPublicCert,
 		Data: []byte(commonName),
 	}
 	reply, err := s.client.GetAccessData(ctx, req)
@@ -150,17 +133,8 @@ func (s *ControllerClient) GetPublicCert(ctx context.Context, commonName string)
 	return pubcert, err
 }
 
-type DNSRequest struct {
-	Zone    string
-	Name    string
-	RType   string
-	Content string
-	TTL     int
-	Proxy   bool
-}
-
 func (s *ControllerClient) CreateOrUpdateDNSRecord(ctx context.Context, zone, name, rtype, content string, ttl int, proxy bool) error {
-	record := DNSRequest{
+	record := platform.DNSRequest{
 		Zone:    zone,
 		Name:    name,
 		RType:   rtype,
@@ -173,7 +147,7 @@ func (s *ControllerClient) CreateOrUpdateDNSRecord(ctx context.Context, zone, na
 		return err
 	}
 	req := &edgeproto.AccessDataRequest{
-		Type: CreateOrUpdateDNSRecord,
+		Type: platform.CreateOrUpdateDNSRecord,
 		Data: data,
 	}
 	_, err = s.client.GetAccessData(ctx, req)
@@ -181,7 +155,7 @@ func (s *ControllerClient) CreateOrUpdateDNSRecord(ctx context.Context, zone, na
 }
 
 func (s *ControllerClient) GetDNSRecords(ctx context.Context, zone, fqdn string) ([]cloudflare.DNSRecord, error) {
-	record := DNSRequest{
+	record := platform.DNSRequest{
 		Zone: zone,
 		Name: fqdn,
 	}
@@ -190,7 +164,7 @@ func (s *ControllerClient) GetDNSRecords(ctx context.Context, zone, fqdn string)
 		return nil, err
 	}
 	req := &edgeproto.AccessDataRequest{
-		Type: GetDNSRecords,
+		Type: platform.GetDNSRecords,
 		Data: data,
 	}
 	reply, err := s.client.GetAccessData(ctx, req)
@@ -206,7 +180,7 @@ func (s *ControllerClient) GetDNSRecords(ctx context.Context, zone, fqdn string)
 }
 
 func (s *ControllerClient) DeleteDNSRecord(ctx context.Context, zone, recordID string) error {
-	record := DNSRequest{
+	record := platform.DNSRequest{
 		Zone: zone,
 		Name: recordID,
 	}
@@ -215,7 +189,7 @@ func (s *ControllerClient) DeleteDNSRecord(ctx context.Context, zone, recordID s
 		return err
 	}
 	req := &edgeproto.AccessDataRequest{
-		Type: DeleteDNSRecord,
+		Type: platform.DeleteDNSRecord,
 		Data: data,
 	}
 	_, err = s.client.GetAccessData(ctx, req)
@@ -224,7 +198,7 @@ func (s *ControllerClient) DeleteDNSRecord(ctx context.Context, zone, recordID s
 
 func (s *ControllerClient) GetSessionTokens(ctx context.Context, arg []byte) (map[string]string, error) {
 	req := &edgeproto.AccessDataRequest{
-		Type: GetSessionTokens,
+		Type: platform.GetSessionTokens,
 		Data: arg,
 	}
 	reply, err := s.client.GetAccessData(ctx, req)
@@ -241,7 +215,7 @@ func (s *ControllerClient) GetSessionTokens(ctx context.Context, arg []byte) (ma
 
 func (s *ControllerClient) GetKafkaCreds(ctx context.Context) (*node.KafkaCreds, error) {
 	req := &edgeproto.AccessDataRequest{
-		Type: GetKafkaCreds,
+		Type: platform.GetKafkaCreds,
 	}
 	reply, err := s.client.GetAccessData(ctx, req)
 	if err != nil {
@@ -254,7 +228,7 @@ func (s *ControllerClient) GetKafkaCreds(ctx context.Context) (*node.KafkaCreds,
 
 func (s *ControllerClient) GetGCSCreds(ctx context.Context) ([]byte, error) {
 	req := &edgeproto.AccessDataRequest{
-		Type: GetGCSCreds,
+		Type: platform.GetGCSCreds,
 	}
 	reply, err := s.client.GetAccessData(ctx, req)
 	if err != nil {
@@ -265,7 +239,7 @@ func (s *ControllerClient) GetGCSCreds(ctx context.Context) ([]byte, error) {
 
 func (s *ControllerClient) GetFederationAPIKey(ctx context.Context, fedName string) (string, error) {
 	req := &edgeproto.AccessDataRequest{
-		Type: GetFederationAPIKey,
+		Type: platform.GetFederationAPIKey,
 		Data: []byte(fedName),
 	}
 	reply, err := s.client.GetAccessData(ctx, req)

--- a/pkg/accessapi/controllerhandler.go
+++ b/pkg/accessapi/controllerhandler.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform"
 )
 
 // Handles unmarshaling of data from ControllerClient. It then calls
@@ -38,44 +39,44 @@ func (s *ControllerHandler) GetAccessData(ctx context.Context, req *edgeproto.Ac
 	var out []byte
 	var merr error
 	switch req.Type {
-	case GetCloudletAccessVars:
+	case platform.GetCloudletAccessVars:
 		vars, err := s.vaultClient.GetCloudletAccessVars(ctx)
 		if err != nil {
 			return nil, err
 		}
 		out, merr = json.Marshal(vars)
-	case GetRegistryAuth:
+	case platform.GetRegistryAuth:
 		auth, err := s.vaultClient.GetRegistryAuth(ctx, string(req.Data))
 		if err != nil {
 			return nil, err
 		}
 		out, merr = json.Marshal(auth)
-	case SignSSHKey:
+	case platform.SignSSHKey:
 		signed, err := s.vaultClient.SignSSHKey(ctx, string(req.Data))
 		if err != nil {
 			return nil, err
 		}
 		out = []byte(signed)
-	case GetSSHPublicKey:
+	case platform.GetSSHPublicKey:
 		pubkey, err := s.vaultClient.GetSSHPublicKey(ctx)
 		if err != nil {
 			return nil, err
 		}
 		out = []byte(pubkey)
-	case GetOldSSHKey:
+	case platform.GetOldSSHKey:
 		mexkey, err := s.vaultClient.GetOldSSHKey(ctx)
 		if err != nil {
 			return nil, err
 		}
 		out, merr = json.Marshal(mexkey)
-	case GetChefAuthKey:
+	case platform.GetChefAuthKey:
 		auth, err := s.vaultClient.GetChefAuthKey(ctx)
 		if err != nil {
 			return nil, err
 		}
 		out, merr = json.Marshal(auth)
-	case CreateOrUpdateDNSRecord:
-		dnsReq := DNSRequest{}
+	case platform.CreateOrUpdateDNSRecord:
+		dnsReq := platform.DNSRequest{}
 		err := json.Unmarshal(req.Data, &dnsReq)
 		if err != nil {
 			return nil, err
@@ -84,8 +85,8 @@ func (s *ControllerHandler) GetAccessData(ctx context.Context, req *edgeproto.Ac
 		if err != nil {
 			return nil, err
 		}
-	case GetDNSRecords:
-		dnsReq := DNSRequest{}
+	case platform.GetDNSRecords:
+		dnsReq := platform.DNSRequest{}
 		err := json.Unmarshal(req.Data, &dnsReq)
 		if err != nil {
 			return nil, err
@@ -95,8 +96,8 @@ func (s *ControllerHandler) GetAccessData(ctx context.Context, req *edgeproto.Ac
 			return nil, err
 		}
 		out, merr = json.Marshal(records)
-	case DeleteDNSRecord:
-		dnsReq := DNSRequest{}
+	case platform.DeleteDNSRecord:
+		dnsReq := platform.DNSRequest{}
 		err := json.Unmarshal(req.Data, &dnsReq)
 		if err != nil {
 			return nil, err
@@ -105,31 +106,31 @@ func (s *ControllerHandler) GetAccessData(ctx context.Context, req *edgeproto.Ac
 		if err != nil {
 			return nil, err
 		}
-	case GetSessionTokens:
+	case platform.GetSessionTokens:
 		tokens, err := s.vaultClient.GetSessionTokens(ctx, req.Data)
 		if err != nil {
 			return nil, err
 		}
 		out, merr = json.Marshal(tokens)
-	case GetPublicCert:
+	case platform.GetPublicCert:
 		publicCert, err := s.vaultClient.GetPublicCert(ctx, string(req.Data))
 		if err != nil {
 			return nil, err
 		}
 		out, merr = json.Marshal(*publicCert)
-	case GetKafkaCreds:
+	case platform.GetKafkaCreds:
 		creds, err := s.vaultClient.GetKafkaCreds(ctx)
 		if err != nil {
 			return nil, err
 		}
 		out, merr = json.Marshal(creds)
-	case GetGCSCreds:
+	case platform.GetGCSCreds:
 		creds, err := s.vaultClient.GetGCSCreds(ctx)
 		if err != nil {
 			return nil, err
 		}
 		out = creds
-	case GetFederationAPIKey:
+	case platform.GetFederationAPIKey:
 		apiKey, err := s.vaultClient.GetFederationAPIKey(ctx, string(req.Data))
 		if err != nil {
 			return nil, err

--- a/pkg/accessapi/vaultclient.go
+++ b/pkg/accessapi/vaultclient.go
@@ -28,6 +28,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudflaremgmt"
 	"github.com/edgexr/edge-cloud-platform/pkg/federationmgmt"
 	"github.com/edgexr/edge-cloud-platform/pkg/gcs"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform"
 	pfutils "github.com/edgexr/edge-cloud-platform/pkg/platform/utils"
 	"github.com/edgexr/edge-cloud-platform/pkg/vault"
 )
@@ -69,7 +70,7 @@ func (s *VaultClient) GetCloudletAccessVars(ctx context.Context) (map[string]str
 	if err != nil {
 		return nil, err
 	}
-	return cloudletPlatform.GetAccessData(ctx, s.cloudlet, s.region, s.vaultConfig, GetCloudletAccessVars, nil)
+	return cloudletPlatform.GetAccessData(ctx, s.cloudlet, s.region, s.vaultConfig, platform.GetCloudletAccessVars, nil)
 }
 
 func (s *VaultClient) GetRegistryAuth(ctx context.Context, imgUrl string) (*cloudcommon.RegistryAuth, error) {
@@ -163,7 +164,7 @@ func (s *VaultClient) GetSessionTokens(ctx context.Context, arg []byte) (map[str
 	if err != nil {
 		return nil, err
 	}
-	return cloudletPlatform.GetAccessData(ctx, s.cloudlet, s.region, s.vaultConfig, GetSessionTokens, arg)
+	return cloudletPlatform.GetAccessData(ctx, s.cloudlet, s.region, s.vaultConfig, platform.GetSessionTokens, arg)
 }
 
 func (s *VaultClient) GetPublicCert(ctx context.Context, commonName string) (*vault.PublicCert, error) {

--- a/pkg/platform/aws/aws-generic/aws-props.go
+++ b/pkg/platform/aws/aws-generic/aws-props.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/infracommon"
-	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/vmlayer"
-	"github.com/edgexr/edge-cloud-platform/pkg/accessapi"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/infracommon"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/vmlayer"
 	"github.com/edgexr/edge-cloud-platform/pkg/vault"
 )
 
@@ -130,14 +130,14 @@ func (a *AwsGenericPlatform) GetSessionTokens(ctx context.Context, vaultConfig *
 func (a *AwsGenericPlatform) GetAccessData(ctx context.Context, cloudlet *edgeproto.Cloudlet, region string, vaultConfig *vault.Config, dataType string, arg []byte) (map[string]string, error) {
 	log.SpanLog(ctx, log.DebugLevelApi, "AwsGenericPlatform GetAccessData", "dataType", dataType)
 	switch dataType {
-	case accessapi.GetCloudletAccessVars:
+	case platform.GetCloudletAccessVars:
 		path := a.GetVaultCloudletAccessPath(&cloudlet.Key, region, cloudlet.PhysicalName)
 		vars, err := infracommon.GetEnvVarsFromVault(ctx, vaultConfig, path)
 		if err != nil {
 			return nil, err
 		}
 		return vars, nil
-	case accessapi.GetSessionTokens:
+	case platform.GetSessionTokens:
 		return a.GetSessionTokens(ctx, vaultConfig, string(arg))
 	}
 	return nil, fmt.Errorf("AwsGeneric unhandled GetAccessData type %s", dataType)

--- a/pkg/platform/azure/azure-props.go
+++ b/pkg/platform/azure/azure-props.go
@@ -18,11 +18,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/infracommon"
-	"github.com/edgexr/edge-cloud-platform/pkg/accessapi"
-	"github.com/edgexr/edge-cloud-platform/pkg/platform"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/infracommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/vault"
 )
 
@@ -59,7 +58,7 @@ func (a *AzurePlatform) GetProviderSpecificProps(ctx context.Context) (map[strin
 func (a *AzurePlatform) GetAccessData(ctx context.Context, cloudlet *edgeproto.Cloudlet, region string, vaultConfig *vault.Config, dataType string, arg []byte) (map[string]string, error) {
 	log.SpanLog(ctx, log.DebugLevelInfra, "AzurePlatform GetAccessData", "dataType", dataType)
 	switch dataType {
-	case accessapi.GetCloudletAccessVars:
+	case platform.GetCloudletAccessVars:
 		vars, err := infracommon.GetEnvVarsFromVault(ctx, vaultConfig, azureVaultPath)
 		if err != nil {
 			return nil, err

--- a/pkg/platform/common/vmlayer/vmprovider.go
+++ b/pkg/platform/common/vmlayer/vmprovider.go
@@ -19,20 +19,19 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/gogo/protobuf/types"
-	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/infracommon"
-	"github.com/edgexr/edge-cloud-platform/pkg/accessapi"
-	"github.com/edgexr/edge-cloud-platform/pkg/k8smgmt"
-	"github.com/edgexr/edge-cloud-platform/pkg/platform"
-	"github.com/edgexr/edge-cloud-platform/pkg/platform/pc"
-	"github.com/edgexr/edge-cloud-platform/pkg/redundancy"
-	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
-	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
 	dme "github.com/edgexr/edge-cloud-platform/api/dme-proto"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
+	"github.com/edgexr/edge-cloud-platform/pkg/k8smgmt"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/infracommon"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform/pc"
+	"github.com/edgexr/edge-cloud-platform/pkg/redundancy"
 	"github.com/edgexr/edge-cloud-platform/pkg/vault"
 	ssh "github.com/edgexr/golang-ssh"
+	"github.com/gogo/protobuf/types"
 )
 
 // VMProvider is an interface that platforms implement to perform the details of interfacing with the orchestration layer
@@ -632,7 +631,7 @@ func (v *VMPlatform) GetClusterInfraResources(ctx context.Context, clusterKey *e
 func (v *VMPlatform) GetAccessData(ctx context.Context, cloudlet *edgeproto.Cloudlet, region string, vaultConfig *vault.Config, dataType string, arg []byte) (map[string]string, error) {
 	log.SpanLog(ctx, log.DebugLevelApi, "VMProvider GetAccessData", "dataType", dataType)
 	switch dataType {
-	case accessapi.GetCloudletAccessVars:
+	case platform.GetCloudletAccessVars:
 		path := v.VMProvider.GetVaultCloudletAccessPath(&cloudlet.Key, region, cloudlet.PhysicalName)
 		if path == "" {
 			log.SpanLog(ctx, log.DebugLevelApi, "No access vars path, returning empty map")
@@ -645,7 +644,7 @@ func (v *VMPlatform) GetAccessData(ctx context.Context, cloudlet *edgeproto.Clou
 			return nil, err
 		}
 		return vars, nil
-	case accessapi.GetSessionTokens:
+	case platform.GetSessionTokens:
 		return v.VMProvider.GetSessionTokens(ctx, vaultConfig, string(arg))
 	}
 	return nil, fmt.Errorf("VMPlatform unhandled GetAccessData type %s", dataType)

--- a/pkg/platform/gcp/gcp-props.go
+++ b/pkg/platform/gcp/gcp-props.go
@@ -20,11 +20,10 @@ import (
 
 	"strings"
 
-	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/infracommon"
-	"github.com/edgexr/edge-cloud-platform/pkg/accessapi"
-	"github.com/edgexr/edge-cloud-platform/pkg/platform"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/infracommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/vault"
 )
 
@@ -73,7 +72,7 @@ func (a *GCPPlatform) GetProviderSpecificProps(ctx context.Context) (map[string]
 func (m *GCPPlatform) GetAccessData(ctx context.Context, cloudlet *edgeproto.Cloudlet, region string, vaultConfig *vault.Config, dataType string, arg []byte) (map[string]string, error) {
 	log.SpanLog(ctx, log.DebugLevelInfra, "GCPPlatform GetAccessData", "dataType", dataType)
 	switch dataType {
-	case accessapi.GetCloudletAccessVars:
+	case platform.GetCloudletAccessVars:
 		vars, err := infracommon.GetEnvVarsFromVault(ctx, vaultConfig, gcpVaultPath)
 		if err != nil {
 			return nil, err

--- a/pkg/platform/openstack/openstack-heat.go
+++ b/pkg/platform/openstack/openstack-heat.go
@@ -20,10 +20,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/infracommon"
-	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/vmlayer"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/infracommon"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/vmlayer"
 	yaml "github.com/mobiledgex/yaml/v2"
 )
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -219,6 +219,33 @@ type AccessApi interface {
 	GetFederationAPIKey(ctx context.Context, fedName string) (string, error)
 }
 
+// AccessData types
+const (
+	GetCloudletAccessVars   = "get-cloudlet-access-vars"
+	GetRegistryAuth         = "get-registry-auth"
+	SignSSHKey              = "sign-ssh-key"
+	GetSSHPublicKey         = "get-ssh-public-key"
+	GetOldSSHKey            = "get-old-ssh-key"
+	GetChefAuthKey          = "get-chef-auth-key"
+	CreateOrUpdateDNSRecord = "create-or-update-dns-record"
+	GetDNSRecords           = "get-dns-records"
+	DeleteDNSRecord         = "delete-dns-record"
+	GetSessionTokens        = "get-session-tokens"
+	GetPublicCert           = "get-public-cert"
+	GetKafkaCreds           = "get-kafka-creds"
+	GetGCSCreds             = "get-gcs-creds"
+	GetFederationAPIKey     = "get-federation-apikey"
+)
+
+type DNSRequest struct {
+	Zone    string
+	Name    string
+	RType   string
+	Content string
+	TTL     int
+	Proxy   bool
+}
+
 var pfMaps = map[string]string{
 	"fakeinfra": "fake",
 	"edgebox":   "dind",

--- a/pkg/plugin/edgeevents/edge-events-plugin.go
+++ b/pkg/plugin/edgeevents/edge-events-plugin.go
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package edgeevents
 
 import (
 	"context"
 	"time"
 
-	edgeevents "github.com/edgexr/edge-cloud-platform/pkg/edge-events"
-	dmecommon "github.com/edgexr/edge-cloud-platform/pkg/dme-common"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	dmecommon "github.com/edgexr/edge-cloud-platform/pkg/dme-common"
+	edgeevents "github.com/edgexr/edge-cloud-platform/pkg/edge-events"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 )
 

--- a/pkg/plugin/platform/operator-plugin.go
+++ b/pkg/plugin/platform/operator-plugin.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package platform
 
 import (
 	"context"

--- a/pkg/plugin/platform/platform-plugin.go
+++ b/pkg/plugin/platform/platform-plugin.go
@@ -12,14 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package platform
 
 import (
 	"fmt"
 
+	"github.com/edgexr/edge-cloud-platform/pkg/platform"
 	awsec2 "github.com/edgexr/edge-cloud-platform/pkg/platform/aws/aws-ec2"
 	awseks "github.com/edgexr/edge-cloud-platform/pkg/platform/aws/aws-eks"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform/azure"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/managedk8s"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/vmlayer"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform/edgebox"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform/fakeinfra"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform/federation"
@@ -30,10 +33,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/platform/vcd"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform/vmpool"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform/vsphere"
-	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/managedk8s"
 	"github.com/edgexr/edge-cloud-platform/pkg/plugin/platform/common"
-	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/vmlayer"
-	"github.com/edgexr/edge-cloud-platform/pkg/platform"
 )
 
 func GetPlatform(plat string) (platform.Platform, error) {

--- a/pkg/proxy/certs/certifications.go
+++ b/pkg/proxy/certs/certifications.go
@@ -24,15 +24,15 @@ import (
 	"sync"
 	"time"
 
+	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/access"
-	"github.com/edgexr/edge-cloud-platform/pkg/accessapi"
+	accessapicloudlet "github.com/edgexr/edge-cloud-platform/pkg/accessapi-cloudlet"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
+	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	pf "github.com/edgexr/edge-cloud-platform/pkg/platform"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform/pc"
 	"github.com/edgexr/edge-cloud-platform/pkg/redundancy"
-	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
-	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
-	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
-	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	ssh "github.com/edgexr/golang-ssh"
 	opentracing "github.com/opentracing/opentracing-go"
 )
@@ -91,11 +91,11 @@ var fixedCerts = false
 
 var AtomicCertsUpdater = "/usr/local/bin/atomic-certs-update.sh"
 
-var accessApi *accessapi.ControllerClient
+var accessApi *accessapicloudlet.ControllerClient
 var platform pf.Platform
 var getRootLBCertsTrigger chan bool
 
-func Init(ctx context.Context, inPlatform pf.Platform, inAccessApi *accessapi.ControllerClient) {
+func Init(ctx context.Context, inPlatform pf.Platform, inAccessApi *accessapicloudlet.ControllerClient) {
 	accessApi = inAccessApi
 	platform = inPlatform
 	getRootLBCertsTrigger = make(chan bool)

--- a/test/e2e-tests/data/mc_shownode.yml
+++ b/test/e2e-tests/data/mc_shownode.yml
@@ -72,21 +72,11 @@ nodes:
     region: local
   containerversion: "2019-10-24"
   internalpki: UseVaultPki
-  properties:
-    FakeInfraBuildAuthor: ""
-    FakeInfraBuildDate: ""
-    FakeInfraBuildHead: ""
-    FakeInfraBuildMaster: ""
 - key:
     type: controller
     region: local
   containerversion: "2019-10-24"
   internalpki: UseVaultPki
-  properties:
-    FakeInfraBuildAuthor: ""
-    FakeInfraBuildDate: ""
-    FakeInfraBuildHead: ""
-    FakeInfraBuildMaster: ""
 - key:
     type: controller
     region: locala
@@ -113,11 +103,6 @@ nodes:
     region: local
   containerversion: "2019-10-24"
   internalpki: useAccessKey,UseVaultPki
-  properties:
-    FakeInfraBuildAuthor: ""
-    FakeInfraBuildDate: ""
-    FakeInfraBuildHead: ""
-    FakeInfraBuildMaster: ""
 - key:
     type: crm
     cloudletkey:


### PR DESCRIPTION
This changes the plugins to direct imports, now that the two repositories have been merged into one. There's a couple of reasons for this:
- Now that everything is open-sourced, any new platforms should be contributed to the open-sourced platform code, rather than live as a private plugin
- It speeds up build time
- It reduces by about half the resulting size of the binaries that need to be put in the container image.

Before (plugin):
Controller: 105M bin + 117M platforms.so = 223M
CRM: 87M + 117M platforms.so = 204M
Cluster-svc: 86M + 117M platforms.so = 203M
Shepherd: 106M + 117M platforms.so = 223M

After (direct import)
Controller: 118M
CRM: 110M
Cluster-svc: 97M
Shepherd: 81M