### PR TITLE
add per-project api keys for harbor

### DIFF
--- a/pkg/accessapi/vaultclient.go
+++ b/pkg/accessapi/vaultclient.go
@@ -78,7 +78,7 @@ func (s *VaultClient) GetCloudletAccessVars(ctx context.Context) (map[string]str
 }
 
 func (s *VaultClient) GetRegistryAuth(ctx context.Context, imgUrl string) (*cloudcommon.RegistryAuth, error) {
-	return cloudcommon.GetRegistryAuth(ctx, imgUrl, s.vaultConfig)
+	return cloudcommon.GetRegistryAuth(ctx, imgUrl, cloudcommon.AllOrgs, s.vaultConfig)
 }
 
 func (s *VaultClient) SignSSHKey(ctx context.Context, publicKey string) (string, error) {

--- a/pkg/mc/orm/appstore_sync_test.go
+++ b/pkg/mc/orm/appstore_sync_test.go
@@ -489,7 +489,7 @@ func waitSyncCount(t *testing.T, sync *AppStoreSync, count int64) {
 
 func verifyVmRegistryApiKey(t *testing.T, ctx context.Context, serverConfig *ServerConfig, mcClient *mctestclient.Client, uri string) {
 	// verify vm registry api key
-	auth, err := cloudcommon.GetRegistryAuth(ctx, serverConfig.VmRegistryAddr, serverConfig.vaultConfig)
+	auth, err := cloudcommon.GetRegistryAuth(ctx, serverConfig.VmRegistryAddr, cloudcommon.AllOrgs, serverConfig.vaultConfig)
 	require.Nil(t, err)
 	require.Equal(t, cloudcommon.BasicAuth, auth.AuthType)
 	require.NotEmpty(t, auth.Username)

--- a/pkg/mc/orm/artifactory.go
+++ b/pkg/mc/orm/artifactory.go
@@ -49,7 +49,7 @@ func artifactoryClient(ctx context.Context) (*artifactory.Artifactory, error) {
 		return nil, fmt.Errorf("no artifactory addr specified")
 	}
 	if rtfAuth == nil {
-		auth, err := cloudcommon.GetRegistryAuth(ctx, serverConfig.ArtifactoryAddr, serverConfig.vaultConfig)
+		auth, err := cloudcommon.GetRegistryAuth(ctx, serverConfig.ArtifactoryAddr, cloudcommon.AllOrgs, serverConfig.vaultConfig)
 		if err != nil {
 			log.SpanLog(ctx, log.DebugLevelInfo, "Failed to fetch artifactory AuthKey from Vault",
 				"artifactoryAddr", serverConfig.ArtifactoryAddr,

--- a/pkg/mc/orm/vm_registry.go
+++ b/pkg/mc/orm/vm_registry.go
@@ -10,7 +10,7 @@ import (
 )
 
 func vmRegistryEnsureApiKey(ctx context.Context, username string) error {
-	auth, err := cloudcommon.GetRegistryAuth(ctx, serverConfig.VmRegistryAddr, serverConfig.vaultConfig)
+	auth, err := cloudcommon.GetRegistryAuth(ctx, serverConfig.VmRegistryAddr, cloudcommon.AllOrgs, serverConfig.vaultConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds per-project api keys (robot accounts) for harbor. This is to be used for allowing federation partners to download images from our container repository (harbor). Unfortunately harbor does not support any finer-grained access (i.e. per image version). That may be possible using OIDC in harbor, but MC currently doesn't support that, so this is a near-term compromise.
