### PR TITLE
fix dme gateway json, allow fake cloudlets

### DIFF
--- a/pkg/cloudcommon/grpc.go
+++ b/pkg/cloudcommon/grpc.go
@@ -20,10 +20,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gogo/gateway"
-	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/tls"
+	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -63,16 +62,7 @@ func GrpcGateway(cfg *GrpcGWConfig) (http.Handler, error) {
 	if err != nil {
 		log.FatalLog("Failed to start REST gateway", "error", err)
 	}
-
-	jsonpb := &gateway.JSONPb{
-		EmitDefaults: true,
-		Indent:       " ",
-		OrigName:     true,
-	}
 	mux := gwruntime.NewServeMux(
-		// this avoids a marshaling issue with grpc-gateway and
-		// gogo protobuf non-nullable embedded structs
-		gwruntime.WithMarshalerOption(gwruntime.MIMEWildcard, jsonpb),
 		// this is necessary to get error details properly
 		// marshalled in unary requests
 		gwruntime.WithProtoErrorHandler(gwruntime.DefaultHTTPProtoErrorHandler),

--- a/pkg/mc/orm/authz_cloudlet.go
+++ b/pkg/mc/orm/authz_cloudlet.go
@@ -275,7 +275,7 @@ func authzCreateCloudlet(ctx context.Context, region, username string, obj *edge
 	if obj.SingleKubernetesClusterOwner != "" {
 		ops = append(ops, withReferenceOrg(obj.SingleKubernetesClusterOwner, "single kubernetes cluster owner", OrgTypeDeveloper))
 	}
-	if obj.PlatformType != edgeproto.PlatformType_PLATFORM_TYPE_EDGEBOX {
+	if obj.PlatformType != edgeproto.PlatformType_PLATFORM_TYPE_EDGEBOX && obj.PlatformType != edgeproto.PlatformType_PLATFORM_TYPE_FAKE {
 		ops = append(ops, withNoEdgeboxOnly())
 	}
 	return authorized(ctx, username, obj.Key.Organization, resource, action, ops...)

--- a/test/e2e-tests/pkg/e2e/dmeapi.go
+++ b/test/e2e-tests/pkg/e2e/dmeapi.go
@@ -272,7 +272,7 @@ func readMatchEngineStatus(filename string, mes *registration) error {
 	return ReadYamlFile(filename, &mes)
 }
 
-func RunDmeAPI(api string, procname string, apiFile string, apiFileVars map[string]string, apiType string, outputDir string) bool {
+func RunDmeAPI(api string, procname string, apiFile string, apiFileVars map[string]string, apiType string, outputDir string, mods []string) bool {
 	if apiFile == "" {
 		log.Println("Error: Cannot run DME APIs without API file")
 		return false
@@ -288,7 +288,14 @@ func RunDmeAPI(api string, procname string, apiFile string, apiFileVars map[stri
 	dme := GetDme(procname)
 	var client dmeClient
 
-	if apiType == "rest" {
+	rest := false
+	for _, mod := range mods {
+		if mod == "rest" {
+			rest = true
+		}
+	}
+
+	if rest || apiType == "rest" {
 		httpClient, err := dme.GetRestClient(apiConnectTimeout)
 		if err != nil {
 			log.Printf("Error: unable to connect to dme addr %v\n", dme.HttpAddr)

--- a/test/e2e-tests/pkg/e2e/setup-mex.go
+++ b/test/e2e-tests/pkg/e2e/setup-mex.go
@@ -817,7 +817,7 @@ func RunAction(ctx context.Context, actionSpec, outputDir string, config *TestCo
 			errs = append(errs, "controller RunCommand api failed")
 		}
 	case "dmeapi":
-		if !RunDmeAPI(actionSubtype, actionParam, spec.ApiFile, spec.ApiFileVars, spec.ApiType, outputDir) {
+		if !RunDmeAPI(actionSubtype, actionParam, spec.ApiFile, spec.ApiFileVars, spec.ApiType, outputDir, mods) {
 			log.Printf("Unable to run api for %s\n", action)
 			errs = append(errs, "dme api failed")
 		}

--- a/test/e2e-tests/testfiles/mc_add_delete.yml
+++ b/test/e2e-tests/testfiles/mc_add_delete.yml
@@ -77,6 +77,8 @@ tests:
 - includefile: mc_ratelimittest.yml
 
 - includefile: find_cloudlet.yml
+- includefile: find_cloudlet.yml
+  mods: [rest]
 
 - name: sleep, allow time for metrics to collect
   actions: [sleep=3]


### PR DESCRIPTION
DME gateway json was failing because the marshaler was not honoring the custom enum marshaler/unmarshaler functions. Replaced the gogo jsonpb with the standard json implementation.

Also allow fake cloudlets to be created by unofficial operator orgs for acceptance testing.