### PR TITLE
fix app store sync test

### DIFF
--- a/pkg/mc/orm/harbor.go
+++ b/pkg/mc/orm/harbor.go
@@ -544,7 +544,7 @@ func harborEnsureRobotAccount(ctx context.Context, harborHostPort, org string) e
 	}
 	req.URL.Query().Add("service", "harbor-registry")
 	req.SetBasicAuth(auth.Username, auth.Password)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := harborClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/pkg/mc/orm/harbor_test.go
+++ b/pkg/mc/orm/harbor_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 type HarborMock struct {
+	bareAddr       string
 	addr           string
 	admin          string
 	password       string
@@ -32,6 +33,7 @@ type HarborMock struct {
 
 func NewHarborMock(addr string, tr *httpmock.MockTransport, admin, password string) *HarborMock {
 	hm := HarborMock{}
+	hm.bareAddr = addr
 	hm.addr = addr + "/api/v2.0"
 	hm.admin = admin
 	hm.password = password
@@ -180,6 +182,12 @@ func (s *HarborMock) registerProjects() {
 				proj.Metadata.Public = harborFalse
 			}
 			log.DebugLog(log.DebugLevelApi, "harbor mock update project", "project", nameOrId)
+			return httpmock.NewBytesResponse(200, []byte{}), nil
+		},
+	)
+	u = fmt.Sprintf(`%s/service/token`, s.bareAddr)
+	s.mockTransport.RegisterResponder("GET", u,
+		func(req *http.Request) (*http.Response, error) {
 			return httpmock.NewBytesResponse(200, []byte{}), nil
 		},
 	)


### PR DESCRIPTION
The app store sync test was timing out because the mock harbor was missing a handle for the newly added login check for org-based harbor robot accounts. 