### PR TITLE
Pass along chef server path to platform init

### DIFF
--- a/cmd/crm/main.go
+++ b/cmd/crm/main.go
@@ -276,6 +276,7 @@ func main() {
 			AccessApi:           accessApi,
 			TrustPolicy:         cloudlet.TrustPolicy,
 			CacheDir:            *cacheDir,
+			ChefServerPath:      *chefServerPath,
 		}
 
 		conditionalInitRequired := true


### PR DESCRIPTION
### Description
Use chef server path from the command line to be passed to platform init.