### PR TITLE
fix ids not being deleted with app/appinst

### DIFF
--- a/cmd/controller/app_api.go
+++ b/cmd/controller/app_api.go
@@ -787,7 +787,7 @@ func (s *AppApi) DeleteApp(ctx context.Context, in *edgeproto.App) (res *edgepro
 		}
 		// delete app
 		s.store.STMDel(stm, &in.Key)
-		s.globalIdStore.STMDel(stm, in.GlobalId)
+		s.globalIdStore.STMDel(stm, app.GlobalId)
 		// delete refs
 		s.all.appInstRefsApi.deleteRef(stm, &in.Key)
 		return nil

--- a/cmd/controller/appinst_api.go
+++ b/cmd/controller/appinst_api.go
@@ -2135,10 +2135,10 @@ func (s *AppInstApi) DeleteFromInfo(ctx context.Context, in *edgeproto.AppInstIn
 		}
 		s.store.STMDel(stm, &in.Key)
 		s.idStore.STMDel(stm, inst.UniqueId)
-		if in.FedKey.FederationName != "" {
-			s.fedStore.STMDel(stm, &in.FedKey)
+		if inst.FedKey.FederationName != "" {
+			s.fedStore.STMDel(stm, &inst.FedKey)
 		}
-		s.dnsLabelStore.STMDel(stm, &in.Key.ClusterInstKey.CloudletKey, inst.DnsLabel)
+		s.dnsLabelStore.STMDel(stm, &inst.Key.ClusterInstKey.CloudletKey, inst.DnsLabel)
 		s.all.appInstRefsApi.removeRef(stm, &in.Key)
 		s.all.clusterRefsApi.removeRef(stm, &inst)
 		return nil
@@ -2245,10 +2245,10 @@ func (s *AppInstApi) ReplaceErrorState(ctx context.Context, in *edgeproto.AppIns
 		if newState == edgeproto.TrackedState_DELETE_DONE {
 			s.store.STMDel(stm, &in.Key)
 			s.idStore.STMDel(stm, inst.UniqueId)
-			if in.FedKey.FederationName != "" {
-				s.fedStore.STMDel(stm, &in.FedKey)
+			if inst.FedKey.FederationName != "" {
+				s.fedStore.STMDel(stm, &inst.FedKey)
 			}
-			s.dnsLabelStore.STMDel(stm, &in.Key.ClusterInstKey.CloudletKey, inst.DnsLabel)
+			s.dnsLabelStore.STMDel(stm, &inst.Key.ClusterInstKey.CloudletKey, inst.DnsLabel)
 			s.all.appInstRefsApi.removeRef(stm, &in.Key)
 			s.all.clusterRefsApi.removeRef(stm, &inst)
 		} else {


### PR DESCRIPTION
IDs were being leaked in etcd on delete, because we were deleting from the input object which had a blank id. Instead, we need to delete from the looked-up object that has the id in it.