### PR TITLE
controller dummy server support inject/evict

### DIFF
--- a/test/testutil/cloudlet_testutil.go
+++ b/test/testutil/cloudlet_testutil.go
@@ -1707,6 +1707,7 @@ func (s *DummyServer) InjectCloudletInfo(ctx context.Context, in *edgeproto.Clou
 	if s.CudNoop {
 		return &edgeproto.Result{}, nil
 	}
+	s.CloudletInfoCache.Update(ctx, in, 0)
 	return &edgeproto.Result{}, nil
 }
 
@@ -1714,6 +1715,7 @@ func (s *DummyServer) EvictCloudletInfo(ctx context.Context, in *edgeproto.Cloud
 	if s.CudNoop {
 		return &edgeproto.Result{}, nil
 	}
+	s.CloudletInfoCache.Delete(ctx, in, 0)
 	return &edgeproto.Result{}, nil
 }
 

--- a/test/testutil/device_testutil.go
+++ b/test/testutil/device_testutil.go
@@ -347,6 +347,7 @@ func (s *DummyServer) InjectDevice(ctx context.Context, in *edgeproto.Device) (*
 	if s.CudNoop {
 		return &edgeproto.Result{}, nil
 	}
+	s.DeviceCache.Update(ctx, in, 0)
 	return &edgeproto.Result{}, nil
 }
 
@@ -378,6 +379,7 @@ func (s *DummyServer) EvictDevice(ctx context.Context, in *edgeproto.Device) (*e
 	if s.CudNoop {
 		return &edgeproto.Result{}, nil
 	}
+	s.DeviceCache.Delete(ctx, in, 0)
 	return &edgeproto.Result{}, nil
 }
 

--- a/tools/protoc-gen-test/testcud.go
+++ b/tools/protoc-gen-test/testcud.go
@@ -898,6 +898,12 @@ func (t *TestCud) getMethodArgs(service string, method *descriptor.MethodDescrip
 		} else if strings.HasPrefix(*method.Name, "Update") {
 			args.CacheFunc = "Update"
 			cud = true
+		} else if strings.HasPrefix(*method.Name, "Evict") {
+			args.CacheFunc = "Delete"
+			cud = true
+		} else if strings.HasPrefix(*method.Name, "Inject") {
+			args.CacheFunc = "Update"
+			cud = true
 		}
 	}
 	args.OutData = "*" + args.Pkg + "." + args.OutName


### PR DESCRIPTION
Support inject/evict commands for the controller dummy server, for unit testing.

Inject/Evict are just like create/delete, but named as such because they are "debug" commands that are admin-only, and potentially can cause data inconsistencies if used incorrectly.