### PR TITLE
custom cloudlet shared rootlb name for backwards compatibility

### DIFF
--- a/pkg/platform/common/infracommon/common-props.go
+++ b/pkg/platform/common/infracommon/common-props.go
@@ -54,6 +54,10 @@ var InfraCommonProps = map[string]*edgeproto.PropertyInfo{
 		Internal:    true,
 		Value:       "3600",
 	},
+	"MEX_SHARED_ROOTLB_NAME": {
+		Name:        "Shared rootLB name",
+		Description: "Used for backwards compatibility if appDnsRoot changes",
+	},
 }
 
 func (ip *InfraProperties) GetCloudletCRMGatewayIPAndPort() (string, int) {

--- a/pkg/platform/common/vmlayer/lb.go
+++ b/pkg/platform/common/vmlayer/lb.go
@@ -25,13 +25,13 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/platform"
 
 	valid "github.com/asaskevich/govalidator"
-	"github.com/edgexr/edge-cloud-platform/pkg/chefmgmt"
-	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/infracommon"
-	"github.com/edgexr/edge-cloud-platform/pkg/platform/pc"
-	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	dme "github.com/edgexr/edge-cloud-platform/api/dme-proto"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/chefmgmt"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/infracommon"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform/pc"
 	"github.com/edgexr/edge-cloud-platform/pkg/vmspec"
 
 	ssh "github.com/edgexr/golang-ssh"
@@ -277,7 +277,12 @@ func (v *VMPlatform) AttachAndEnableRootLBInterface(ctx context.Context, client 
 // the VM name the same, and only use the new RootLBFQDN name
 // for the DNS registration.
 func (v *VMPlatform) GetRootLBName(key *edgeproto.CloudletKey) string {
-	name := cloudcommon.GetRootLBFQDNOld(key, v.VMProperties.CommonPf.PlatformConfig.AppDNSRoot)
+	// If the appDnsRoot changes, the only way to point back
+	// to the original rootLB name is manually via this env var.
+	name, ok := v.VMProperties.CommonPf.Properties.GetValue("MEX_SHARED_ROOTLB_NAME")
+	if !ok || name == "" {
+		name = cloudcommon.GetRootLBFQDNOld(key, v.VMProperties.CommonPf.PlatformConfig.AppDNSRoot)
+	}
 	return v.VMProvider.NameSanitize(name)
 }
 


### PR DESCRIPTION
Add a cloudlet env var that allows for overriding the shared rootLB name. This is used if the appDnsRoot value changes, as it affects the name of the shared rootLB which is computed dynamically. If the appDnsRoot changes, then CRM will not be able to find the existing shared root LB. Although the CRM will create a new shared root LB, it currently does not have any code to repopulate the envoy proxies for existing AppInsts.

We should have a way to rebuild the rootLB properly, which is a better solution, but until then this allows the CRM to continue using the existing shared rootLB that has the correct envoy proxies set up.