### PR TITLE
operators can only see their own cloudlets

### DIFF
--- a/pkg/mc/federation/fed_appinst.go
+++ b/pkg/mc/federation/fed_appinst.go
@@ -122,6 +122,7 @@ func (p *PartnerApi) InstallApp(c echo.Context, fedCtxId FederationContextId) (r
 	appKey := provArt.GetAppKey()
 	provAppInst := ormapi.ProviderAppInst{
 		FederationName:      provider.Name,
+		AppID:               in.AppId,
 		AppInstID:           in.AppInstanceId,
 		AppInstCallbackLink: in.AppInstCallbackLink,
 		Region:              base.Region,

--- a/pkg/mc/orm/server.go
+++ b/pkg/mc/orm/server.go
@@ -978,6 +978,9 @@ func RunServer(config *ServerConfig) (retserver *Server, reterr error) {
 	ws.GET("/metrics/clientappusage", GetMetricsCommon)
 	ws.GET("/metrics/clientcloudletusage", GetMetricsCommon)
 
+	ws.GET("/federation/consumer/app/onboard", OnboardConsumerApp)
+	ws.GET("/federation/consumer/app/deboard", DeboardConsumerApp)
+
 	if config.NotifySrvAddr != "" {
 		server.notifyServer = &notify.ServerMgr{}
 		nodeMgr.RegisterServer(server.notifyServer)

--- a/test/e2e-tests/data/fedprov_provappinsts_show.yml
+++ b/test/e2e-tests/data/fedprov_provappinsts_show.yml
@@ -102,6 +102,7 @@ providerapps:
 providerappinsts:
 - federationname: dmuus-partner1
   appinstid: '***replaced***'
+  appid: pa-k8sapp10fedappco
   region: local
   appname: pa-k8sapp10fedappco
   appvers: "1.0"
@@ -112,6 +113,7 @@ providerappinsts:
   appinstcallbacklink: https://127.0.0.1:9808/operatorplatform/fedcallbacks/v1/onInstanceStatusEvent/fedappcok8sapp10-autoclusterk8s-dmuuscloud1-dmuus-partner1
 - federationname: dmuus-partner1
   appinstid: '***replaced***'
+  appid: pa-dockerapp10fedappco
   region: local
   appname: pa-dockerapp10fedappco
   appvers: "1.0"
@@ -122,6 +124,7 @@ providerappinsts:
   appinstcallbacklink: https://127.0.0.1:9808/operatorplatform/fedcallbacks/v1/onInstanceStatusEvent/fedappcodockerapp10-autoclusterdocker-dmuuscloud1-dmuus-partner1
 - federationname: dmuus-partner1
   appinstid: '***replaced***'
+  appid: pa-vmapp10fedappco
   region: local
   appname: pa-vmapp10fedappco
   appvers: "1.0"


### PR DESCRIPTION
Change cloudlet show so that operators can only see their own cloudlets, and not other operator cloudlets, even if those cloudlets are public. Only developers can see (a filtered view of) all cloudlets.

Fix missing AppID on ProviderAppInst.