### PR TITLE
Use tls by default for noreply email

### DIFF
--- a/pkg/cloudcommon/noreply.go
+++ b/pkg/cloudcommon/noreply.go
@@ -14,7 +14,7 @@ type EmailAccount struct {
 }
 
 func GetNoreply(vaultConfig *vault.Config) (*EmailAccount, error) {
-	noreply := EmailAccount{}
+	noreply := EmailAccount{SmtpTLS: true} // default tls to true
 	err := vault.GetData(vaultConfig,
 		"/secret/data/accounts/noreplyemail", 0, &noreply)
 	if err != nil {


### PR DESCRIPTION
### Description
We use to have an explicit tls=true in vault for noreply smtp settings, but no in the new deployments
However since golang smtp library doesn't allow auth smtp requests without tls(https://pkg.go.dev/net/smtp#PlainAuth), setting this setting to true by default seems like the correct way to handle this.
