### PR TITLE
fix harbor secret, ignore test cloudletRegistryPath

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -154,6 +154,11 @@ func validateFields(ctx context.Context) error {
 		if *versionTag == "" {
 			return fmt.Errorf("Version tag is required")
 		}
+		if *cloudletRegistryPath == "edge-cloud-crm" {
+			// local KIND operators testing, ignore
+			log.SpanLog(ctx, log.DebugLevelInfo, "skipping cloudletRegistryPath validation for local KIND testing", "cloudletRegistryPath", *cloudletRegistryPath)
+			return nil
+		}
 		parts := strings.Split(*cloudletRegistryPath, "/")
 		if len(parts) < 2 || !strings.Contains(parts[0], ".") {
 			return fmt.Errorf("Cloudlet registry path should be full registry URL: <domain-name>/<registry-path>")

--- a/pkg/mc/orm/harbor.go
+++ b/pkg/mc/orm/harbor.go
@@ -591,7 +591,7 @@ func harborEnsureRobotAccount(ctx context.Context, harborHostPort string) error 
 	// re-write it to Harbor.
 	log.SpanLog(ctx, log.DebugLevelApi, "harbor update robot secret", "name", HarborRobotName)
 	rsec := models.RobotSec{
-		Secret: auth.ApiKey,
+		Secret: auth.Password,
 	}
 	code, resBody, err = harborDoReq(ctx, http.MethodPatch, path, &rsec)
 	if err != nil {


### PR DESCRIPTION
Controller fails to start for local operator KIND testing because it can't look up the image (the image is pre-loaded into the KIND k8s cluster). This allows the Controller to start.

Also, the harbor secret was being updated from the wrong field, since it is a password and not an API token.