### PR TITLE
Changed the comparison for the undeploy rule to be strict with respect to active connections

### DIFF
--- a/cmd/shepherd/shepherd_update_test.go
+++ b/cmd/shepherd/shepherd_update_test.go
@@ -155,7 +155,7 @@ scrape_configs:
 - name: autoprov-feature
   rules:
   - alert: AutoProvUndeploy
-    expr: envoy_cluster_upstream_cx_active{app="App",appver="",apporg=""} <= 3
+    expr: envoy_cluster_upstream_cx_active{app="App",appver="",apporg=""} < 3
     for: 15m
 `
 	require.Equal(t, expected, string(fileContents))
@@ -201,7 +201,7 @@ scrape_configs:
 - name: autoprov-feature
   rules:
   - alert: AutoProvUndeploy
-    expr: envoy_cluster_upstream_cx_active{app="App",appver="",apporg=""} <= 3
+    expr: envoy_cluster_upstream_cx_active{app="App",appver="",apporg=""} < 3
     for: 45s
 `
 	require.Equal(t, expected, string(fileContents))
@@ -226,7 +226,7 @@ scrape_configs:
 - name: autoprov-feature
   rules:
   - alert: AutoProvUndeploy
-    expr: envoy_cluster_upstream_cx_active{app="App",appver="",apporg=""} <= 5
+    expr: envoy_cluster_upstream_cx_active{app="App",appver="",apporg=""} < 5
     for: 45s
 `
 	require.Equal(t, expected, string(fileContents))

--- a/pkg/autorules/autoprovrules.go
+++ b/pkg/autorules/autoprovrules.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/edgexr/edge-cloud-platform/pkg/prommgmt"
-	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
+	"github.com/edgexr/edge-cloud-platform/pkg/prommgmt"
 	"github.com/prometheus/common/model"
 )
 
@@ -37,7 +37,7 @@ func GetAutoUndeployRules(ctx context.Context, settings edgeproto.Settings, appK
 		edgeproto.AppKeyTagName + `="` + appKey.Name + `",` +
 		edgeproto.AppKeyTagVersion + `="` + appKey.Version + `",` +
 		edgeproto.AppKeyTagOrganization + `="` + appKey.Organization +
-		`"} <= ` + fmt.Sprintf("%d", policy.UndeployClientCount)
+		`"} < ` + fmt.Sprintf("%d", policy.UndeployClientCount)
 	forSec := int64(policy.UndeployIntervalCount) * int64(settings.AutoDeployIntervalSec)
 	rule.For = model.Duration(time.Second * time.Duration(forSec))
 	grp.Rules = append(grp.Rules, rule)


### PR DESCRIPTION
### Description
Help string for `undeployclientcount` states that the number has to be strictly less than the configured one - made the rule match the help string