### PR TITLE
fed mcc/mnc validity checks, fed guest update fields

### DIFF
--- a/pkg/mc/orm/federation_test.go
+++ b/pkg/mc/orm/federation_test.go
@@ -536,6 +536,7 @@ func testFederationInterconnect(t *testing.T, ctx context.Context, clientRun mct
 		PartnerTokenUrl: "http://" + op.tokenAddr + "/" + federation.TokenUrl,
 		MyInfo: ormapi.Federator{
 			CountryCode: consAttr.countryCode,
+			MCC:         "123",
 			MNC:         []string{"123", "345"},
 		},
 	}
@@ -1217,6 +1218,7 @@ func testFederationIgnorePartner(t *testing.T, ctx context.Context, clientRun mc
 		PartnerTokenUrl: "http://" + op.tokenAddr + "/" + federation.TokenUrl,
 		MyInfo: ormapi.Federator{
 			CountryCode: consAttr.countryCode,
+			MCC:         "123",
 			MNC:         []string{"123", "345"},
 		},
 		ProviderClientId:  provResp.ClientId,

--- a/test/e2e-tests/data/federation_guests_show.yml
+++ b/test/e2e-tests/data/federation_guests_show.yml
@@ -16,6 +16,7 @@ federationconsumers:
 - id: 1
   name: dmuus-partner1
   operatorid: partner1
+  public: true
   partneraddr: https://127.0.0.1:9801
   partnertokenurl: https://127.0.0.1:9900/oauth2/token
   federationcontextid: '***replaced***'
@@ -51,6 +52,7 @@ federationconsumers:
 - id: 2
   name: enterprise-partner1
   operatorid: partner1
+  public: true
   partneraddr: https://127.0.0.1:9801
   partnertokenurl: https://127.0.0.1:9900/oauth2/token
   federationcontextid: '***replaced***'

--- a/test/e2e-tests/data/federation_guestzones_unreg_show.yml
+++ b/test/e2e-tests/data/federation_guestzones_unreg_show.yml
@@ -16,42 +16,36 @@ consumerzones:
 - zoneid: dmuuscloud1
   consumername: dmuus-partner1
   operatorid: partner1
-  region: PA
   geolocation: 31,-91
   geographydetails: None
   status: Unregistered
 - zoneid: dmuuscloud2
   consumername: dmuus-partner1
   operatorid: partner1
-  region: PA
   geolocation: 35,-95
   geographydetails: None
   status: Unregistered
 - zoneid: dmuuscloud3
   consumername: dmuus-partner1
   operatorid: partner1
-  region: PA
   geolocation: 32,-92
   geographydetails: None
   status: Unregistered
 - zoneid: dmuuscloud4
   consumername: dmuus-partner1
   operatorid: partner1
-  region: PA
   geolocation: 36,-96
   geographydetails: None
   status: Unregistered
 - zoneid: enterprise1
   consumername: enterprise-partner1
   operatorid: partner1
-  region: PA
   geolocation: 31,-91
   geographydetails: None
   status: Unregistered
 - zoneid: enterprise2
   consumername: enterprise-partner1
   operatorid: partner1
-  region: PA
   geolocation: 31,-91
   geographydetails: None
   status: Unregistered

--- a/test/e2e-tests/data/fedprov_appinsts_show.yml
+++ b/test/e2e-tests/data/fedprov_appinsts_show.yml
@@ -431,6 +431,9 @@ regiondata:
       realclustername: reservable1
       uniqueid: dmuus-partner1pa-dockerapp10fedappco10-autoclusterabcdefabcdef-dmuus-cloud-1-dmuus
       dnslabel: pa-dockerapp10fedappco10-dmuus-partner1
+      fedkey:
+        federationname: dmuus-partner1
+        appinstid: '***replaced***'
     - key:
         appkey:
           organization: dmuus-partner1
@@ -468,6 +471,9 @@ regiondata:
       realclustername: reservable0
       uniqueid: dmuus-partner1pa-k8sapp10fedappco10-autoclusterabcdefabcdef-dmuus-cloud-1-dmuus
       dnslabel: pa-k8sapp10fedappco10-dmuus-partner1
+      fedkey:
+        federationname: dmuus-partner1
+        appinstid: '***replaced***'
     - key:
         appkey:
           organization: dmuus-partner1
@@ -498,6 +504,9 @@ regiondata:
       vmflavor: x1.small
       uniqueid: dmuus-partner1pa-vmapp10fedappco10-dmuus-cloud-2-dmuus
       dnslabel: pa-vmapp10fedappco10-dmuus-partner1
+      fedkey:
+        federationname: dmuus-partner1
+        appinstid: '***replaced***'
     appinstrefs:
     - key:
         organization: dmuus-partner1


### PR DESCRIPTION
More minor fixes
- mcc/mnc required/validity checks
- allow full set of fields to be updated on Federation Guest
- fixes for e2e tests