### PR TITLE
federation associated orgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,7 @@ Infrastructure specific code is packaged under a plugin to allow for new infrast
 - Google Cloud Platform (GCP) GKE
 - K8S Bare Metal (primarily but not limited to Google Anthos)
 - Microsoft Azure Kubernetes Service (AKS)
+
+## Federation
+
+Refer to [Federation README](pkg/mc/federation/README.md)

--- a/api/ormapi/api.comments.go
+++ b/api/ormapi/api.comments.go
@@ -534,8 +534,8 @@ var GenerateReportComments = map[string]string{
 
 var FederationProviderComments = map[string]string{
 	"id":                            `Unique ID`,
-	"name":                          `Name to describe this provider`,
-	"operatorid":                    `Operator Organization`,
+	"name":                          `Unique name of this provider, will be used as a developer org name for consumer's images and apps`,
+	"operatorid":                    `Operator Organization that provides the resources`,
 	"regions":                       `Regions from which to provide resources`,
 	"federationcontextid":           `The federation context id we generated for this federation`,
 	"myinfo.federationid":           `Globally unique string used to indentify a federation operator`,
@@ -571,11 +571,10 @@ var FederationProviderInfoComments = map[string]string{
 
 var FederationConsumerComments = map[string]string{
 	"id":                            `Unique ID`,
-	"name":                          `Name to describe this consumer`,
-	"operatorid":                    `Operator Organization`,
+	"name":                          `Unique name of this consumer, will be used as an operator org for provider's zones`,
+	"operatorid":                    `Operator Organization that establishes the federation with a provider`,
 	"partneraddr":                   `Partner Address`,
 	"partnertokenurl":               `Partner token URL`,
-	"region":                        `Region in which partner zones will be created as cloudlets and whose apps will be mirrored to federation partner`,
 	"federationcontextid":           `Federation context id returned by partner`,
 	"myinfo.federationid":           `Globally unique string used to indentify a federation operator`,
 	"myinfo.countrycode":            `ISO 3166-1 Alpha-2 code for the country where operator platform is located`,
@@ -592,6 +591,7 @@ var FederationConsumerComments = map[string]string{
 	"partnerinfo.discoveryendpoint": `IP and Port of discovery service URL of operator platform`,
 	"partnerinfo.initialdate":       `Initial create time to denote time zone`,
 	"autoregisterzones":             `Automatically register any zone shared with me`,
+	"autoregisterregion":            `Region used for automatically registered zones`,
 	"status":                        `Status`,
 	"providerclientid":              `Auth ClientId for connecting to provider`,
 	"providerclientkey":             `Auth ClientKey for connection to provider (stored in secret storage)`,
@@ -637,19 +637,19 @@ var ConsumerZoneComments = map[string]string{
 	"zoneid":           `Zone unique name`,
 	"consumername":     `Name of the Federation consumer`,
 	"operatorid":       `Consumer operator organization`,
+	"region":           `Region in which zone is instantiated`,
 	"geolocation":      `GPS co-ordinates associated with the zone (in decimal format)`,
 	"geographydetails": `Geography details`,
 	"status":           `Zone status`,
 }
 
 var FederatedZoneRegRequestComments = map[string]string{
-	"operatorid":   `Operator organization`,
 	"consumername": `Federation consumer name`,
+	"region":       `Region to create local cloudlet versions of provider zones`,
 	"zones":        `Partner federator zones to be registered/deregistered`,
 }
 
 var FederatedZoneShareRequestComments = map[string]string{
-	"operatorid":   `Operator organization`,
 	"providername": `Federation provider name`,
 	"zones":        `Self federator zones to be shared/unshared`,
 }

--- a/pkg/mc/federation/README.md
+++ b/pkg/mc/federation/README.md
@@ -31,8 +31,15 @@ Notes:
 - FederationProvider is multi-region
    - Cloudlets can be shared as zones from regions configured on the FederationProvider
    - App definitions sent by the Consumer to the Provider will be created on every region configured on the Provider
-- FederationConsumer is single region
-   - Cloudlets that are created on the consumer to represent Provider Zones are created in the single region configured on the FederationConsumer
+- FederationConsumer is multi-region
+   - Each zone can be registered to a specific region as a Cloudlet
+
+## Organizations
+
+- Creating a FederationProvider also creates a developer organization of the same name
+   - The federation developer org is used to house images (files), artefacts, apps, and app instances sent by the partner
+- Creating a FederationConsumer also creates an operator organization of the same name
+   - The federation operator org is used to house cloudlets corresponding to partner zones
 
 ## Authentication
 

--- a/pkg/mc/federation/fed_appinst.go
+++ b/pkg/mc/federation/fed_appinst.go
@@ -34,7 +34,7 @@ func (p *PartnerApi) InstallApp(c echo.Context, fedCtxId FederationContextId) er
 	}
 
 	// lookup zone to make sure zone is shared
-	zone, err := p.LookupProviderZone(ctx, provider.Name, in.ZoneInfo.ZoneId, provider.OperatorId)
+	zone, err := p.LookupProviderZone(ctx, provider.Name, in.ZoneInfo.ZoneId)
 	if err != nil {
 		return err
 	}

--- a/pkg/mc/federation/federation_op.go
+++ b/pkg/mc/federation/federation_op.go
@@ -579,7 +579,7 @@ func (p *PartnerApi) AddConsumerZones(ctx context.Context, consumer *ormapi.Fede
 	}
 
 	if consumer.AutoRegisterZones {
-		regErr := p.RegisterConsumerZones(ctx, consumer, consumer.Region, createdZones)
+		regErr := p.RegisterConsumerZones(ctx, consumer, consumer.AutoRegisterRegion, createdZones)
 		if regErr != nil {
 			// don't fail, just log that registration will need
 			// to be done manually

--- a/pkg/mcctl/ormctl/federation.go
+++ b/pkg/mcctl/ormctl/federation.go
@@ -234,7 +234,7 @@ func init() {
 			Use:          "deregister",
 			Short:        "DeRegister Partner Federator Zone",
 			SpecialArgs:  &RegisterZoneSpecialArgs,
-			RequiredArgs: strings.Join(RegisterZoneRequiredArgs, " "),
+			RequiredArgs: strings.Join(DeregisterZoneRequiredArgs, " "),
 			Comments:     ormapi.FederatedZoneRegRequestComments,
 			ReqData:      &ormapi.FederatedZoneRegRequest{},
 			ReplyData:    &ormapi.Result{},
@@ -316,7 +316,6 @@ var ProviderZoneBaseSpecialArgs = map[string]string{
 }
 
 var ShareZoneRequiredArgs = []string{
-	"operatorid",
 	"providername",
 	"zones",
 }
@@ -336,13 +335,13 @@ var FederationConsumerRequiredArgs = []string{
 	"name",
 	"operatorid",
 	"partneraddr",
-	"region",
 	"providerclientid",
 	"providerclientkey",
 }
 
 var FederationConsumerOptionalArgs = []string{
 	"autoregisterzones",
+	"autoregisterregion",
 	"partnertokenurl",
 	"myinfo.countrycode",
 	"myinfo.mcc",
@@ -362,7 +361,6 @@ var FederationConsumerShowArgs = []string{
 	"name",
 	"operatorid",
 	"partneraddr",
-	"region",
 	"federationcontextid",
 	"myinfo.federationid",
 	"myinfo.countrycode",
@@ -382,7 +380,12 @@ var FederationConsumerShowArgs = []string{
 }
 
 var RegisterZoneRequiredArgs = []string{
-	"operatorid",
+	"consumername",
+	"region",
+	"zones",
+}
+
+var DeregisterZoneRequiredArgs = []string{
 	"consumername",
 	"zones",
 }

--- a/test/e2e-tests/data/federation_consumers.yml
+++ b/test/e2e-tests/data/federation_consumers.yml
@@ -3,8 +3,8 @@ federationconsumers:
   operatorid: {{partnertag}}
   partneraddr: {{fedaddr}}
   partnertokenurl: {{tokenurl}}
-  region: {{region}}
   autoregisterzones: true
+  autoregisterregion: {{region}}
   providerclientid: set-by-mcapi.go
   providerclientkey: set-by-macpi.go
   myinfo:
@@ -16,8 +16,8 @@ federationconsumers:
   operatorid: {{partnertag}}
   partneraddr: {{fedaddr}}
   partnertokenurl: {{tokenurl}}
-  region: {{region}}
   autoregisterzones: true
+  autoregisterregion: {{region}}
   providerclientid: set-by-mcapi.go
   providerclientkey: set-by-macpi.go
   myinfo:

--- a/test/e2e-tests/data/federation_consumers_show.yml
+++ b/test/e2e-tests/data/federation_consumers_show.yml
@@ -18,7 +18,6 @@ federationconsumers:
   operatorid: partner1
   partneraddr: https://127.0.0.1:9801
   partnertokenurl: https://127.0.0.1:9900/oauth2/token
-  region: PA
   myinfo:
     countrycode: SA
     mcc: "456"
@@ -42,13 +41,13 @@ federationconsumers:
     - bar
     - foobar
   autoregisterzones: true
+  autoregisterregion: PA
   status: Registered
 - id: 2
   name: enterprise-partner1
   operatorid: partner1
   partneraddr: https://127.0.0.1:9801
   partnertokenurl: https://127.0.0.1:9900/oauth2/token
-  region: PA
   myinfo:
     countrycode: SA
     mcc: "456"
@@ -72,4 +71,5 @@ federationconsumers:
     - bar
     - foobar
   autoregisterzones: true
+  autoregisterregion: PA
   status: Registered

--- a/test/e2e-tests/data/federation_consumerzones_show.yml
+++ b/test/e2e-tests/data/federation_consumerzones_show.yml
@@ -16,30 +16,36 @@ consumerzones:
 - zoneid: dmuuscloud1
   consumername: dmuus-partner1
   operatorid: partner1
+  region: PA
   geolocation: 31,-91
   status: Registered
 - zoneid: dmuuscloud2
   consumername: dmuus-partner1
   operatorid: partner1
+  region: PA
   geolocation: 35,-95
   status: Registered
 - zoneid: dmuuscloud3
   consumername: dmuus-partner1
   operatorid: partner1
+  region: PA
   geolocation: 32,-92
   status: Registered
 - zoneid: dmuuscloud4
   consumername: dmuus-partner1
   operatorid: partner1
+  region: PA
   geolocation: 36,-96
   status: Registered
 - zoneid: enterprise1
   consumername: enterprise-partner1
   operatorid: partner1
+  region: PA
   geolocation: 31,-91
   status: Registered
 - zoneid: enterprise2
   consumername: enterprise-partner1
   operatorid: partner1
+  region: PA
   geolocation: 31,-91
   status: Registered

--- a/test/e2e-tests/data/federation_consumerzones_unreg_show.yml
+++ b/test/e2e-tests/data/federation_consumerzones_unreg_show.yml
@@ -16,30 +16,36 @@ consumerzones:
 - zoneid: dmuuscloud1
   consumername: dmuus-partner1
   operatorid: partner1
+  region: PA
   geolocation: 31,-91
   status: Unregistered
 - zoneid: dmuuscloud2
   consumername: dmuus-partner1
   operatorid: partner1
+  region: PA
   geolocation: 35,-95
   status: Unregistered
 - zoneid: dmuuscloud3
   consumername: dmuus-partner1
   operatorid: partner1
+  region: PA
   geolocation: 32,-92
   status: Unregistered
 - zoneid: dmuuscloud4
   consumername: dmuus-partner1
   operatorid: partner1
+  region: PA
   geolocation: 36,-96
   status: Unregistered
 - zoneid: enterprise1
   consumername: enterprise-partner1
   operatorid: partner1
+  region: PA
   geolocation: 31,-91
   status: Unregistered
 - zoneid: enterprise2
   consumername: enterprise-partner1
   operatorid: partner1
+  region: PA
   geolocation: 31,-91
   status: Unregistered

--- a/test/e2e-tests/data/federation_show_partner1_cloudlets.yml
+++ b/test/e2e-tests/data/federation_show_partner1_cloudlets.yml
@@ -15,11 +15,21 @@
 controllers:
 - region: PA
 orgs:
+- name: dmuus-partner1
+  type: operator
+- name: enterprise-partner1
+  type: operator
 - name: partner1
   type: operator
   address: mobiledgex
   phone: 123-123-1234
 roles:
+- org: dmuus-partner1
+  username: fedop
+  role: OperatorManager
+- org: enterprise-partner1
+  username: fedop
+  role: OperatorManager
 - org: partner1
   username: fedop
   role: OperatorManager
@@ -44,9 +54,9 @@ regiondata:
       disk: 1
     cloudlets:
     - key:
-        organization: partner1
+        organization: dmuus-partner1
         name: dmuuscloud1
-        federatedorganization: dmuus-partner1
+        federatedorganization: partner1
       location:
         latitude: 31
         longitude: -91
@@ -65,15 +75,15 @@ regiondata:
       - name: RAM
         value: 409600
       defaultresourcealertthreshold: 80
-      dnslabel: dmuuscloud1-partner1
-      rootlbfqdn: shared.dmuuscloud1-partner1.pa.edgecloude2e.net
+      dnslabel: dmuuscloud1-dmuus-partner1
+      rootlbfqdn: shared.dmuuscloud1-dmuus-partner1.pa.edgecloude2e.net
       federationconfig:
         partnerfederationaddr: https://127.0.0.1:9801
         federationdbid: 1
     - key:
-        organization: partner1
+        organization: dmuus-partner1
         name: dmuuscloud2
-        federatedorganization: dmuus-partner1
+        federatedorganization: partner1
       location:
         latitude: 35
         longitude: -95
@@ -92,15 +102,15 @@ regiondata:
       - name: RAM
         value: 40960
       defaultresourcealertthreshold: 80
-      dnslabel: dmuuscloud2-partner1
-      rootlbfqdn: shared.dmuuscloud2-partner1.pa.edgecloude2e.net
+      dnslabel: dmuuscloud2-dmuus-partner1
+      rootlbfqdn: shared.dmuuscloud2-dmuus-partner1.pa.edgecloude2e.net
       federationconfig:
         partnerfederationaddr: https://127.0.0.1:9801
         federationdbid: 1
     - key:
-        organization: partner1
+        organization: dmuus-partner1
         name: dmuuscloud3
-        federatedorganization: dmuus-partner1
+        federatedorganization: partner1
       location:
         latitude: 32
         longitude: -92
@@ -119,15 +129,15 @@ regiondata:
       - name: RAM
         value: 40960
       defaultresourcealertthreshold: 80
-      dnslabel: dmuuscloud3-partner1
-      rootlbfqdn: shared.dmuuscloud3-partner1.pa.edgecloude2e.net
+      dnslabel: dmuuscloud3-dmuus-partner1
+      rootlbfqdn: shared.dmuuscloud3-dmuus-partner1.pa.edgecloude2e.net
       federationconfig:
         partnerfederationaddr: https://127.0.0.1:9801
         federationdbid: 1
     - key:
-        organization: partner1
+        organization: dmuus-partner1
         name: dmuuscloud4
-        federatedorganization: dmuus-partner1
+        federatedorganization: partner1
       location:
         latitude: 36
         longitude: -96
@@ -146,15 +156,15 @@ regiondata:
       - name: RAM
         value: 40960
       defaultresourcealertthreshold: 80
-      dnslabel: dmuuscloud4-partner1
-      rootlbfqdn: shared.dmuuscloud4-partner1.pa.edgecloude2e.net
+      dnslabel: dmuuscloud4-dmuus-partner1
+      rootlbfqdn: shared.dmuuscloud4-dmuus-partner1.pa.edgecloude2e.net
       federationconfig:
         partnerfederationaddr: https://127.0.0.1:9801
         federationdbid: 1
     - key:
-        organization: partner1
+        organization: enterprise-partner1
         name: enterprise1
-        federatedorganization: enterprise-partner1
+        federatedorganization: partner1
       location:
         latitude: 31
         longitude: -91
@@ -173,15 +183,15 @@ regiondata:
       - name: RAM
         value: 40960
       defaultresourcealertthreshold: 80
-      dnslabel: enterprise1-partner1
-      rootlbfqdn: shared.enterprise1-partner1.pa.edgecloude2e.net
+      dnslabel: enterprise1-enterprise-partner1
+      rootlbfqdn: shared.enterprise1-enterprise-partner1.pa.edgecloude2e.net
       federationconfig:
         partnerfederationaddr: https://127.0.0.1:9801
         federationdbid: 2
     - key:
-        organization: partner1
+        organization: enterprise-partner1
         name: enterprise2
-        federatedorganization: enterprise-partner1
+        federatedorganization: partner1
       location:
         latitude: 31
         longitude: -91
@@ -200,8 +210,8 @@ regiondata:
       - name: RAM
         value: 40960
       defaultresourcealertthreshold: 80
-      dnslabel: enterprise2-partner1
-      rootlbfqdn: shared.enterprise2-partner1.pa.edgecloude2e.net
+      dnslabel: enterprise2-enterprise-partner1
+      rootlbfqdn: shared.enterprise2-enterprise-partner1.pa.edgecloude2e.net
       federationconfig:
         partnerfederationaddr: https://127.0.0.1:9801
         federationdbid: 2
@@ -251,9 +261,9 @@ regiondata:
       rootlbfqdn: shared.partner1-cloud-2-partner1.pa.edgecloude2e.net
     cloudletinfos:
     - key:
-        organization: partner1
+        organization: dmuus-partner1
         name: dmuuscloud1
-        federatedorganization: dmuus-partner1
+        federatedorganization: partner1
       state: Ready
       flavors:
       - name: x1.tiny
@@ -265,9 +275,9 @@ regiondata:
         ram: 4096
         disk: 40
     - key:
-        organization: partner1
+        organization: dmuus-partner1
         name: dmuuscloud2
-        federatedorganization: dmuus-partner1
+        federatedorganization: partner1
       state: Ready
       flavors:
       - name: x1.tiny
@@ -279,9 +289,9 @@ regiondata:
         ram: 4096
         disk: 40
     - key:
-        organization: partner1
+        organization: dmuus-partner1
         name: dmuuscloud3
-        federatedorganization: dmuus-partner1
+        federatedorganization: partner1
       state: Ready
       flavors:
       - name: x1.tiny
@@ -293,9 +303,9 @@ regiondata:
         ram: 4096
         disk: 40
     - key:
-        organization: partner1
+        organization: dmuus-partner1
         name: dmuuscloud4
-        federatedorganization: dmuus-partner1
+        federatedorganization: partner1
       state: Ready
       flavors:
       - name: x1.tiny
@@ -307,9 +317,9 @@ regiondata:
         ram: 4096
         disk: 40
     - key:
-        organization: partner1
+        organization: enterprise-partner1
         name: enterprise1
-        federatedorganization: enterprise-partner1
+        federatedorganization: partner1
       state: Ready
       flavors:
       - name: x1.tiny
@@ -321,9 +331,9 @@ regiondata:
         ram: 4096
         disk: 40
     - key:
-        organization: partner1
+        organization: enterprise-partner1
         name: enterprise2
-        federatedorganization: enterprise-partner1
+        federatedorganization: partner1
       state: Ready
       flavors:
       - name: x1.tiny

--- a/test/e2e-tests/data/federation_show_partner1_fedorgs.yml
+++ b/test/e2e-tests/data/federation_show_partner1_fedorgs.yml
@@ -1,0 +1,138 @@
+# Copyright 2022 MobiledgeX, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+controllers:
+- region: PA
+orgs:
+- name: dmuus-partner1
+  type: operator
+- name: enterprise-partner1
+  type: operator
+- name: partner1
+  type: operator
+  address: mobiledgex
+  phone: 123-123-1234
+roles:
+- org: dmuus-partner1
+  username: fedop
+  role: OperatorManager
+- org: enterprise-partner1
+  username: fedop
+  role: OperatorManager
+- org: partner1
+  username: fedop
+  role: OperatorManager
+regiondata:
+- region: PA
+  appdata:
+    flavors:
+    - key:
+        name: x1.medium
+      ram: 4096
+      vcpus: 4
+      disk: 4
+    - key:
+        name: x1.small
+      ram: 2048
+      vcpus: 2
+      disk: 2
+    - key:
+        name: x1.tiny
+      ram: 1024
+      vcpus: 1
+      disk: 1
+    cloudlets:
+    - key:
+        organization: partner1
+        name: partner1-cloud-1
+      location:
+        latitude: 31
+        longitude: -91
+      ipsupport: Dynamic
+      numdynamicips: 254
+      state: Ready
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: partner1-cloud-1
+      containerversion: "2019-10-24"
+      deployment: docker
+      trustpolicystate: NotPresent
+      defaultresourcealertthreshold: 80
+      dnslabel: partner1-cloud-1-partner1
+      rootlbfqdn: shared.partner1-cloud-1-partner1.pa.edgecloude2e.net
+    - key:
+        organization: partner1
+        name: partner1-cloud-2
+      location:
+        latitude: 81
+        longitude: -11
+      ipsupport: Dynamic
+      numdynamicips: 254
+      state: Ready
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: partner1-cloud-2
+      containerversion: "2019-10-24"
+      deployment: docker
+      trustpolicystate: NotPresent
+      resourcequotas:
+      - name: RAM
+        alertthreshold: 50
+      - name: vCPUs
+        value: 20
+        alertthreshold: 50
+      - name: External IPs
+        alertthreshold: 10
+      defaultresourcealertthreshold: 80
+      dnslabel: partner1-cloud-2-partner1
+      rootlbfqdn: shared.partner1-cloud-2-partner1.pa.edgecloude2e.net
+    cloudletinfos:
+    - key:
+        organization: partner1
+        name: partner1-cloud-1
+      state: Ready
+      osmaxram: 40960
+      osmaxvcores: 50
+      osmaxvolgb: 5000
+      flavors:
+      - name: x1.tiny
+        vcpus: 1
+        ram: 1024
+        disk: 20
+      - name: x1.small
+        vcpus: 2
+        ram: 4096
+        disk: 40
+      containerversion: "2019-10-24"
+      controllercachereceived: true
+      trustpolicystate: NotPresent
+    - key:
+        organization: partner1
+        name: partner1-cloud-2
+      state: Ready
+      osmaxram: 40960
+      osmaxvcores: 50
+      osmaxvolgb: 5000
+      flavors:
+      - name: x1.tiny
+        vcpus: 1
+        ram: 1024
+        disk: 20
+      - name: x1.small
+        vcpus: 2
+        ram: 4096
+        disk: 40
+      containerversion: "2019-10-24"
+      controllercachereceived: true
+      trustpolicystate: NotPresent

--- a/test/e2e-tests/pkg/e2e/mcapi.go
+++ b/test/e2e-tests/pkg/e2e/mcapi.go
@@ -1204,7 +1204,6 @@ func manageFederatorZoneData(mode, uri, token, tag string, data *ormapi.AllData,
 	case "share":
 		for ii, fd := range data.ProviderZones {
 			share := ormapi.FederatedZoneShareRequest{
-				OperatorId:   fd.OperatorId,
 				ProviderName: fd.ProviderName,
 				Zones:        []string{fd.ZoneId},
 			}
@@ -1214,7 +1213,6 @@ func manageFederatorZoneData(mode, uri, token, tag string, data *ormapi.AllData,
 	case "unshare":
 		for ii, fd := range data.ProviderZones {
 			share := ormapi.FederatedZoneShareRequest{
-				OperatorId:   fd.OperatorId,
 				ProviderName: fd.ProviderName,
 				Zones:        []string{fd.ZoneId},
 			}
@@ -1224,7 +1222,6 @@ func manageFederatorZoneData(mode, uri, token, tag string, data *ormapi.AllData,
 	case "register":
 		for ii, fd := range data.ConsumerZones {
 			req := ormapi.FederatedZoneRegRequest{
-				OperatorId:   fd.OperatorId,
 				ConsumerName: fd.ConsumerName,
 				Zones:        []string{fd.ZoneId},
 			}
@@ -1234,7 +1231,6 @@ func manageFederatorZoneData(mode, uri, token, tag string, data *ormapi.AllData,
 	case "deregister":
 		for ii, fd := range data.ConsumerZones {
 			req := ormapi.FederatedZoneRegRequest{
-				OperatorId:   fd.OperatorId,
 				ConsumerName: fd.ConsumerName,
 				Zones:        []string{fd.ZoneId},
 			}

--- a/test/e2e-tests/testfiles/federationtest.yml
+++ b/test/e2e-tests/testfiles/federationtest.yml
@@ -166,7 +166,7 @@ tests:
   curuserfile: '{{datadir2}}/mc_user_fedop.yml'
   compareyaml:
     yaml1: '{{outputdir}}/show-commands.yml'
-    yaml2: '{{datadir2}}/federation_show_partner1.yml'
+    yaml2: '{{datadir2}}/federation_show_partner1_fedorgs.yml'
     filetype: mcdata
 
 - name: delete federation consumers

--- a/test/testutil/test_data.go
+++ b/test/testutil/test_data.go
@@ -840,6 +840,9 @@ func GetAppInstRefsData() []edgeproto.AppInstRefs {
 		Insts: map[string]uint32{
 			appInstData[17].Key.GetKeyString(): 1,
 		},
+	}, { // edgeproto.AppInstRefs
+		Key:   appData[16].Key,
+		Insts: map[string]uint32{},
 	}}
 }
 


### PR DESCRIPTION
- Changes primary keys of FederationProvider and FederationConsumer from Name+OperatorID to just Name.
- Creation of FederationProvider/Consumer now also creates an associated org with the same name as the Provider/Consumer
- Associated org will be used to house images/artefacts/apps/appinsts (provider) or cloudlets (consumer) sent by remote partner to fit into our scheme of all objects belonging to an org.
- Consumer regions changed from single to multi by associating region with ConsumerZones instead of FederationConsumer
- Lots of upgrade functions to deal with changes to primary keys, column types, and constraints in federation tables. Tests to ensure constraints are correct after upgrade, or without upgrade, or when upgrade is run multiple times.