### PR TITLE
Kubectl version wrapper and downloader

### DIFF
--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -14,15 +14,10 @@ import (
 // This serves as a wrapper around kubectl to ensure the
 // correct version of kubectl is used for the target cluster.
 
-type KubectlVersion struct {
-	ClusterName string
-	Kubectl     string
-}
-
 var (
 	BinDir           = "/usr/bin"
 	DefaultMajorVers = "1"
-	DefaultMinorVers = "16"
+	DefaultMinorVers = "18"
 )
 
 type VersionOutput struct {
@@ -93,24 +88,24 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	minX := strconv.Itoa(minInt - 1)
-	minZ := strconv.Itoa(minInt + 1)
+	minLT := strconv.Itoa(minInt - 1)
+	minGT := strconv.Itoa(minInt + 1)
 
 	kubectl := ""
-	kubectlX := kubectlPath(maj, minX)
-	kubectlY := kubectlPath(maj, min)
-	kubectlZ := kubectlPath(maj, minZ)
-	if _, err := os.Stat(kubectlY); err == nil {
-		kubectl = kubectlY
-	} else if _, err := os.Stat(kubectlX); err == nil {
-		kubectl = kubectlX
-	} else if _, err := os.Stat(kubectlZ); err == nil {
-		kubectl = kubectlZ
+	kubectlLT := kubectlPath(maj, minLT)
+	kubectlEQ := kubectlPath(maj, min)
+	kubectlGT := kubectlPath(maj, minGT)
+	if _, err := os.Stat(kubectlEQ); err == nil {
+		kubectl = kubectlEQ
+	} else if _, err := os.Stat(kubectlLT); err == nil {
+		kubectl = kubectlLT
+	} else if _, err := os.Stat(kubectlGT); err == nil {
+		kubectl = kubectlGT
 	} else {
-		kubectl = kubectlY
+		kubectl = kubectlEQ
 		download(maj, min)
 	}
-	// run original command with matching kubectl version
+	// run original command with compatible kubectl version
 	cmd := exec.Command(kubectl, os.Args[1:]...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Kubectl only officially supports a version skew between kubectl and the cluster of +/-1 minor version.

Edge Cloud previously supported a single version of kubernetes, which was 1.18 (which is already very "old"). The client version is set by the edge-cloud container base image which the Controller and CRM containers use, and is built before deployment. The server version is either set by us when deploying k8s ourselves on top of VMs we controlled (via the Mobiledgex package), or as a requirement for managed k8s clusters. It was assumed that only a single version was allowed.

But 1.18 is very old. And to move to a model where the CRM can be deployed to any old k8s cluster, it is unrealistic to require users to use a specific (and probably outdated) version of kubernetes. We have 1.18 while the current k8s is 1.25, already 7 minor versions away. And kubernetes versions change pretty quickly, so even if we change kubectl to 1.25, in a year we will be outdated again. And it won't support our existing base image and existing deployments which use 1.18.

The kubectl binary is about 45MB. So we don't want to have to install every single version of it, because it will unnecessarily bloat the container.

Instead, the below kubectl command replacement figures out which version the target cluster is for the command, and then runs a compatible version of kubectl. If a compatible version of kubectl doesn't exist, it is downloaded on the fly.
