### PR TITLE
fix missing docker container ids for when using docker manifest

### DIFF
--- a/pkg/dockermgmt/dockerapp.go
+++ b/pkg/dockermgmt/dockerapp.go
@@ -445,14 +445,14 @@ func GetAppInstRuntime(ctx context.Context, client ssh.Client, app *edgeproto.Ap
 	cmd := fmt.Sprintf(`docker ps --format "{{.Names}}" --filter "label=%s=%s" --filter "label=%s=%s"`,
 		cloudcommon.MexAppNameLabel, nameLabelVal, cloudcommon.MexAppVersionLabel, versionLabelVal)
 	out, err := client.Output(cmd)
-	if err == nil {
+	if err == nil && len(out) > 0 {
 		for _, name := range strings.Split(out, "\n") {
 			name = strings.TrimSpace(name)
 			rt.ContainerIds = append(rt.ContainerIds, name)
 		}
 		return rt, nil
 	} else {
-		log.SpanLog(ctx, log.DebugLevelInfo, "GetAppInstRuntime cmd failed", "cmd", cmd, "err", err)
+		log.SpanLog(ctx, log.DebugLevelInfo, "GetAppInstRuntime cmd failed", "cmd", cmd, "out", out, "err", err)
 	}
 
 	// get the expected names if couldn't get it from the runtime


### PR DESCRIPTION
Fixes an issue where the docker container ids were missing when deploying a docker AppInst that uses a docker compose manifest file. In this case, the usual command we use to find the containers doesn't work because our labels are not present. This should then default to parsing the compose file, however the command doesn't actually fail (maybe we're using a different version of docker now where this changed), it just does not provide any output.
