### PR TITLE
fed command aliasing and appinst create timeout fix

### DIFF
--- a/api/ormapi/api.comments.go
+++ b/api/ormapi/api.comments.go
@@ -535,7 +535,7 @@ var GenerateReportComments = map[string]string{
 
 var FederationProviderComments = map[string]string{
 	"id":                            `Unique ID`,
-	"name":                          `Unique name of this provider, will be used as a developer org name for consumer's images and apps`,
+	"name":                          `Unique name of this federation Host, will be used as a developer org name for Guest OP's images and apps`,
 	"operatorid":                    `Operator Organization that provides the resources`,
 	"regions":                       `Regions from which to provide resources`,
 	"federationcontextid":           `The federation context id we generated for this federation`,
@@ -559,7 +559,7 @@ var FederationProviderComments = map[string]string{
 	"partnernotifyclientkey":        `Partner notification client key (saved in secret storage)`,
 	"defaultcontainerdeployment":    `Default container deployment type (either docker or kubernetes)`,
 	"status":                        `Status`,
-	"providerclientid":              `Provider client ID for inbound connections`,
+	"providerclientid":              `Host client ID for inbound connections`,
 	"createdat":                     `Time created`,
 	"updatedat":                     `Time updated`,
 }
@@ -573,8 +573,8 @@ var FederationProviderInfoComments = map[string]string{
 
 var FederationConsumerComments = map[string]string{
 	"id":                            `Unique ID`,
-	"name":                          `Unique name of this consumer, will be used as an operator org for provider's zones`,
-	"operatorid":                    `Operator Organization that establishes the federation with a provider`,
+	"name":                          `Unique name of this Federation Guest, will be used as an operator org for host's zones`,
+	"operatorid":                    `Operator Organization that establishes the federation with a Host OP`,
 	"public":                        `Public means any developer will be able to use the cloudlets, otherwise (TODO) allowed developers will need to be added explicitly`,
 	"partneraddr":                   `Partner Address`,
 	"partnertokenurl":               `Partner token URL`,
@@ -596,9 +596,9 @@ var FederationConsumerComments = map[string]string{
 	"autoregisterzones":             `Automatically register any zone shared with me`,
 	"autoregisterregion":            `Region used for automatically registered zones`,
 	"status":                        `Status`,
-	"providerclientid":              `Auth ClientId for connecting to provider`,
-	"providerclientkey":             `Auth ClientKey for connection to provider (stored in secret storage)`,
-	"notifyclientid":                `Auth ClientId for notify callbacks to this consumer`,
+	"providerclientid":              `Auth ClientId for connecting to the Host OP`,
+	"providerclientkey":             `Auth ClientKey for connection to the Host OP (stored in secret storage)`,
+	"notifyclientid":                `Auth ClientId for notify callbacks to this Guest OP`,
 	"createdat":                     `Time created`,
 	"updatedat":                     `Time updated`,
 }
@@ -630,16 +630,16 @@ var ProviderZoneBaseComments = map[string]string{
 
 var ProviderZoneComments = map[string]string{
 	"zoneid":               `Globally unique identifier of the federator zone`,
-	"providername":         `Name of the Federation Provider`,
-	"operatorid":           `Provider operator organization`,
+	"providername":         `Name of the Federation Host OP`,
+	"operatorid":           `Host operator organization`,
 	"status":               `Zone status`,
 	"partnernotifyzoneuri": `Partner notify zone URI`,
 }
 
 var ConsumerZoneComments = map[string]string{
 	"zoneid":           `Zone unique name`,
-	"consumername":     `Name of the Federation consumer`,
-	"operatorid":       `Consumer operator organization`,
+	"consumername":     `Name of the Federation Guest`,
+	"operatorid":       `Guest operator organization`,
 	"region":           `Region in which zone is instantiated`,
 	"geolocation":      `GPS co-ordinates associated with the zone (in decimal format)`,
 	"geographydetails": `Geography details`,
@@ -647,20 +647,20 @@ var ConsumerZoneComments = map[string]string{
 }
 
 var FederatedZoneRegRequestComments = map[string]string{
-	"consumername": `Federation consumer name`,
-	"region":       `Region to create local cloudlet versions of provider zones`,
-	"zones":        `Partner federator zones to be registered/deregistered`,
+	"fedguest": `Federation Guest name`,
+	"region":   `Region to create local cloudlet versions of Host zones`,
+	"zones":    `Partner federator zones to be registered/deregistered`,
 }
 
 var FederatedZoneShareRequestComments = map[string]string{
-	"providername": `Federation provider name`,
-	"zones":        `Self federator zones to be shared/unshared`,
+	"fedhost": `Federation Host name`,
+	"zones":   `Self federator zones to be shared/unshared`,
 }
 
 var ConsumerImageComments = map[string]string{
 	"id":             `ID`,
 	"organization":   `Developer organization that owns the image`,
-	"federationname": `Federation the image is copied to (ConsumerFederation)`,
+	"federationname": `Federation the image is copied to (FederationGuest)`,
 	"name":           `Image name`,
 	"version":        `Image version`,
 	"sourcepath":     `Full path to source image as used in App, i.e. https://vm-registry.domain/org/image.img`,
@@ -670,7 +670,7 @@ var ConsumerImageComments = map[string]string{
 }
 
 var ProviderImageComments = map[string]string{
-	"federationname": `Federation Provider name`,
+	"federationname": `Host federation name`,
 	"fileid":         `File ID sent by partner`,
 	"path":           `Image path`,
 	"name":           `Image name`,
@@ -684,7 +684,7 @@ var ProviderImageComments = map[string]string{
 
 var ConsumerAppComments = map[string]string{
 	"id":             `Unique ID, acts as both the App and Artefact IDs`,
-	"federationname": `Target federation consumer name`,
+	"federationname": `Target Guest Federation name`,
 	"region":         `Region name`,
 	"appname":        `App name in region`,
 	"apporg":         `App org in region`,
@@ -694,7 +694,7 @@ var ConsumerAppComments = map[string]string{
 }
 
 var ProviderArtefactComments = map[string]string{
-	"federationname":  `Federation Provider name`,
+	"federationname":  `Host Federation name`,
 	"artefactid":      `Artefact ID send by partner`,
 	"artefactname":    `Artefact name`,
 	"artefactversion": `Artefact version`,
@@ -707,7 +707,7 @@ var ProviderArtefactComments = map[string]string{
 }
 
 var ProviderAppComments = map[string]string{
-	"federationname":        `Federation Provider name`,
+	"federationname":        `Host Federation name`,
 	"appid":                 `App ID send by partner`,
 	"appname":               `App name of federation app (not region app)`,
 	"appvers":               `App version  of federation app (not region app)`,
@@ -718,7 +718,7 @@ var ProviderAppComments = map[string]string{
 }
 
 var ProviderAppInstComments = map[string]string{
-	"federationname":      `Federation Provider name`,
+	"federationname":      `Host Federation name`,
 	"appinstid":           `AppInst unique ID`,
 	"appid":               `AppID for ProviderApp`,
 	"region":              `Region for AppInst`,

--- a/pkg/mc/federation/fed_artefact.go
+++ b/pkg/mc/federation/fed_artefact.go
@@ -68,7 +68,7 @@ func (p *PartnerApi) lookupArtefact(c echo.Context, provider *ormapi.FederationP
 	provArt.ArtefactID = artefactId
 	res := db.Where(&provArt).First(&provArt)
 	if res.RecordNotFound() {
-		return nil, fmt.Errorf("Artefact %s not found", artefactId)
+		return nil, fedError(http.StatusNotFound, fmt.Errorf("Artefact %s not found", artefactId))
 	}
 	if res.Error != nil {
 		return nil, fedError(http.StatusInternalServerError, fmt.Errorf("Failed to look up artefact, %s", res.Error.Error()))

--- a/pkg/mc/federation/fed_zone.go
+++ b/pkg/mc/federation/fed_zone.go
@@ -38,7 +38,7 @@ func (p *PartnerApi) LookupProviderZone(ctx context.Context, providerName, zoneI
 	db := p.loggedDB(ctx)
 	res := db.Where(&lookup).First(&lookup)
 	if res.RecordNotFound() {
-		return nil, fmt.Errorf("Zone not found")
+		return nil, fedError(http.StatusNotFound, fmt.Errorf("Zone %s not found", zoneId))
 	}
 	if res.Error != nil {
 		return nil, ormutil.DbErr(res.Error)

--- a/pkg/mc/federation/federation_op.go
+++ b/pkg/mc/federation/federation_op.go
@@ -135,7 +135,7 @@ func (p *PartnerApi) lookupProvider(c echo.Context, federationContextId Federati
 	}
 	res := db.Where(&provider).First(&provider)
 	if res.RecordNotFound() {
-		return nil, fmt.Errorf("federation provider %q not found", claims.ApiKeyUsername)
+		return nil, fedError(http.StatusNotFound, fmt.Errorf("federation %q not found", claims.ApiKeyUsername))
 	}
 	if res.Error != nil {
 		return nil, ormutil.DbErr(res.Error)

--- a/pkg/mc/orm/federation_mc.go
+++ b/pkg/mc/orm/federation_mc.go
@@ -440,7 +440,7 @@ func UpdateFederationProvider(c echo.Context) error {
 		*/
 	}
 
-	return ormutil.SetReply(c, ormutil.Msg("Updated federation provider"))
+	return ormutil.SetReply(c, ormutil.Msg("Updated Federation Host"))
 }
 
 // Delete FederationProvider
@@ -543,7 +543,7 @@ func DeleteFederationProvider(c echo.Context) error {
 	}
 	err = DeleteOrgObj(ctx, claims, &devOrg)
 	log.SpanLog(ctx, log.DebugLevelApi, "delete provider's dev org", "name", devOrg.Name, "err", err)
-	return ormutil.SetReply(c, ormutil.Msg(fmt.Sprintf("FederationProvider %s deleted", provider.Name)))
+	return ormutil.SetReply(c, ormutil.Msg(fmt.Sprintf("Federation Host %s deleted", provider.Name)))
 }
 
 // Fields to ignore for ShowFederation filtering. Names are in database format.
@@ -769,7 +769,7 @@ func CreateFederationConsumer(c echo.Context) (reterr error) {
 		return err
 	}
 
-	return ormutil.SetReply(c, ormutil.Msg(fmt.Sprintf("Federation consumer %s created", consumer.Name)))
+	return ormutil.SetReply(c, ormutil.Msg(fmt.Sprintf("Federation Guest %s created", consumer.Name)))
 }
 
 func DeleteFederationConsumer(c echo.Context) error {
@@ -830,7 +830,7 @@ func DeleteFederationConsumer(c echo.Context) error {
 	err = DeleteOrgObj(ctx, claims, &operOrg)
 	log.SpanLog(ctx, log.DebugLevelApi, "delete consumer's operator org", "name", operOrg.Name, "err", err)
 
-	return ormutil.SetReply(c, ormutil.Msg(fmt.Sprintf("Federation consumer %s deleted", consumer.Name)))
+	return ormutil.SetReply(c, ormutil.Msg(fmt.Sprintf("Federation Guest %s deleted", consumer.Name)))
 }
 
 func UpdateFederationConsumer(c echo.Context) error {
@@ -887,7 +887,7 @@ func UpdateFederationConsumer(c echo.Context) error {
 	if err != nil {
 		return ormutil.DbErr(err)
 	}
-	return ormutil.SetReply(c, ormutil.Msg(fmt.Sprintf("Federation consumer %s updated", consumer.Name)))
+	return ormutil.SetReply(c, ormutil.Msg(fmt.Sprintf("Federation Guest %s updated", consumer.Name)))
 }
 
 // Update consumer's client key for provider in case provider regenerated it.
@@ -921,7 +921,7 @@ func SetFederationConsumerAPIKey(c echo.Context) error {
 	if err != nil {
 		return ormutil.DbErr(err)
 	}
-	return ormutil.SetReply(c, ormutil.Msg(fmt.Sprintf("Federation consumer %s api key set", consumer.Name)))
+	return ormutil.SetReply(c, ormutil.Msg(fmt.Sprintf("Federation Guest %s api key set", consumer.Name)))
 }
 
 // Generate a notify key to allow provider to callback to consumer
@@ -1117,7 +1117,7 @@ func DeleteProviderZoneBase(c echo.Context) error {
 		return ormutil.DbErr(err)
 	}
 
-	return ormutil.SetReply(c, ormutil.Msg("Deleted federator zone successfully"))
+	return ormutil.SetReply(c, ormutil.Msg("Deleted federation zone successfully"))
 }
 
 // Fields to ignore for ShowProviderZoneBase
@@ -1174,7 +1174,7 @@ func ShareProviderZone(c echo.Context) (reterr error) {
 	if len(share.Zones) == 0 {
 		return fmt.Errorf("Must specify the zones to be shared")
 	}
-	provider, err := lookupFederationProvider(ctx, 0, share.ProviderName)
+	provider, err := lookupFederationProvider(ctx, 0, share.FedHost)
 	if err != nil {
 		return err
 	}
@@ -1292,7 +1292,7 @@ func UnshareProviderZone(c echo.Context) error {
 	if len(share.Zones) == 0 {
 		return fmt.Errorf("Must specify the zones to be unshared")
 	}
-	provider, err := lookupFederationProvider(ctx, 0, share.ProviderName)
+	provider, err := lookupFederationProvider(ctx, 0, share.FedHost)
 	if err != nil {
 		return err
 	}
@@ -1454,7 +1454,7 @@ func RegisterConsumerZone(c echo.Context) error {
 	if _, err := getControllerObj(ctx, reg.Region); err != nil {
 		return err
 	}
-	consumer, err := lookupFederationConsumer(ctx, 0, reg.ConsumerName)
+	consumer, err := lookupFederationConsumer(ctx, 0, reg.FedGuest)
 	if err != nil {
 		return err
 	}
@@ -1487,7 +1487,7 @@ func DeregisterConsumerZone(c echo.Context) error {
 	if len(reg.Zones) == 0 {
 		return fmt.Errorf("Must specify zones to be deregistered")
 	}
-	consumer, err := lookupFederationConsumer(ctx, 0, reg.ConsumerName)
+	consumer, err := lookupFederationConsumer(ctx, 0, reg.FedGuest)
 	if err != nil {
 		return err
 	}

--- a/pkg/mc/orm/federation_test.go
+++ b/pkg/mc/orm/federation_test.go
@@ -396,8 +396,8 @@ func createAndShareProviderZones(t *testing.T, ctx context.Context, mcClient *mc
 		names = append(names, cloudlet.Key.Name)
 	}
 	zoneShReq := &ormapi.FederatedZoneShareRequest{
-		ProviderName: provAttr.fedName,
-		Zones:        names,
+		FedHost: provAttr.fedName,
+		Zones:   names,
 	}
 	_, status, err := mcClient.ShareHostZone(op.uri, provAttr.tokenOper, zoneShReq)
 	require.Nil(t, err, "share zones")
@@ -694,9 +694,9 @@ func testFederationInterconnect(t *testing.T, ctx context.Context, clientRun mct
 	// Register consumer zone should fail if zoneid is invalid
 	// ==================================================================
 	zoneRegReq := &ormapi.FederatedZoneRegRequest{
-		ConsumerName: consAttr.fedName,
-		Region:       consAttr.region,
-		Zones:        []string{"badzone"},
+		FedGuest: consAttr.fedName,
+		Region:   consAttr.region,
+		Zones:    []string{"badzone"},
 	}
 	_, _, err = mcClient.RegisterGuestZone(op.uri, consAttr.tokenAd, zoneRegReq)
 	require.NotNil(t, err, "Zone not found")
@@ -1012,8 +1012,8 @@ func testFederationInterconnect(t *testing.T, ctx context.Context, clientRun mct
 	// Unshare provider zone should fail if it's still in use
 	// ======================================================
 	zoneShReq := &ormapi.FederatedZoneShareRequest{
-		ProviderName: provAttr.fedName,
-		Zones:        sharedZones,
+		FedHost: provAttr.fedName,
+		Zones:   sharedZones,
 	}
 	_, status, err = mcClient.UnshareHostZone(op.uri, provAttr.tokenOper, zoneShReq)
 	require.NotNil(t, err, "unshare zones")
@@ -1022,9 +1022,9 @@ func testFederationInterconnect(t *testing.T, ctx context.Context, clientRun mct
 	// Deregister all the partner zones
 	// ================================
 	zoneRegReq = &ormapi.FederatedZoneRegRequest{
-		ConsumerName: consAttr.fedName,
-		Region:       consAttr.region,
-		Zones:        sharedZones,
+		FedGuest: consAttr.fedName,
+		Region:   consAttr.region,
+		Zones:    sharedZones,
 	}
 	_, status, err = mcClient.DeregisterGuestZone(op.uri, consAttr.tokenOper, zoneRegReq)
 	require.Nil(t, err, "deregister consumer zones")
@@ -1233,9 +1233,9 @@ func testFederationIgnorePartner(t *testing.T, ctx context.Context, clientRun mc
 	// Register all the partner zones to be used
 	// =========================================
 	zoneRegReq := &ormapi.FederatedZoneRegRequest{
-		ConsumerName: consAttr.fedName,
-		Region:       consAttr.region,
-		Zones:        sharedZones,
+		FedGuest: consAttr.fedName,
+		Region:   consAttr.region,
+		Zones:    sharedZones,
 	}
 	_, status, err = mcClient.RegisterGuestZone(op.uri, consAttr.tokenOper, zoneRegReq)
 	require.Nil(t, err, "register partner federator zone")
@@ -1317,8 +1317,8 @@ func testFederationIgnorePartner(t *testing.T, ctx context.Context, clientRun mc
 	require.Equal(t, 0, len(provImagesShow))
 	// zones
 	zoneShReq := &ormapi.FederatedZoneShareRequest{
-		ProviderName: provAttr.fedName,
-		Zones:        sharedZones,
+		FedHost: provAttr.fedName,
+		Zones:   sharedZones,
 	}
 	queryParams := map[string]string{
 		"ignorepartner": "true",
@@ -1397,9 +1397,9 @@ func testFederationIgnorePartner(t *testing.T, ctx context.Context, clientRun mc
 	}
 	// zones
 	zoneRegReq = &ormapi.FederatedZoneRegRequest{
-		ConsumerName: consAttr.fedName,
-		Region:       consAttr.region,
-		Zones:        sharedZones,
+		FedGuest: consAttr.fedName,
+		Region:   consAttr.region,
+		Zones:    sharedZones,
 	}
 	_, status, err = mcClient.DeregisterGuestZone(op.uri, consAttr.tokenOper, zoneRegReq, mctestclient.WithQueryParams(queryParams))
 	require.Nil(t, err, "deregister consumer zones")

--- a/pkg/mcctl/cliwrapper/wrapcli.go
+++ b/pkg/mcctl/cliwrapper/wrapcli.go
@@ -225,7 +225,8 @@ func injectRequiredArgs(args []string, apiCmd *ormctl.ApiCommand) []string {
 		}
 		specifiedArgs[kv[0]] = struct{}{}
 	}
-	// build unalias map
+	// build alias and unalias map
+	aliases := make(map[string]string)
 	unalias := make(map[string]string)
 	for _, alias := range strings.Fields(apiCmd.AliasArgs) {
 		kv := strings.SplitN(alias, "=", 2)
@@ -233,14 +234,20 @@ func injectRequiredArgs(args []string, apiCmd *ormctl.ApiCommand) []string {
 			continue
 		}
 		unalias[kv[0]] = kv[1]
+		aliases[kv[1]] = kv[0]
 	}
+
 	inType := reflect.TypeOf(apiCmd.ReqData)
 	if inType.Kind() == reflect.Ptr {
 		inType = inType.Elem()
 	}
 	for _, req := range strings.Fields(apiCmd.RequiredArgs) {
 		if _, found := specifiedArgs[req]; found {
-			// already present
+			// already present, unaliased value
+			continue
+		}
+		if _, found := specifiedArgs[aliases[req]]; found {
+			// already present, aliased value
 			continue
 		}
 		// To figure out what value to specify, we need to

--- a/pkg/mcctl/ormctl/federation.go
+++ b/pkg/mcctl/ormctl/federation.go
@@ -34,6 +34,7 @@ func init() {
 			SpecialArgs:  &FederationProviderSpecialArgs,
 			RequiredArgs: strings.Join(FederationProviderRequiredArgs, " "),
 			OptionalArgs: strings.Join(FederationProviderOptionalArgs, " "),
+			AliasArgs:    strings.Join(FederationProviderAliasArgs, " "),
 			Comments:     ormapi.FederationProviderComments,
 			ReqData:      &ormapi.FederationProvider{},
 			ReplyData:    &ormapi.FederationProviderInfo{},
@@ -46,6 +47,7 @@ func init() {
 			SpecialArgs:  &FederationProviderSpecialArgs,
 			RequiredArgs: "name operatorid",
 			OptionalArgs: strings.Join(FederationProviderOptionalArgs, " "),
+			AliasArgs:    strings.Join(FederationProviderAliasArgs, " "),
 			Comments:     ormapi.FederationProviderComments,
 			ReqData:      &ormapi.FederationProvider{},
 			ReplyData:    &ormapi.Result{},
@@ -67,6 +69,7 @@ func init() {
 			Short:        "Show Federation Host",
 			SpecialArgs:  &FederationProviderSpecialArgs,
 			OptionalArgs: strings.Join(FederationProviderShowArgs, " "),
+			AliasArgs:    strings.Join(FederationProviderAliasArgs, " "),
 			Comments:     ormapi.FederationProviderComments,
 			ReqData:      &ormapi.FederationProvider{},
 			ReplyData:    &[]ormapi.FederationProvider{},
@@ -157,6 +160,7 @@ func init() {
 			Use:          "showsharedzones",
 			Short:        "Show Shared Host Zones",
 			OptionalArgs: strings.Join(ProviderZoneShowArgs, " "),
+			AliasArgs:    strings.Join(ProviderZoneAliasArgs, " "),
 			Comments:     ormapi.ProviderZoneComments,
 			ReqData:      &ormapi.ProviderZone{},
 			ReplyData:    &[]ormapi.ProviderZone{},
@@ -251,6 +255,7 @@ func init() {
 			SpecialArgs:  &FederationConsumerSpecialArgs,
 			RequiredArgs: strings.Join(FederationConsumerRequiredArgs, " "),
 			OptionalArgs: strings.Join(FederationConsumerOptionalArgs, " "),
+			AliasArgs:    strings.Join(FederationConsumerAliasArgs, " "),
 			Comments:     ormapi.FederationConsumerComments,
 			ReqData:      &ormapi.FederationConsumer{},
 			ReplyData:    &ormapi.Result{},
@@ -263,6 +268,7 @@ func init() {
 			SpecialArgs:  &FederationConsumerSpecialArgs,
 			RequiredArgs: "name operatorid",
 			OptionalArgs: "public",
+			AliasArgs:    strings.Join(FederationConsumerAliasArgs, " "),
 			Comments:     ormapi.FederationConsumerComments,
 			ReqData:      &ormapi.FederationConsumer{},
 			ReplyData:    &ormapi.Result{},
@@ -287,6 +293,7 @@ func init() {
 			Short:        "Show Federation Guest",
 			SpecialArgs:  &FederationConsumerSpecialArgs,
 			OptionalArgs: strings.Join(FederationConsumerShowArgs, " "),
+			AliasArgs:    strings.Join(FederationConsumerAliasArgs, " "),
 			Comments:     ormapi.FederationConsumerComments,
 			ReqData:      &ormapi.FederationConsumer{},
 			ReplyData:    &[]ormapi.FederationConsumer{},
@@ -297,8 +304,9 @@ func init() {
 			Name:         "SetFederationGuestAPIKey",
 			Use:          "setpartnerapikey",
 			Short:        "Set Partner Federation API Key",
-			RequiredArgs: "name operatorid providerclientid providerclientkey",
+			RequiredArgs: "name operatorid hostclientid hostclientkey",
 			SpecialArgs:  &FederationConsumerSpecialArgs,
+			AliasArgs:    strings.Join(FederationConsumerAliasArgs, " "),
 			Comments:     ormapi.FederationConsumerComments,
 			ReqData:      &ormapi.FederationConsumer{},
 			ReplyData:    &ormapi.Result{},
@@ -310,6 +318,7 @@ func init() {
 			Short:        "Set Partner Federation API Key",
 			RequiredArgs: "name operatorid",
 			SpecialArgs:  &FederationConsumerSpecialArgs,
+			AliasArgs:    strings.Join(FederationConsumerAliasArgs, " "),
 			Comments:     ormapi.FederationConsumerComments,
 			ReqData:      &ormapi.FederationConsumer{},
 			ReplyData:    &ormapi.Result{},
@@ -344,6 +353,7 @@ func init() {
 			Use:          "showzones",
 			Short:        "Show Federated Partner Zones",
 			OptionalArgs: strings.Join(ConsumerZoneShowArgs, " "),
+			AliasArgs:    strings.Join(ConsumerZoneAliasArgs, " "),
 			Comments:     ormapi.ConsumerZoneComments,
 			ReqData:      &ormapi.ConsumerZone{},
 			ReplyData:    &[]ormapi.ConsumerZone{},
@@ -394,6 +404,10 @@ var FederationProviderSpecialArgs = map[string]string{
 	"partnerinfo.fixednetworkids": "StringArray",
 }
 
+var FederationProviderAliasArgs = []string{
+	"hostclientid=providerclientid",
+}
+
 var FederationProviderShowArgs = []string{
 	"id",
 	"name",
@@ -413,7 +427,7 @@ var FederationProviderShowArgs = []string{
 	"partnerinfo.fixednetworkids",
 	"partnerinfo.discoveryendpoint",
 	"status",
-	"providerclientid",
+	"hostclientid",
 }
 
 var ProviderZoneBaseRequiredArgs = []string{
@@ -434,19 +448,23 @@ var ProviderZoneBaseSpecialArgs = map[string]string{
 }
 
 var ShareZoneRequiredArgs = []string{
-	"providername",
+	"fedhost",
 	"zones",
 }
 
 var ProviderZoneShowArgs = []string{
 	"zoneid",
 	"operatorid",
-	"providername",
+	"fedhost",
 	"status",
 }
 
 var ShareZoneSpecialArgs = map[string]string{
 	"zones": "StringArray",
+}
+
+var ProviderZoneAliasArgs = []string{
+	"fedhost=providername",
 }
 
 var ProviderArtefactShowArgs = []string{
@@ -486,8 +504,8 @@ var FederationConsumerRequiredArgs = []string{
 	"name",
 	"operatorid",
 	"partneraddr",
-	"providerclientid",
-	"providerclientkey",
+	"hostclientid",
+	"hostclientkey",
 }
 
 var FederationConsumerOptionalArgs = []string{
@@ -527,18 +545,23 @@ var FederationConsumerShowArgs = []string{
 	"partnerinfo.fixednetworkids",
 	"partnerinfo.discoveryendpoint",
 	"status",
-	"providerclientid",
+	"hostclientid",
 	"notifyclientid",
 }
 
+var FederationConsumerAliasArgs = []string{
+	"hostclientid=providerclientid",
+	"hostclientkey=providerclientkey",
+}
+
 var RegisterZoneRequiredArgs = []string{
-	"consumername",
+	"fedguest",
 	"region",
 	"zones",
 }
 
 var DeregisterZoneRequiredArgs = []string{
-	"consumername",
+	"fedguest",
 	"zones",
 }
 
@@ -548,11 +571,15 @@ var RegisterZoneSpecialArgs = map[string]string{
 
 var ConsumerZoneShowArgs = []string{
 	"zoneid",
-	"consumername",
+	"fedguest",
 	"operatorid",
 	"geolocation",
 	"geographydetails",
 	"status",
+}
+
+var ConsumerZoneAliasArgs = []string{
+	"fedguest=consumername",
 }
 
 var ProviderImageShowArgs = []string{

--- a/pkg/mcctl/ormctl/federation_dev.go
+++ b/pkg/mcctl/ormctl/federation_dev.go
@@ -17,6 +17,7 @@ func init() {
 		Short:        "Show federations for App deployment",
 		SpecialArgs:  &FederationConsumerSpecialArgs,
 		OptionalArgs: strings.Join(FederationConsumerShowArgs, " "),
+		AliasArgs:    strings.Join(FederationConsumerAliasArgs, " "),
 		Comments:     ormapi.FederationConsumerComments,
 		ReqData:      &ormapi.FederationConsumer{},
 		ReplyData:    &[]ormapi.FederationConsumer{},

--- a/pkg/platform/federation/federation_pf.go
+++ b/pkg/platform/federation/federation_pf.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	AppInstDeploymentTimeout = 20 * time.Minute
+	AppInstDeploymentTimeout = 10 * time.Minute
 )
 
 // NOTE: This object is shared by all FRM-based cloudlets and hence it can't
@@ -229,6 +229,7 @@ func (f *FederationPlatform) CreateAppInst(ctx context.Context, clusterInst *edg
 	if os.Getenv("E2ETEST_TLS") != "" {
 		timeout = 3 * time.Second
 	}
+	timeoutChan := time.After(timeout)
 
 	// Set up polling in case callbacks are lost
 	pollApiPath := fmt.Sprintf("/%s/%s/application/lcm/app/%s/instance/%s/zone/%s", federationmgmt.ApiRoot, fedConfig.FederationContextId, app.GlobalId, req.AppInstanceId, cloudletKey.Name)
@@ -264,7 +265,7 @@ func (f *FederationPlatform) CreateAppInst(ctx context.Context, clusterInst *edg
 			} else {
 				updateCallback(edgeproto.UpdateTask, event.Message)
 			}
-		case <-time.After(timeout):
+		case <-timeoutChan:
 			return fmt.Errorf("Timed out waiting for callback")
 		}
 	}

--- a/test/e2e-tests/pkg/e2e/mcapi.go
+++ b/test/e2e-tests/pkg/e2e/mcapi.go
@@ -1334,8 +1334,8 @@ func manageFederatorZoneData(mode, uri, token, tag string, data *ormapi.AllData,
 	case "share":
 		for ii, fd := range data.ProviderZones {
 			share := ormapi.FederatedZoneShareRequest{
-				ProviderName: fd.ProviderName,
-				Zones:        []string{fd.ZoneId},
+				FedHost: fd.ProviderName,
+				Zones:   []string{fd.ZoneId},
 			}
 			_, st, err := mcClient.ShareHostZone(uri, token, &share)
 			outMcErr(output, fmt.Sprintf("ShareHostZone[%d]", ii), st, err)
@@ -1343,8 +1343,8 @@ func manageFederatorZoneData(mode, uri, token, tag string, data *ormapi.AllData,
 	case "unshare":
 		for ii, fd := range data.ProviderZones {
 			share := ormapi.FederatedZoneShareRequest{
-				ProviderName: fd.ProviderName,
-				Zones:        []string{fd.ZoneId},
+				FedHost: fd.ProviderName,
+				Zones:   []string{fd.ZoneId},
 			}
 			_, st, err := mcClient.UnshareHostZone(uri, token, &share)
 			outMcErr(output, fmt.Sprintf("UnshareHostZone[%d]", ii), st, err)
@@ -1352,8 +1352,8 @@ func manageFederatorZoneData(mode, uri, token, tag string, data *ormapi.AllData,
 	case "register":
 		for ii, fd := range data.ConsumerZones {
 			req := ormapi.FederatedZoneRegRequest{
-				ConsumerName: fd.ConsumerName,
-				Zones:        []string{fd.ZoneId},
+				FedGuest: fd.ConsumerName,
+				Zones:    []string{fd.ZoneId},
 			}
 			_, st, err := mcClient.RegisterGuestZone(uri, token, &req)
 			outMcErr(output, fmt.Sprintf("RegisterGuestZone[%d]", ii), st, err)
@@ -1361,8 +1361,8 @@ func manageFederatorZoneData(mode, uri, token, tag string, data *ormapi.AllData,
 	case "deregister":
 		for ii, fd := range data.ConsumerZones {
 			req := ormapi.FederatedZoneRegRequest{
-				ConsumerName: fd.ConsumerName,
-				Zones:        []string{fd.ZoneId},
+				FedGuest: fd.ConsumerName,
+				Zones:    []string{fd.ZoneId},
 			}
 			_, st, err := mcClient.DeregisterGuestZone(uri, token, &req)
 			outMcErr(output, fmt.Sprintf("DeregisterGuestZone[%d]", ii), st, err)


### PR DESCRIPTION
Changes to mcctl aliases to convert provider/consumer to host/guest terminology.

Also fix AppInst create timeout broken by addition of polling.