### PR TITLE
set correct domain for http cookie

### DIFF
--- a/cmd/mc/mc.go
+++ b/cmd/mc/mc.go
@@ -102,7 +102,6 @@ func main() {
 		AlertCache:               &alertCache,
 		AlertmgrResolveTimout:    *alertMgrResolveTimeout,
 		UsageCheckpointInterval:  *usageCheckpointInterval,
-		DomainName:               nodeMgr.CommonName(),
 		StaticDir:                *staticDir,
 		DeploymentName:           nodeMgr.DeploymentName,
 		DeploymentTag:            nodeMgr.DeploymentTag,

--- a/pkg/mc/orm/appstore_sync_test.go
+++ b/pkg/mc/orm/appstore_sync_test.go
@@ -212,7 +212,7 @@ func TestAppStoreApi(t *testing.T) {
 		PasswordResetConsolePath: "#/passwordreset",
 		VerifyEmailConsolePath:   "#/verify",
 		testTransport:            mockTransport,
-		DomainName:               domain,
+		HTTPCookieDomain:         domain,
 	}
 	server, err := RunServer(&config)
 	require.Nil(t, err, "run server")

--- a/pkg/mc/orm/server.go
+++ b/pkg/mc/orm/server.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"reflect"
 	"strconv"
@@ -109,7 +110,7 @@ type ServerConfig struct {
 	AlertMgrAddr             string
 	AlertmgrResolveTimout    time.Duration
 	UsageCheckpointInterval  string
-	DomainName               string
+	HTTPCookieDomain         string
 	StaticDir                string
 	DeploymentName           string
 	DeploymentTag            string
@@ -196,6 +197,11 @@ func RunServer(config *ServerConfig) (retserver *Server, reterr error) {
 		if !strings.HasSuffix(config.ConsoleAddr, "/") {
 			config.ConsoleAddr = config.ConsoleAddr + "/"
 		}
+		u, err := url.Parse(config.ConsoleAddr)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse URL %s for consoleAddr", config.ConsoleAddr)
+		}
+		config.HTTPCookieDomain = strings.Split(u.Host, ":")[0]
 	}
 	if config.PublicAddr != "" {
 		if !strings.HasPrefix(config.PublicAddr, "http") {

--- a/pkg/mc/orm/user.go
+++ b/pkg/mc/orm/user.go
@@ -255,7 +255,7 @@ func Login(c echo.Context) error {
 		}
 	}
 
-	cookie, err := GenerateCookie(&user, login.ApiKeyId, serverConfig.DomainName, config)
+	cookie, err := GenerateCookie(&user, login.ApiKeyId, serverConfig.HTTPCookieDomain, config)
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelApi, "failed to generate cookie", "err", err)
 		return fmt.Errorf("Failed to generate cookie")
@@ -335,7 +335,7 @@ func RefreshAuthCookie(c echo.Context) error {
 		log.SpanLog(ctx, log.DebugLevelApi, "failed to generate cookie", "err", err)
 		return fmt.Errorf("Failed to generate cookie")
 	}
-	httpCookie := NewHTTPAuthCookie(cookie, claims.ExpiresAt, serverConfig.DomainName)
+	httpCookie := NewHTTPAuthCookie(cookie, claims.ExpiresAt, serverConfig.HTTPCookieDomain)
 	c.SetCookie(httpCookie)
 	return c.JSON(http.StatusOK, ormutil.M{"token": cookie})
 }


### PR DESCRIPTION
The "domain" on the http cookie was incorrectly being set to "mc.<domain>". The domain really should be "console.<domain>", because the domain attached to the http cookie must match the domain that the console will send api requests to (which ends up being console.<domain>, not mc.<domain>).

This issue does not affect r3.0 hf5 since at that point it wasn't using http cookies yet, it was managing the jwt token itself.