### PR TITLE
mcctl token per address

### DIFF
--- a/pkg/mcctl/mccli/login.go
+++ b/pkg/mcctl/mccli/login.go
@@ -19,10 +19,11 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/edgexr/edge-cloud-platform/pkg/mcctl/ormctl"
 	"github.com/edgexr/edge-cloud-platform/api/ormapi"
 	"github.com/edgexr/edge-cloud-platform/pkg/cli"
+	"github.com/edgexr/edge-cloud-platform/pkg/mcctl/ormctl"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 )
 
 func (s *RootCommand) getLoginCmd() *cobra.Command {
@@ -61,7 +62,13 @@ func (s *RootCommand) runLogin(path string) func(c *cli.Command, args []string) 
 			return err
 		}
 		fmt.Fprintln(wr, "login successful")
-		err = ioutil.WriteFile(GetTokenFile(), []byte(token), 0600)
+		tokens := GetTokens()
+		tokens[s.getAddr()] = token
+		dat, err := yaml.Marshal(tokens)
+		if err != nil {
+			return err
+		}
+		err = ioutil.WriteFile(GetTokenFile(), dat, 0600)
 		if err != nil {
 			fmt.Fprintf(wr, "warning, cannot save token file %s, %v\n", GetTokenFile(), err)
 			fmt.Fprintf(wr, "token: %s\n", token)

--- a/tools/punisher/punisher.go
+++ b/tools/punisher/punisher.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -24,10 +23,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/edgexr/edge-cloud-platform/pkg/mcctl/mccli"
-	"github.com/edgexr/edge-cloud-platform/pkg/mcctl/mctestclient"
 	"github.com/edgexr/edge-cloud-platform/api/ormapi"
 	"github.com/edgexr/edge-cloud-platform/pkg/mc/ormclient"
+	"github.com/edgexr/edge-cloud-platform/pkg/mcctl/mccli"
+	"github.com/edgexr/edge-cloud-platform/pkg/mcctl/mctestclient"
 )
 
 var numThreads = flag.Int("numthreads", 2, "number of threads")
@@ -43,11 +42,8 @@ func main() {
 		*token = os.Getenv("TOKEN")
 	}
 	if *token == "" {
-		tok, err := ioutil.ReadFile(mccli.GetTokenFile())
-		if err != nil {
-			log.Fatal(err)
-		}
-		*token = strings.TrimSpace(string(tok))
+		tokens := mccli.GetTokens()
+		*token = tokens[*addr]
 	}
 	if *token == "" {
 		log.Fatal("please login via mcctl, or specify --token, or set TOKEN env var")


### PR DESCRIPTION
Change saved token file from a single token to a token per remote address. This allows the user to log in to different deployments from different terminals concurrently.
