### PR TITLE
vcd: don't delete image on appinst delete if upload disabled

### DIFF
--- a/pkg/platform/vcd/vcd-vapptemplate.go
+++ b/pkg/platform/vcd/vcd-vapptemplate.go
@@ -407,6 +407,10 @@ func (v *VcdPlatform) DeleteImage(ctx context.Context, folder, image string) err
 		log.SpanLog(ctx, log.DebugLevelInfra, NoVCDClientInContext)
 		return fmt.Errorf(NoVCDClientInContext)
 	}
+	if !v.GetTemplateArtifactoryImportEnabled() {
+		log.SpanLog(ctx, log.DebugLevelInfra, "skipping template delete because import is disabled, delete manually if needed", "template", image)
+		return nil
+	}
 	err := v.DeleteTemplate(ctx, image, vcdClient)
 	if err != nil {
 		if strings.Contains(err.Error(), govcd.ErrorEntityNotFound.Error()) {


### PR DESCRIPTION
If uploading is disabled which requires manual uploading, also disable vcd apptemplate delete, otherwise recreating with the same will require manually uploading the same image again.