### PR TITLE
k8s-operator missing namespaces create

### DIFF
--- a/pkg/platform/k8s-operator/k8sop-appinst.go
+++ b/pkg/platform/k8s-operator/k8sop-appinst.go
@@ -34,6 +34,10 @@ func (s *K8sOperator) CreateAppInst(ctx context.Context, clusterInst *edgeproto.
 
 	updateCallback(edgeproto.UpdateTask, "Creating Registry Secret")
 	for _, imagePath := range names.ImagePaths {
+		err = k8smgmt.CreateAllNamespaces(ctx, client, names)
+		if err != nil {
+			return err
+		}
 		err = infracommon.CreateDockerRegistrySecret(ctx, client, k8smgmt.GetKconfName(clusterInst), imagePath, s.CommonPf.PlatformConfig.AccessApi, names, nil)
 		if err != nil {
 			return err


### PR DESCRIPTION
The k8s-operator platform was missing the create of namespaces. This is copied from same appinst create code in k8s-baremetal.