### PR TITLE
move federation api structs to common api path

### DIFF
--- a/api/fedapi/api.go
+++ b/api/fedapi/api.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package federation
+package fedapi
 
 // Federation API Standard Definitions
 // ===================================


### PR DESCRIPTION
This just moves the EWBI (east-west bound interface) federation API structs to the common api path under /api/fedapi, to be consistent with the other API structs under /api.

The federation code and API handlers remain in the same place, although a lot of them will be updated to the newer version of the API soon.

There are no logical changes here, just a file move and update of references.