### PR TITLE
allow multiple dns zones for backwards compatibility

### DIFF
--- a/cmd/controller/cloudlet_api.go
+++ b/cmd/controller/cloudlet_api.go
@@ -248,7 +248,7 @@ func (s *StreamObjApi) StreamCloudlet(key *edgeproto.CloudletKey, cb edgeproto.S
 	if err != nil {
 		return fmt.Errorf("Failed to get platform: %v", err)
 	}
-	accessApi := accessapi.NewVaultClient(cloudlet, vaultConfig, *region)
+	accessApi := accessapi.NewVaultClient(cloudlet, vaultConfig, *region, *dnsZone)
 	updatecb := updateCloudletCallback{cloudlet, cb}
 	err = cloudletPlatform.GetRestrictedCloudletStatus(ctx, cloudlet, pfConfig, accessApi, updatecb.cb)
 	if err != nil {
@@ -749,7 +749,7 @@ func (s *CloudletApi) createCloudletInternal(cctx *CallContext, in *edgeproto.Cl
 	} else {
 		// Some platform types require caches
 		caches := s.getCaches(ctx, &vmPool)
-		accessApi := accessapi.NewVaultClient(in, vaultConfig, *region)
+		accessApi := accessapi.NewVaultClient(in, vaultConfig, *region, *dnsZone)
 		cloudletResourcesCreated, err = cloudletPlatform.CreateCloudlet(ctx, in, pfConfig, &pfFlavor, caches, accessApi, updatecb.cb)
 	}
 
@@ -1486,7 +1486,7 @@ func (s *CloudletApi) PlatformDeleteCloudlet(in *edgeproto.Cloudlet, cb edgeprot
 
 	// Some platform types require caches
 	caches := s.getCaches(ctx, &vmPool)
-	accessApi := accessapi.NewVaultClient(in, vaultConfig, *region)
+	accessApi := accessapi.NewVaultClient(in, vaultConfig, *region, *dnsZone)
 	return cloudletPlatform.DeleteCloudlet(ctx, in, pfConfig, caches, accessApi, updatecb.cb)
 }
 
@@ -2008,7 +2008,7 @@ func (s *CloudletApi) GetCloudletManifest(ctx context.Context, key *edgeproto.Cl
 	if err != nil {
 		return nil, err
 	}
-	accessApi := accessapi.NewVaultClient(cloudlet, vaultConfig, *region)
+	accessApi := accessapi.NewVaultClient(cloudlet, vaultConfig, *region, *dnsZone)
 	cloudletPlatform, err := pfutils.GetPlatform(ctx, cloudlet.PlatformType.String(), nodeMgr.UpdateNodeProps)
 	if err != nil {
 		return nil, err

--- a/cmd/controller/cloudletaccess_api.go
+++ b/cmd/controller/cloudletaccess_api.go
@@ -98,7 +98,7 @@ func (s *CloudletApi) GetAccessData(ctx context.Context, req *edgeproto.AccessDa
 	if !s.all.cloudletApi.cache.Get(&verified.Key, cloudlet) {
 		return nil, verified.Key.NotFoundError()
 	}
-	vaultClient := accessapi.NewVaultClient(cloudlet, vaultConfig, *region)
-	handler := accessapi.NewControllerHandler(vaultClient, *dnsZone)
+	vaultClient := accessapi.NewVaultClient(cloudlet, vaultConfig, *region, *dnsZone)
+	handler := accessapi.NewControllerHandler(vaultClient)
 	return handler.GetAccessData(ctx, req)
 }

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -88,7 +88,7 @@ var checkpointInterval = flag.String("checkpointInterval", "MONTH", "Interval at
 var appDNSRoot = flag.String("appDNSRoot", "appdnsroot.net", "App domain name root")
 var requireNotifyAccessKey = flag.Bool("requireNotifyAccessKey", false, "Require AccessKey authentication on notify API")
 var thanosRecvAddr = flag.String("thanosRecvAddr", "", "Address of thanos receive API endpoint including port")
-var dnsZone = flag.String("dnsZone", "", "dns zone for DNS update requests")
+var dnsZone = flag.String("dnsZone", "", "comma separated list of allowed dns zones for DNS update requests")
 
 var ControllerId = ""
 var InfluxDBName = cloudcommon.DeveloperMetricsDbName

--- a/cmd/dme/dme-main.go
+++ b/cmd/dme/dme-main.go
@@ -743,7 +743,7 @@ func main() {
 		cloudlet := &edgeproto.Cloudlet{
 			Key: dmecommon.MyCloudletKey,
 		}
-		accessApi = accessapi.NewVaultClient(cloudlet, nodeMgr.VaultConfig, *region)
+		accessApi = accessapi.NewVaultClient(cloudlet, nodeMgr.VaultConfig, *region, "")
 	}
 
 	var getPublicCertApi cloudcommon.GetPublicCertApi

--- a/pkg/accessapi-cloudlet/controllerclient.go
+++ b/pkg/accessapi-cloudlet/controllerclient.go
@@ -134,9 +134,8 @@ func (s *ControllerClient) GetPublicCert(ctx context.Context, commonName string)
 	return pubcert, err
 }
 
-func (s *ControllerClient) CreateOrUpdateDNSRecord(ctx context.Context, zone, name, rtype, content string, ttl int, proxy bool) error {
+func (s *ControllerClient) CreateOrUpdateDNSRecord(ctx context.Context, name, rtype, content string, ttl int, proxy bool) error {
 	record := platform.DNSRequest{
-		Zone:    zone,
 		Name:    name,
 		RType:   rtype,
 		Content: content,
@@ -155,9 +154,8 @@ func (s *ControllerClient) CreateOrUpdateDNSRecord(ctx context.Context, zone, na
 	return err
 }
 
-func (s *ControllerClient) GetDNSRecords(ctx context.Context, zone, fqdn string) ([]cloudflare.DNSRecord, error) {
+func (s *ControllerClient) GetDNSRecords(ctx context.Context, fqdn string) ([]cloudflare.DNSRecord, error) {
 	record := platform.DNSRequest{
-		Zone: zone,
 		Name: fqdn,
 	}
 	data, err := json.Marshal(record)
@@ -180,9 +178,8 @@ func (s *ControllerClient) GetDNSRecords(ctx context.Context, zone, fqdn string)
 	return records, nil
 }
 
-func (s *ControllerClient) DeleteDNSRecord(ctx context.Context, zone, recordID string) error {
+func (s *ControllerClient) DeleteDNSRecord(ctx context.Context, recordID string) error {
 	record := platform.DNSRequest{
-		Zone: zone,
 		Name: recordID,
 	}
 	data, err := json.Marshal(record)

--- a/pkg/accessapi/controllerhandler.go
+++ b/pkg/accessapi/controllerhandler.go
@@ -28,13 +28,11 @@ import (
 // to the VaultClient to access data from Vault.
 type ControllerHandler struct {
 	vaultClient *VaultClient
-	dnsZone     string
 }
 
-func NewControllerHandler(vaultClient *VaultClient, dnsZone string) *ControllerHandler {
+func NewControllerHandler(vaultClient *VaultClient) *ControllerHandler {
 	return &ControllerHandler{
 		vaultClient: vaultClient,
-		dnsZone:     dnsZone,
 	}
 }
 
@@ -84,7 +82,7 @@ func (s *ControllerHandler) GetAccessData(ctx context.Context, req *edgeproto.Ac
 		if err != nil {
 			return nil, err
 		}
-		err = s.vaultClient.CreateOrUpdateDNSRecord(ctx, s.dnsZone, dnsReq.Name, dnsReq.RType, dnsReq.Content, dnsReq.TTL, dnsReq.Proxy)
+		err = s.vaultClient.CreateOrUpdateDNSRecord(ctx, dnsReq.Name, dnsReq.RType, dnsReq.Content, dnsReq.TTL, dnsReq.Proxy)
 		if err != nil {
 			return nil, err
 		}
@@ -94,7 +92,7 @@ func (s *ControllerHandler) GetAccessData(ctx context.Context, req *edgeproto.Ac
 		if err != nil {
 			return nil, err
 		}
-		records, err := s.vaultClient.GetDNSRecords(ctx, s.dnsZone, dnsReq.Name)
+		records, err := s.vaultClient.GetDNSRecords(ctx, dnsReq.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -105,7 +103,7 @@ func (s *ControllerHandler) GetAccessData(ctx context.Context, req *edgeproto.Ac
 		if err != nil {
 			return nil, err
 		}
-		err = s.vaultClient.DeleteDNSRecord(ctx, dnsReq.Zone, dnsReq.Name)
+		err = s.vaultClient.DeleteDNSRecord(ctx, dnsReq.Name)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/accessapi/vaultclient.go
+++ b/pkg/accessapi/vaultclient.go
@@ -47,13 +47,15 @@ type VaultClient struct {
 	vaultConfig   *vault.Config
 	region        string
 	cloudflareApi *cloudflare.API
+	dnsZones      []string
 }
 
-func NewVaultClient(cloudlet *edgeproto.Cloudlet, vaultConfig *vault.Config, region string) *VaultClient {
+func NewVaultClient(cloudlet *edgeproto.Cloudlet, vaultConfig *vault.Config, region string, dnsZones string) *VaultClient {
 	return &VaultClient{
 		cloudlet:    cloudlet,
 		vaultConfig: vaultConfig,
 		region:      region,
+		dnsZones:    strings.Split(dnsZones, ","),
 	}
 }
 
@@ -149,31 +151,31 @@ func (s *VaultClient) getCloudflareApi() (*cloudflare.API, error) {
 	return cloudflareApi, nil
 }
 
-func (s *VaultClient) CreateOrUpdateDNSRecord(ctx context.Context, zone, name, rtype, content string, ttl int, proxy bool) error {
+func (s *VaultClient) CreateOrUpdateDNSRecord(ctx context.Context, name, rtype, content string, ttl int, proxy bool) error {
 	api, err := s.getCloudflareApi()
 	if err != nil {
 		return err
 	}
 	// TODO: validate parameters are ok for this cloudlet
-	return cloudflaremgmt.CreateOrUpdateDNSRecord(ctx, api, zone, name, rtype, content, ttl, proxy)
+	return cloudflaremgmt.CreateOrUpdateDNSRecord(ctx, api, s.dnsZones, name, rtype, content, ttl, proxy)
 }
 
-func (s *VaultClient) GetDNSRecords(ctx context.Context, zone, fqdn string) ([]cloudflare.DNSRecord, error) {
+func (s *VaultClient) GetDNSRecords(ctx context.Context, fqdn string) ([]cloudflare.DNSRecord, error) {
 	api, err := s.getCloudflareApi()
 	if err != nil {
 		return nil, err
 	}
 	// TODO: validate parameters are ok for this cloudlet
-	return cloudflaremgmt.GetDNSRecords(ctx, api, zone, fqdn)
+	return cloudflaremgmt.GetDNSRecords(ctx, api, s.dnsZones, fqdn)
 }
 
-func (s *VaultClient) DeleteDNSRecord(ctx context.Context, zone, recordID string) error {
+func (s *VaultClient) DeleteDNSRecord(ctx context.Context, recordID string) error {
 	api, err := s.getCloudflareApi()
 	if err != nil {
 		return err
 	}
 	// TODO: validate parameters are ok for this cloudlet
-	return cloudflaremgmt.DeleteDNSRecord(ctx, api, zone, recordID)
+	return cloudflaremgmt.DeleteDNSRecord(ctx, api, s.dnsZones, recordID)
 }
 
 func (s *VaultClient) GetSessionTokens(ctx context.Context, arg []byte) (map[string]string, error) {

--- a/pkg/cloudflaremgmt/dns_test.go
+++ b/pkg/cloudflaremgmt/dns_test.go
@@ -67,7 +67,7 @@ func TestGetDNSRecords(t *testing.T) {
 		return
 	}
 	// XXX not sure if domain is zone or name, but guessing zone
-	recs, err := GetDNSRecords(ctx, testapi, domain, "")
+	recs, err := GetDNSRecords(ctx, testapi, []string{domain}, "")
 	if err != nil {
 		t.Errorf("can not get dns records for %s, %v", domain, err)
 	}
@@ -98,14 +98,14 @@ func TestCreateDNSRecord(t *testing.T) {
 		t.Errorf("should have failed")
 	}
 
-	recs, err := GetDNSRecords(ctx, testapi, domain, "")
+	recs, err := GetDNSRecords(ctx, testapi, []string{domain}, "")
 	if err != nil {
 		t.Errorf("can not get dns records for %s, %v", domain, err)
 	}
 
 	for _, rec := range recs {
 		if strings.HasPrefix(rec.Name, cname) {
-			err = DeleteDNSRecord(ctx, testapi, domain, rec.ID)
+			err = DeleteDNSRecord(ctx, testapi, []string{domain}, rec.ID)
 			if err != nil {
 				t.Errorf("cannot delete dns record id %s zone %s, %v", rec.ID, domain, err)
 			}

--- a/pkg/mc/orm/ctrl_test.go
+++ b/pkg/mc/orm/ctrl_test.go
@@ -3176,7 +3176,7 @@ func testEdgeboxOnlyCloudletCreate(t *testing.T, ctx context.Context, mcClient *
 				Name:         "cl1",
 				Organization: operOrg.Name,
 			},
-			PlatformType: edgeproto.PlatformType_PLATFORM_TYPE_FAKE,
+			PlatformType: edgeproto.PlatformType_PLATFORM_TYPE_FAKEINFRA,
 		},
 	}
 	_, status, err = mcClient.CreateCloudlet(uri, token, &regCloudlet)

--- a/pkg/platform/common/infracommon/dns.go
+++ b/pkg/platform/common/infracommon/dns.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/edgexr/edge-cloud-platform/pkg/k8smgmt"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
+	"github.com/edgexr/edge-cloud-platform/pkg/k8smgmt"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	ssh "github.com/edgexr/golang-ssh"
 	v1 "k8s.io/api/core/v1"
@@ -116,7 +116,7 @@ func (c *CommonPlatform) CreateAppDNSAndPatchKubeSvc(ctx context.Context, client
 				dnsRecType = "CNAME"
 				mappedAddr = action.Hostname
 			}
-			if err := c.PlatformConfig.AccessApi.CreateOrUpdateDNSRecord(ctx, c.GetCloudletDNSZone(), fqdn, dnsRecType, mappedAddr, 1, false); err != nil {
+			if err := c.PlatformConfig.AccessApi.CreateOrUpdateDNSRecord(ctx, fqdn, dnsRecType, mappedAddr, 1, false); err != nil {
 				if testMode {
 					log.SpanLog(ctx, log.DebugLevelInfra, "ignoring dns error in testMode", "err", err)
 				} else {
@@ -166,13 +166,13 @@ func (c *CommonPlatform) DeleteAppDNS(ctx context.Context, client ssh.Client, ku
 
 func (c *CommonPlatform) DeleteDNSRecords(ctx context.Context, fqdn string) error {
 	log.SpanLog(ctx, log.DebugLevelInfra, "DeleteDNSRecords", "fqdn", fqdn)
-	recs, derr := c.PlatformConfig.AccessApi.GetDNSRecords(ctx, c.GetCloudletDNSZone(), fqdn)
+	recs, derr := c.PlatformConfig.AccessApi.GetDNSRecords(ctx, fqdn)
 	if derr != nil {
 		return fmt.Errorf("error getting dns records for %s, %v", c.GetCloudletDNSZone(), derr)
 	}
 	for _, rec := range recs {
 		if (rec.Type == "A" || rec.Type == "CNAME") && rec.Name == fqdn {
-			if err := c.PlatformConfig.AccessApi.DeleteDNSRecord(ctx, c.GetCloudletDNSZone(), rec.ID); err != nil {
+			if err := c.PlatformConfig.AccessApi.DeleteDNSRecord(ctx, rec.ID); err != nil {
 				return fmt.Errorf("cannot delete existing DNS record %v, %v", rec, err)
 			}
 			log.SpanLog(ctx, log.DebugLevelInfra, "deleted DNS record", "name", fqdn)

--- a/pkg/platform/common/infracommon/fqdn.go
+++ b/pkg/platform/common/infracommon/fqdn.go
@@ -75,5 +75,5 @@ func uri2fqdn(uri string) string {
 func (c *CommonPlatform) ActivateFQDNA(ctx context.Context, fqdn, addr string) error {
 
 	mappedAddr := c.GetMappedExternalIP(addr)
-	return c.PlatformConfig.AccessApi.CreateOrUpdateDNSRecord(ctx, c.GetCloudletDNSZone(), fqdn, "A", mappedAddr, 1, false)
+	return c.PlatformConfig.AccessApi.CreateOrUpdateDNSRecord(ctx, fqdn, "A", mappedAddr, 1, false)
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -190,9 +190,9 @@ type AccessApi interface {
 	GetSSHPublicKey(ctx context.Context) (string, error)
 	GetOldSSHKey(ctx context.Context) (*vault.MEXKey, error)
 	GetChefAuthKey(ctx context.Context) (*chefauth.ChefAuthKey, error)
-	CreateOrUpdateDNSRecord(ctx context.Context, zone, name, rtype, content string, ttl int, proxy bool) error
-	GetDNSRecords(ctx context.Context, zone, fqdn string) ([]cloudflare.DNSRecord, error)
-	DeleteDNSRecord(ctx context.Context, zone, recordID string) error
+	CreateOrUpdateDNSRecord(ctx context.Context, name, rtype, content string, ttl int, proxy bool) error
+	GetDNSRecords(ctx context.Context, fqdn string) ([]cloudflare.DNSRecord, error)
+	DeleteDNSRecord(ctx context.Context, recordID string) error
 	GetSessionTokens(ctx context.Context, arg []byte) (map[string]string, error)
 	GetKafkaCreds(ctx context.Context) (*node.KafkaCreds, error)
 	GetGCSCreds(ctx context.Context) ([]byte, error)
@@ -218,7 +218,6 @@ const (
 )
 
 type DNSRequest struct {
-	Zone    string
 	Name    string
 	RType   string
 	Content string


### PR DESCRIPTION
If the deployment's DNS zone needs to change, there is a transition period where existing objects continue to use the old domain and new objects use the new domain. In particular, the CRM on restart will attempt to update the DNS entry for the existing rootLBs. These rootLBs have fixed FQDNs saved on the cloudlet/cluster/appinst objects, so continue to use the old dns names. This means the CRM is requesting DNS updates (via the controller) for both the old dns zone and the new one. Thus the controller checks need to allow for such.
