### PR TITLE
better audit event names

### DIFF
--- a/pkg/cloudcommon/node/events.go
+++ b/pkg/cloudcommon/node/events.go
@@ -106,7 +106,7 @@ type EventData struct {
 	// Name of event
 	Name string `json:"name"`
 	// Organizations that scan see event
-	Org []string `json:"org"`
+	Org []string `json:"org,omitempty"`
 	// Type of event, audit or event
 	Type string `json:"type"`
 	// Region in which event happened
@@ -123,7 +123,7 @@ type EventData struct {
 
 type EventDataOld struct {
 	Name      string            `json:"name"`
-	Org       string            `json:"org"`
+	Org       string            `json:"org,omitempty"`
 	Type      string            `json:"type"`
 	Region    string            `json:"region,omitempty"`
 	Timestamp time.Time         `json:"timestamp"`

--- a/pkg/mc/federation/fed_app.go
+++ b/pkg/mc/federation/fed_app.go
@@ -184,7 +184,7 @@ func (p *PartnerApi) OnboardApplication(c echo.Context, fedCtxId FederationConte
 			log.SpanLog(ctx, log.DebugLevelApi, "failed to send app create callback", "url", req.AppStatusCallbackLink, "err", err)
 			return
 		}
-		_, _, err = fedClient.SendRequest(ctx, "POST", "", &cb, nil, nil)
+		_, _, err = fedClient.SendRequest(ctx, "FedAppCreate Callback", "POST", "", &cb, nil, nil)
 		log.SpanLog(ctx, log.DebugLevelApi, "sent app create callback", "url", req.AppStatusCallbackLink, "err", err)
 	})
 	return nil

--- a/pkg/mc/federation/fed_appinst.go
+++ b/pkg/mc/federation/fed_appinst.go
@@ -325,7 +325,7 @@ func (s *AppInstWorker) sendCallback(ctx context.Context, state *fedewapi.Instan
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelApi, "appInstWorker sendCallback get fedClient failed", "err", err)
 	}
-	_, _, err = fedClient.SendRequest(ctx, "POST", "", &req, nil, nil)
+	_, _, err = fedClient.SendRequest(ctx, "FedAppInstCreate Callback", "POST", "", &req, nil, nil)
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelApi, "appInstWorker sendCallback failed", "err", err)
 	}

--- a/pkg/mc/federation/fed_artefact.go
+++ b/pkg/mc/federation/fed_artefact.go
@@ -117,6 +117,10 @@ func (p *PartnerApi) UploadArtefact(c echo.Context, fedCtxId FederationContextId
 		ArtefactVirtType:       provArt.VirtType,
 		ArtefactDescriptorType: provArt.DescType,
 	}
+	requestData, _ := json.Marshal(artReq)
+	log.SetContextTags(ctx, map[string]string{
+		"request": string(requestData),
+	})
 	if err := artReq.Validate(); err != nil {
 		return err
 	}

--- a/pkg/mc/federation/fed_file.go
+++ b/pkg/mc/federation/fed_file.go
@@ -130,8 +130,15 @@ func (p *PartnerApi) UploadFile(c echo.Context, fedCtxId FederationContextId) (r
 		FileType:         fedewapi.VirtImageType(image.Type),
 		ImgOSType:        osType,
 		ImgInsSetArch:    fedewapi.CPUArchType(archTypeStr),
+		RepoType:         &repoType,
 		FileRepoLocation: src,
+		FileDescription:  &image.Description,
+		Checksum:         &image.Checksum,
 	}
+	requestData, _ := json.Marshal(fileReq)
+	log.SetContextTags(ctx, map[string]string{
+		"request": string(requestData),
+	})
 	if err := fileReq.Validate(); err != nil {
 		return err
 	}

--- a/pkg/mc/federation/fed_zone.go
+++ b/pkg/mc/federation/fed_zone.go
@@ -426,7 +426,7 @@ func (p *PartnerApi) RegisterConsumerZones(ctx context.Context, consumer *ormapi
 	}
 	opZoneRes := fedewapi.ZoneRegistrationResponseData{}
 	apiPath := fmt.Sprintf("/%s/%s/zones", federationmgmt.ApiRoot, consumer.FederationContextId)
-	_, _, err = fedClient.SendRequest(ctx, "POST", apiPath, &opZoneReg, &opZoneRes, nil)
+	_, _, err = fedClient.SendRequest(ctx, "ZoneSubscribe", "POST", apiPath, &opZoneReg, &opZoneRes, nil)
 	if err != nil {
 		return err
 	}
@@ -635,7 +635,7 @@ func (p *PartnerApi) DeregisterConsumerZones(ctx context.Context, consumer *orma
 		if fedQueryParams.IgnorePartner {
 			log.SpanLog(ctx, log.DebugLevelApi, "skipping partner call", "method", "DELETE", "api", apiPath)
 		} else {
-			_, _, err = fedClient.SendRequest(ctx, "DELETE", apiPath, nil, nil, nil)
+			_, _, err = fedClient.SendRequest(ctx, "ZoneUnsubscribe", "DELETE", apiPath, nil, nil, nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/mc/orm/body_dump.go
+++ b/pkg/mc/orm/body_dump.go
@@ -81,13 +81,15 @@ func BodyDumpWithConfig(config BodyDumpConfig) echo.MiddlewareFunc {
 			// Request
 			reqBody := []byte{}
 			reqContentType := c.Request().Header.Get("Content-Type")
-			if strings.Contains(reqContentType, "application/json") {
-				if c.Request().Body != nil { // Read
-					reqBody, _ = ioutil.ReadAll(c.Request().Body)
+			if c.Request().Method != http.MethodGet {
+				if strings.Contains(reqContentType, "application/json") {
+					if c.Request().Body != nil { // Read
+						reqBody, _ = ioutil.ReadAll(c.Request().Body)
+					}
+					c.Request().Body = ioutil.NopCloser(bytes.NewBuffer(reqBody)) // Reset
+				} else {
+					reqBody = []byte(reqContentType + " data omitted")
 				}
-				c.Request().Body = ioutil.NopCloser(bytes.NewBuffer(reqBody)) // Reset
-			} else {
-				reqBody = []byte(reqContentType + " data omitted")
 			}
 			// Response
 			resBody := new(bytes.Buffer)

--- a/pkg/mc/orm/ctrl_test.go
+++ b/pkg/mc/orm/ctrl_test.go
@@ -1482,7 +1482,7 @@ func testControllerClientRun(t *testing.T, ctx context.Context, clientRun mctest
 		matches := de.WaitLastEventMatches(numEvents, func(event *node.EventData) bool {
 			log.DebugLog(log.DebugLevelInfo, "Check event", "event", *event)
 			lastEvent = event
-			if event.Name != apiUri {
+			if event.Name != api {
 				return false
 			}
 			if event.Type != "audit" {

--- a/pkg/mc/orm/federation_mc.go
+++ b/pkg/mc/orm/federation_mc.go
@@ -1322,7 +1322,7 @@ func ShareProviderZone(c echo.Context) (reterr error) {
 			OperationType:       "ADD_ZONES",
 			AddZones:            zoneDetails,
 		}
-		_, _, err = fedClient.SendRequest(ctx, "POST", "", &req, nil, nil)
+		_, _, err = fedClient.SendRequest(ctx, "ShareZone Callback", "POST", "", &req, nil, nil)
 		if err != nil {
 			return fmt.Errorf("failed to notify partner: %s", err)
 		}
@@ -1402,7 +1402,7 @@ func UnshareProviderZone(c echo.Context) error {
 			OperationType:       "REMOVE_ZONES",
 			RemoveZones:         rmZones,
 		}
-		_, _, err = fedClient.SendRequest(ctx, "POST", "", &req, nil, nil)
+		_, _, err = fedClient.SendRequest(ctx, "UnshareZone Callback", "POST", "", &req, nil, nil)
 		if err != nil {
 			return fmt.Errorf("failed to notify partner: %s", err)
 		}
@@ -1613,7 +1613,7 @@ func registerFederationConsumer(ctx context.Context, consumer *ormapi.Federation
 		ClientSecret: notifyKey,
 	}
 	req.PartnerCallbackCredentials = &ccreds
-	_, _, err = fedClient.SendRequest(ctx, "POST", "/"+fedmgmt.ApiRoot+"/partner", &req, &res, nil)
+	_, _, err = fedClient.SendRequest(ctx, "RegisterFedGuest", "POST", "/"+fedmgmt.ApiRoot+"/partner", &req, &res, nil)
 	if err != nil {
 		return err
 	}
@@ -1678,7 +1678,7 @@ func deregisterFederationConsumer(ctx context.Context, consumer *ormapi.Federati
 	if fedQueryParams.IgnorePartner {
 		log.SpanLog(ctx, log.DebugLevelApi, "skipping federation api call", "method", "DELETE", "api", apiPath)
 	} else {
-		_, _, err = fedClient.SendRequest(ctx, "DELETE", apiPath, nil, nil, nil)
+		_, _, err = fedClient.SendRequest(ctx, "DeregisterFedGuest", "DELETE", apiPath, nil, nil, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/mc/orm/fedmc_app.go
+++ b/pkg/mc/orm/fedmc_app.go
@@ -255,7 +255,7 @@ func createAppArtefact(ctx context.Context, consumer *ormapi.FederationConsumer,
 		return err
 	}
 	apiPath := fmt.Sprintf("/%s/%s/artefact", federationmgmt.ApiRoot, consumer.FederationContextId)
-	_, _, err = fedClient.SendRequest(ctx, http.MethodPost, apiPath, data, nil, nil)
+	_, _, err = fedClient.SendRequest(ctx, "CreateArtefact", http.MethodPost, apiPath, data, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -289,7 +289,7 @@ func createConsumerApp(ctx context.Context, consumer *ormapi.FederationConsumer,
 		return err
 	}
 	apiPath := fmt.Sprintf("/%s/%s/application/onboarding", federationmgmt.ApiRoot, consumer.FederationContextId)
-	_, _, err = fedClient.SendRequest(ctx, http.MethodPost, apiPath, appReq, nil, nil)
+	_, _, err = fedClient.SendRequest(ctx, "OnboardApp", http.MethodPost, apiPath, appReq, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -407,7 +407,7 @@ func deleteApp(ctx context.Context, consumer *ormapi.FederationConsumer, cApp *o
 		return err
 	}
 	apiPath := fmt.Sprintf("/%s/%s/application/onboarding/app/%s", federationmgmt.ApiRoot, consumer.FederationContextId, cApp.ID)
-	_, _, err = fedClient.SendRequest(ctx, http.MethodDelete, apiPath, nil, nil, nil)
+	_, _, err = fedClient.SendRequest(ctx, "DeleteApp", http.MethodDelete, apiPath, nil, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -420,7 +420,7 @@ func deleteAppArtefact(ctx context.Context, consumer *ormapi.FederationConsumer,
 		return err
 	}
 	apiPath := fmt.Sprintf("/%s/%s/artefact/%s", federationmgmt.ApiRoot, consumer.FederationContextId, cApp.ID)
-	_, _, err = fedClient.SendRequest(ctx, http.MethodDelete, apiPath, nil, nil, nil)
+	_, _, err = fedClient.SendRequest(ctx, "DeleteArtefact", http.MethodDelete, apiPath, nil, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/mc/orm/fedmc_direct.go
+++ b/pkg/mc/orm/fedmc_direct.go
@@ -14,7 +14,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func federationGetPartner(c echo.Context, consumerName, reqPath string, respObj interface{}) error {
+func federationGetPartner(c echo.Context, eventName, consumerName, reqPath string, respObj interface{}) error {
 	ctx := ormutil.GetContext(c)
 	claims, err := getClaims(c)
 	if err != nil {
@@ -29,7 +29,7 @@ func federationGetPartner(c echo.Context, consumerName, reqPath string, respObj 
 	}
 	apiPath := fmt.Sprintf("/%s/%s/%s", federationmgmt.ApiRoot, consumer.FederationContextId, reqPath)
 	fedClient, err := partnerApi.ConsumerPartnerClient(ctx, consumer)
-	_, _, err = fedClient.SendRequest(ctx, "GET", apiPath, nil, respObj, nil)
+	_, _, err = fedClient.SendRequest(ctx, eventName, "GET", apiPath, nil, respObj, nil)
 	if err != nil {
 		return err
 	}
@@ -43,7 +43,7 @@ func FederationGetPartner(c echo.Context) error {
 	}
 	reqPath := "partner"
 	resp := fedewapi.GetFederationDetails200Response{}
-	return federationGetPartner(c, in.Name, reqPath, &resp)
+	return federationGetPartner(c, "Direct GetPartner", in.Name, reqPath, &resp)
 }
 
 func FederationGetZone(c echo.Context) error {
@@ -53,7 +53,7 @@ func FederationGetZone(c echo.Context) error {
 	}
 	reqPath := "zones/" + in.ZoneId
 	resp := fedewapi.ZoneRegisteredData{}
-	return federationGetPartner(c, in.ConsumerName, reqPath, &resp)
+	return federationGetPartner(c, "Direct GetZone", in.ConsumerName, reqPath, &resp)
 }
 
 func FederationGetArtefact(c echo.Context) error {
@@ -63,7 +63,7 @@ func FederationGetArtefact(c echo.Context) error {
 	}
 	reqPath := "artefact/" + in.ID
 	resp := fedewapi.GetArtefact200Response{}
-	return federationGetPartner(c, in.FederationName, reqPath, &resp)
+	return federationGetPartner(c, "Direct GetArtefact", in.FederationName, reqPath, &resp)
 }
 
 func FederationGetFile(c echo.Context) error {
@@ -73,7 +73,7 @@ func FederationGetFile(c echo.Context) error {
 	}
 	reqPath := "files/" + in.ID
 	resp := fedewapi.ViewFile200Response{}
-	return federationGetPartner(c, in.FederationName, reqPath, &resp)
+	return federationGetPartner(c, "Direct GetFile", in.FederationName, reqPath, &resp)
 }
 
 func FederationGetApp(c echo.Context) error {
@@ -83,7 +83,7 @@ func FederationGetApp(c echo.Context) error {
 	}
 	reqPath := "application/onboarding/app/" + in.ID
 	resp := fedewapi.ViewApplication200Response{}
-	return federationGetPartner(c, in.FederationName, reqPath, &resp)
+	return federationGetPartner(c, "Direct GetApp", in.FederationName, reqPath, &resp)
 }
 
 func FederationGetAppInst(c echo.Context) error {
@@ -138,7 +138,7 @@ func FederationGetAppInst(c echo.Context) error {
 		apiPath := fmt.Sprintf("/%s/%s/application/lcm/app/%s/instance/%s/zone/%s", federationmgmt.ApiRoot, consumer.FederationContextId, app.GlobalId, ai.FedKey.AppInstId, ai.Key.ClusterInstKey.CloudletKey.Name)
 		out := fedewapi.GetAppInstanceDetails200Response{}
 		fedClient, err := partnerApi.ConsumerPartnerClient(ctx, consumer)
-		_, _, err = fedClient.SendRequest(ctx, "GET", apiPath, nil, &out, nil)
+		_, _, err = fedClient.SendRequest(ctx, "Direct GetFedAppInst", "GET", apiPath, nil, &out, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/mc/orm/fedmc_file.go
+++ b/pkg/mc/orm/fedmc_file.go
@@ -261,7 +261,7 @@ func createFederatedImageObj(ctx context.Context, image *ormapi.ConsumerImage) (
 		return err
 	}
 	apiPath := fmt.Sprintf("/%s/%s/files", federationmgmt.ApiRoot, consumer.FederationContextId)
-	_, _, err = fedClient.SendRequest(ctx, http.MethodPost, apiPath, data, nil, nil)
+	_, _, err = fedClient.SendRequest(ctx, "FedFiles", http.MethodPost, apiPath, data, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -331,7 +331,7 @@ func DeleteConsumerImage(c echo.Context) error {
 		if err != nil {
 			return err
 		}
-		_, _, err = fedClient.SendRequest(ctx, http.MethodDelete, apiPath, nil, nil, nil)
+		_, _, err = fedClient.SendRequest(ctx, "Delete FedFile", http.MethodDelete, apiPath, nil, nil, nil)
 		if err != nil && strings.Contains(strings.ToLower(err.Error()), "not found") {
 			err = nil
 		}

--- a/pkg/mc/ormclient/rest_client.go
+++ b/pkg/mc/ormclient/rest_client.go
@@ -304,7 +304,10 @@ func (s *Client) HttpJsonSendReq(method, uri, token string, reqData interface{},
 			reqBody, _ = ioutil.ReadAll(req.Body)
 		}
 		req.Body = ioutil.NopCloser(bytes.NewBuffer(reqBody))
+	} else if mpfd, ok := reqData.(*MultiPartFormData); ok && s.AuditLogFunc != nil {
+		reqBody, _ = json.Marshal(mpfd.fields)
 	}
+
 	// send request
 	resp, err := client.Do(req)
 
@@ -574,7 +577,7 @@ func (s *Client) EnablePrintTransformations() {
 func (s *AuditLogData) GetEventTags() map[string]string {
 	return map[string]string{
 		"method":            s.Method,
-		"url":               s.Url.String(),
+		"remoteurl":         s.Url.String(),
 		"req-content-type":  s.ReqContentType,
 		"request":           string(s.ReqBody),
 		"status":            fmt.Sprintf("%d", s.Status),

--- a/test/e2e-tests/data/mc_admin_eventsshow.yml
+++ b/test/e2e-tests/data/mc_admin_eventsshow.yml
@@ -25,8 +25,8 @@
     - audit
   notmatch:
     names:
-    - /api/v1/auth/events/show
-    - /api/v1/auth/events/terms
+    - ShowEvents
+    - EventTerms
 - limit: 3
   match:
     failed: true
@@ -41,4 +41,4 @@
 - limit: 3
   match:
     names:
-    - /api/v1/auth/ctrl/CreateApp
+    - CreateApp

--- a/test/e2e-tests/data/mc_admin_eventsshow_exp.yml
+++ b/test/e2e-tests/data/mc_admin_eventsshow_exp.yml
@@ -117,11 +117,11 @@
       - audit
     notmatch:
       names:
-      - /api/v1/auth/events/show
-      - /api/v1/auth/events/terms
+      - ShowEvents
+      - EventTerms
     limit: 5
   results:
-  - name: /api/v1/auth/ctrl/DeleteAutoProvPolicy
+  - name: DeleteAutoProvPolicy
     org:
     - AcmeAppCo
     type: audit
@@ -130,6 +130,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/DeleteAutoProvPolicy
       method: POST
       org: AcmeAppCo
       policy: autoprovHA
@@ -142,7 +143,7 @@
       status: "200"
       traceid: ""
       username: user2
-  - name: /api/v1/auth/ctrl/DeleteApp
+  - name: DeleteApp
     org:
     - AcmeAppCo
     type: audit
@@ -154,6 +155,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/DeleteApp
       method: POST
       org: AcmeAppCo
       region: local
@@ -164,7 +166,7 @@
       status: "200"
       traceid: ""
       username: user2
-  - name: /api/v1/auth/ctrl/UpdateCloudlet
+  - name: UpdateCloudlet
     org:
     - dmuus
     type: audit
@@ -176,6 +178,7 @@
       federatedorg: ""
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/UpdateCloudlet
       method: POST
       org: dmuus
       region: local
@@ -187,7 +190,7 @@
       status: "200"
       traceid: ""
       username: user1
-  - name: /api/v1/auth/ctrl/RemoveAutoProvPolicyCloudlet
+  - name: RemoveAutoProvPolicyCloudlet
     org:
     - AcmeAppCo
     type: audit
@@ -196,6 +199,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/RemoveAutoProvPolicyCloudlet
       method: POST
       org: AcmeAppCo
       policy: autoprovHA
@@ -208,7 +212,7 @@
       status: "200"
       traceid: ""
       username: user2
-  - name: /api/v1/auth/ctrl/UpdateCloudlet
+  - name: UpdateCloudlet
     org:
     - dmuus
     type: audit
@@ -220,6 +224,7 @@
       federatedorg: ""
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/UpdateCloudlet
       method: POST
       org: dmuus
       region: local
@@ -241,7 +246,7 @@
       failed: true
     limit: 3
   results:
-  - name: /api/v1/auth/org/delete
+  - name: DeleteOrg
     org:
     - platos
     type: audit
@@ -250,6 +255,7 @@
       email: mexadmin-email-not-specified
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/org/delete
       method: POST
       org: platos
       remote-ip: 127.0.0.1
@@ -260,7 +266,7 @@
       status: "400"
       traceid: ""
       username: mexadmin
-  - name: /api/v1/auth/org/delete
+  - name: DeleteOrg
     org:
     - gcp
     type: audit
@@ -269,6 +275,7 @@
       email: mexadmin-email-not-specified
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/org/delete
       method: POST
       org: gcp
       remote-ip: 127.0.0.1
@@ -279,7 +286,7 @@
       status: "400"
       traceid: ""
       username: mexadmin
-  - name: /api/v1/auth/org/delete
+  - name: DeleteOrg
     org:
     - azure
     type: audit
@@ -288,6 +295,7 @@
       email: mexadmin-email-not-specified
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/org/delete
       method: POST
       org: azure
       remote-ip: 127.0.0.1
@@ -304,7 +312,7 @@
       - AcmeAppCo
     limit: 3
   results:
-  - name: /api/v1/auth/ctrl/DeleteAutoProvPolicy
+  - name: DeleteAutoProvPolicy
     org:
     - AcmeAppCo
     type: audit
@@ -313,6 +321,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/DeleteAutoProvPolicy
       method: POST
       org: AcmeAppCo
       policy: autoprovHA
@@ -369,7 +378,7 @@
         app: someapplication1
     limit: 3
   results:
-  - name: /api/v1/auth/ctrl/CreateAppInst
+  - name: CreateAppInst
     org:
     - AcmeAppCo
     type: audit
@@ -386,6 +395,7 @@
       federatedorg: ""
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/CreateAppInst
       method: POST
       org: AcmeAppCo
       region: locala
@@ -400,7 +410,7 @@
       status: "200"
       traceid: ""
       username: user2
-  - name: /api/v1/auth/ctrl/CreateAppInst
+  - name: CreateAppInst
     org:
     - AcmeAppCo
     type: audit
@@ -417,6 +427,7 @@
       federatedorg: ""
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/CreateAppInst
       method: POST
       org: AcmeAppCo
       region: locala
@@ -431,7 +442,7 @@
       status: "200"
       traceid: ""
       username: user2
-  - name: /api/v1/auth/ctrl/CreateApp
+  - name: CreateApp
     org:
     - AcmeAppCo
     type: audit
@@ -443,6 +454,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/CreateApp
       method: POST
       org: AcmeAppCo
       region: locala
@@ -458,10 +470,10 @@
 - search:
     match:
       names:
-      - /api/v1/auth/ctrl/CreateApp
+      - CreateApp
     limit: 3
   results:
-  - name: /api/v1/auth/ctrl/CreateApp
+  - name: CreateApp
     org:
     - AcmeAppCo
     type: audit
@@ -473,6 +485,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/CreateApp
       method: POST
       org: AcmeAppCo
       region: local
@@ -483,7 +496,7 @@
       status: "200"
       traceid: ""
       username: user2
-  - name: /api/v1/auth/ctrl/CreateApp
+  - name: CreateApp
     org:
     - user3org
     type: audit
@@ -495,6 +508,7 @@
       email: user3@enterprise.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/CreateApp
       method: POST
       org: user3org
       region: local
@@ -505,7 +519,7 @@
       status: "200"
       traceid: ""
       username: user3
-  - name: /api/v1/auth/ctrl/CreateApp
+  - name: CreateApp
     org:
     - platos
     type: audit
@@ -517,6 +531,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/CreateApp
       method: POST
       org: platos
       region: locala

--- a/test/e2e-tests/data/mc_admin_eventsterms_exp.yml
+++ b/test/e2e-tests/data/mc_admin_eventsterms_exp.yml
@@ -14,37 +14,7 @@
 
 - terms:
     names:
-    - key: /api/v1/auth/billingorg/create
-    - key: /api/v1/auth/cloudletpoolaccessinvitation/create
-    - key: /api/v1/auth/cloudletpoolaccessresponse/create
-    - key: /api/v1/auth/config/update
-    - key: /api/v1/auth/ctrl/CreateApp
-    - key: /api/v1/auth/ctrl/CreateAppInst
-    - key: /api/v1/auth/ctrl/CreateAutoProvPolicy
-    - key: /api/v1/auth/ctrl/CreateAutoScalePolicy
-    - key: /api/v1/auth/ctrl/CreateCloudlet
-    - key: /api/v1/auth/ctrl/CreateCloudletPool
-    - key: /api/v1/auth/ctrl/CreateClusterInst
-    - key: /api/v1/auth/ctrl/CreateGPUDriver
-    - key: /api/v1/auth/ctrl/CreateOperatorCode
-    - key: /api/v1/auth/ctrl/DeleteApp
-    - key: /api/v1/auth/ctrl/DeleteAppInst
-    - key: /api/v1/auth/ctrl/DeleteAutoProvPolicy
-    - key: /api/v1/auth/ctrl/RemoveAutoProvPolicyCloudlet
-    - key: /api/v1/auth/ctrl/RunCommand
-    - key: /api/v1/auth/ctrl/RunDebug
-    - key: /api/v1/auth/ctrl/ShowApp
-    - key: /api/v1/auth/ctrl/ShowLogs
-    - key: /api/v1/auth/ctrl/UpdateCloudlet
-    - key: /api/v1/auth/ctrl/UpdateSettings
-    - key: /api/v1/auth/events/terms
-    - key: /api/v1/auth/org/create
-    - key: /api/v1/auth/org/delete
-    - key: /api/v1/auth/ratelimitsettingsmc/createflow
-    - key: /api/v1/auth/ratelimitsettingsmc/createmaxreqs
-    - key: /api/v1/auth/ratelimitsettingsmc/deleteflow
-    - key: /api/v1/auth/ratelimitsettingsmc/deletemaxreqs
-    - key: /api/v1/auth/ratelimitsettingsmc/updateflow
+    - key: AccessCloudlet
     - key: AutoCluster create
     - key: AutoProv create AppInst
     - key: AutoProv delete AppInst
@@ -52,8 +22,39 @@
     - key: Cloudlet maintenance start
     - key: Cloudlet online
     - key: ClusterAutoScale ClusterInst
+    - key: CreateApp
+    - key: CreateAppInst
+    - key: CreateAutoProvPolicy
+    - key: CreateAutoScalePolicy
+    - key: CreateBillingOrg
+    - key: CreateCloudlet
+    - key: CreateCloudletPool
+    - key: CreateCloudletPoolAccessInvitation
+    - key: CreateCloudletPoolAccessResponse
+    - key: CreateClusterInst
+    - key: CreateFlowRateLimitSettingsMc
+    - key: CreateGPUDriver
+    - key: CreateMaxReqsRateLimitSettingsMc
+    - key: CreateOperatorCode
+    - key: CreateOrg
+    - key: DeleteApp
+    - key: DeleteAppInst
+    - key: DeleteAutoProvPolicy
+    - key: DeleteFlowRateLimitSettingsMc
+    - key: DeleteMaxReqsRateLimitSettingsMc
+    - key: DeleteOrg
+    - key: EventTerms
     - key: Free ClusterInst reservation
+    - key: RemoveAutoProvPolicyCloudlet
     - key: Reserve ClusterInst
+    - key: RunCommand
+    - key: RunDebug
+    - key: ShowApp
+    - key: ShowLogs
+    - key: UpdateCloudlet
+    - key: UpdateConfig
+    - key: UpdateFlowRateLimitSettingsMc
+    - key: UpdateSettings
     - key: cluster-svc create App
     - key: cluster-svc create AppInst
     - key: crm start
@@ -93,6 +94,7 @@
     - key: gpudriverorg
     - key: hostname
     - key: lineno
+    - key: localuri
     - key: maintenance-state
     - key: method
     - key: new nodecount

--- a/test/e2e-tests/data/mc_admin_orgeventsshow_exp.yml
+++ b/test/e2e-tests/data/mc_admin_orgeventsshow_exp.yml
@@ -18,7 +18,7 @@
       - AcmeAppCo
     limit: 3
   results:
-  - name: /api/v1/auth/org/delete
+  - name: DeleteOrg
     org:
     - AcmeAppCo
     type: audit
@@ -27,6 +27,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/org/delete
       method: POST
       org: AcmeAppCo
       remote-ip: 127.0.0.1
@@ -36,7 +37,7 @@
       status: "200"
       traceid: ""
       username: user2
-  - name: /api/v1/auth/org/create
+  - name: CreateOrg
     org:
     - AcmeAppCo
     type: audit
@@ -45,6 +46,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/org/create
       method: POST
       org: AcmeAppCo
       remote-ip: 127.0.0.1
@@ -54,7 +56,7 @@
       status: "200"
       traceid: ""
       username: user2
-  - name: /api/v1/auth/org/delete
+  - name: DeleteOrg
     org:
     - AcmeAppCo
     type: audit
@@ -63,6 +65,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/org/delete
       method: POST
       org: AcmeAppCo
       remote-ip: 127.0.0.1

--- a/test/e2e-tests/data/mc_user1_eventsshow.yml
+++ b/test/e2e-tests/data/mc_user1_eventsshow.yml
@@ -15,7 +15,7 @@
 - limit: 3
   match:
     names:
-    - /api/v1/auth/ctrl/CreateAppInst
+    - CreateAppInst
 - limit: 3
   match:
     tags:

--- a/test/e2e-tests/data/mc_user1_eventsshow_exp.yml
+++ b/test/e2e-tests/data/mc_user1_eventsshow_exp.yml
@@ -15,10 +15,10 @@
 - search:
     match:
       names:
-      - /api/v1/auth/ctrl/CreateAppInst
+      - CreateAppInst
     limit: 3
   results:
-  - name: /api/v1/auth/ctrl/CreateAppInst
+  - name: CreateAppInst
     org:
     - user3org
     - enterprise
@@ -36,6 +36,7 @@
       federatedorg: ""
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/CreateAppInst
       method: POST
       org: user3org
       region: local

--- a/test/e2e-tests/data/mc_user2_eventsshow.yml
+++ b/test/e2e-tests/data/mc_user2_eventsshow.yml
@@ -22,8 +22,8 @@
     failed: true
   notmatch:
     names:
-    - "*/auth/ctrl/RunCommand"
-    - "*/auth/ctrl/ShowLogs"
+    - RunCommand
+    - ShowLogs
 - limit: 3
   match:
     orgs:
@@ -40,7 +40,7 @@
 - limit: 3
   match:
     names:
-    - /api/v1/auth/ctrl/CreateApp
+    - CreateApp
 - limit: 3
   match:
     tags:
@@ -75,4 +75,4 @@
 - limit: 3
   match:
     names:
-    - /api/v1/auth/org/create
+    - CreateOrg

--- a/test/e2e-tests/data/mc_user2_eventsshow_exp.yml
+++ b/test/e2e-tests/data/mc_user2_eventsshow_exp.yml
@@ -17,11 +17,11 @@
       failed: true
     notmatch:
       names:
-      - '*/auth/ctrl/RunCommand'
-      - '*/auth/ctrl/ShowLogs'
+      - RunCommand
+      - ShowLogs
     limit: 3
   results:
-  - name: /api/v1/auth/org/delete
+  - name: DeleteOrg
     org:
     - platos
     type: audit
@@ -30,6 +30,7 @@
       email: mexadmin-email-not-specified
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/org/delete
       method: POST
       org: platos
       remote-ip: 127.0.0.1
@@ -40,7 +41,7 @@
       status: "400"
       traceid: ""
       username: mexadmin
-  - name: /api/v1/auth/org/delete
+  - name: DeleteOrg
     org:
     - AcmeAppCo
     type: audit
@@ -49,6 +50,7 @@
       email: mexadmin-email-not-specified
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/org/delete
       method: POST
       org: AcmeAppCo
       remote-ip: 127.0.0.1
@@ -72,7 +74,7 @@
         reason: orphaned
     limit: 3
   results:
-  - name: /api/v1/auth/ctrl/DeleteAutoProvPolicy
+  - name: DeleteAutoProvPolicy
     org:
     - AcmeAppCo
     type: audit
@@ -81,6 +83,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/DeleteAutoProvPolicy
       method: POST
       org: AcmeAppCo
       policy: autoprovHA
@@ -137,7 +140,7 @@
         app: someapplication1
     limit: 3
   results:
-  - name: /api/v1/auth/ctrl/CreateAppInst
+  - name: CreateAppInst
     org:
     - AcmeAppCo
     type: audit
@@ -154,6 +157,7 @@
       federatedorg: ""
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/CreateAppInst
       method: POST
       org: AcmeAppCo
       region: locala
@@ -168,7 +172,7 @@
       status: "200"
       traceid: ""
       username: user2
-  - name: /api/v1/auth/ctrl/CreateAppInst
+  - name: CreateAppInst
     org:
     - AcmeAppCo
     type: audit
@@ -185,6 +189,7 @@
       federatedorg: ""
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/CreateAppInst
       method: POST
       org: AcmeAppCo
       region: locala
@@ -199,7 +204,7 @@
       status: "200"
       traceid: ""
       username: user2
-  - name: /api/v1/auth/ctrl/CreateApp
+  - name: CreateApp
     org:
     - AcmeAppCo
     type: audit
@@ -211,6 +216,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/CreateApp
       method: POST
       org: AcmeAppCo
       region: locala
@@ -226,10 +232,10 @@
 - search:
     match:
       names:
-      - /api/v1/auth/ctrl/CreateApp
+      - CreateApp
     limit: 3
   results:
-  - name: /api/v1/auth/ctrl/CreateApp
+  - name: CreateApp
     org:
     - AcmeAppCo
     type: audit
@@ -241,6 +247,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/CreateApp
       method: POST
       org: AcmeAppCo
       region: local
@@ -251,7 +258,7 @@
       status: "200"
       traceid: ""
       username: user2
-  - name: /api/v1/auth/ctrl/CreateApp
+  - name: CreateApp
     org:
     - platos
     type: audit
@@ -263,6 +270,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/CreateApp
       method: POST
       org: platos
       region: locala
@@ -273,7 +281,7 @@
       status: "200"
       traceid: ""
       username: user2
-  - name: /api/v1/auth/ctrl/CreateApp
+  - name: CreateApp
     org:
     - AcmeAppCo
     type: audit
@@ -285,6 +293,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/CreateApp
       method: POST
       org: AcmeAppCo
       region: locala
@@ -433,7 +442,7 @@
         cloudlet: dmuus cloud
     limit: 4
   results:
-  - name: /api/v1/auth/ctrl/CreateAppInst
+  - name: CreateAppInst
     org:
     - AcmeAppCo
     type: audit
@@ -450,6 +459,7 @@
       federatedorg: ""
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/CreateAppInst
       method: POST
       org: AcmeAppCo
       region: locala
@@ -464,7 +474,7 @@
       status: "200"
       traceid: ""
       username: user2
-  - name: /api/v1/auth/ctrl/CreateAppInst
+  - name: CreateAppInst
     org:
     - AcmeAppCo
     type: audit
@@ -481,6 +491,7 @@
       federatedorg: ""
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/CreateAppInst
       method: POST
       org: AcmeAppCo
       region: locala
@@ -615,7 +626,7 @@
       - audit
     limit: 3
   results:
-  - name: /api/v1/auth/ctrl/DeleteAutoProvPolicy
+  - name: DeleteAutoProvPolicy
     org:
     - AcmeAppCo
     type: audit
@@ -624,6 +635,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/DeleteAutoProvPolicy
       method: POST
       org: AcmeAppCo
       policy: autoprovHA
@@ -636,7 +648,7 @@
       status: "200"
       traceid: ""
       username: user2
-  - name: /api/v1/auth/ctrl/DeleteApp
+  - name: DeleteApp
     org:
     - AcmeAppCo
     type: audit
@@ -648,6 +660,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/DeleteApp
       method: POST
       org: AcmeAppCo
       region: local
@@ -658,7 +671,7 @@
       status: "200"
       traceid: ""
       username: user2
-  - name: /api/v1/auth/ctrl/RemoveAutoProvPolicyCloudlet
+  - name: RemoveAutoProvPolicyCloudlet
     org:
     - AcmeAppCo
     type: audit
@@ -667,6 +680,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/RemoveAutoProvPolicyCloudlet
       method: POST
       org: AcmeAppCo
       policy: autoprovHA
@@ -685,7 +699,7 @@
         username: user2
     limit: 3
   results:
-  - name: /api/v1/auth/ctrl/DeleteAutoProvPolicy
+  - name: DeleteAutoProvPolicy
     org:
     - AcmeAppCo
     type: audit
@@ -694,6 +708,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/DeleteAutoProvPolicy
       method: POST
       org: AcmeAppCo
       policy: autoprovHA
@@ -706,7 +721,7 @@
       status: "200"
       traceid: ""
       username: user2
-  - name: /api/v1/auth/ctrl/DeleteApp
+  - name: DeleteApp
     org:
     - AcmeAppCo
     type: audit
@@ -718,6 +733,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/DeleteApp
       method: POST
       org: AcmeAppCo
       region: local
@@ -728,7 +744,7 @@
       status: "200"
       traceid: ""
       username: user2
-  - name: /api/v1/auth/ctrl/RemoveAutoProvPolicyCloudlet
+  - name: RemoveAutoProvPolicyCloudlet
     org:
     - AcmeAppCo
     type: audit
@@ -737,6 +753,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/RemoveAutoProvPolicyCloudlet
       method: POST
       org: AcmeAppCo
       policy: autoprovHA
@@ -752,10 +769,10 @@
 - search:
     match:
       names:
-      - /api/v1/auth/org/create
+      - CreateOrg
     limit: 3
   results:
-  - name: /api/v1/auth/org/create
+  - name: CreateOrg
     org:
     - platos
     type: audit
@@ -764,6 +781,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/org/create
       method: POST
       org: platos
       remote-ip: 127.0.0.1
@@ -773,7 +791,7 @@
       status: "200"
       traceid: ""
       username: user2
-  - name: /api/v1/auth/org/create
+  - name: CreateOrg
     org:
     - AcmeAppCo
     type: audit
@@ -782,6 +800,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/org/create
       method: POST
       org: AcmeAppCo
       remote-ip: 127.0.0.1

--- a/test/e2e-tests/data/mc_user2_eventsterms_exp.yml
+++ b/test/e2e-tests/data/mc_user2_eventsterms_exp.yml
@@ -14,25 +14,25 @@
 
 - terms:
     names:
-    - key: /api/v1/auth/ctrl/CreateApp
-    - key: /api/v1/auth/ctrl/CreateAppInst
-    - key: /api/v1/auth/ctrl/CreateAutoProvPolicy
-    - key: /api/v1/auth/ctrl/CreateAutoScalePolicy
-    - key: /api/v1/auth/ctrl/CreateClusterInst
-    - key: /api/v1/auth/ctrl/DeleteApp
-    - key: /api/v1/auth/ctrl/DeleteAppInst
-    - key: /api/v1/auth/ctrl/DeleteAutoProvPolicy
-    - key: /api/v1/auth/ctrl/RemoveAutoProvPolicyCloudlet
-    - key: /api/v1/auth/ctrl/RunCommand
-    - key: /api/v1/auth/ctrl/ShowLogs
-    - key: /api/v1/auth/org/create
-    - key: /api/v1/auth/org/delete
     - key: AutoCluster create
     - key: AutoProv create AppInst
     - key: AutoProv delete AppInst
     - key: ClusterAutoScale ClusterInst
+    - key: CreateApp
+    - key: CreateAppInst
+    - key: CreateAutoProvPolicy
+    - key: CreateAutoScalePolicy
+    - key: CreateClusterInst
+    - key: CreateOrg
+    - key: DeleteApp
+    - key: DeleteAppInst
+    - key: DeleteAutoProvPolicy
+    - key: DeleteOrg
     - key: Free ClusterInst reservation
+    - key: RemoveAutoProvPolicyCloudlet
     - key: Reserve ClusterInst
+    - key: RunCommand
+    - key: ShowLogs
     orgs:
     - key: AcmeAppCo
     - key: platos
@@ -55,6 +55,7 @@
     - key: federatedorg
     - key: hostname
     - key: lineno
+    - key: localuri
     - key: method
     - key: new nodecount
     - key: org

--- a/test/e2e-tests/data/mc_user2_orgeventsshow_empty.yml
+++ b/test/e2e-tests/data/mc_user2_orgeventsshow_empty.yml
@@ -18,7 +18,7 @@
       - AcmeAppCo
     limit: 3
   results:
-  - name: /api/v1/auth/org/create
+  - name: CreateOrg
     org:
     - AcmeAppCo
     type: audit
@@ -27,6 +27,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/org/create
       method: POST
       org: AcmeAppCo
       remote-ip: 127.0.0.1

--- a/test/e2e-tests/data/mc_user2_orgeventsshow_exp.yml
+++ b/test/e2e-tests/data/mc_user2_orgeventsshow_exp.yml
@@ -18,7 +18,7 @@
       - AcmeAppCo
     limit: 3
   results:
-  - name: /api/v1/auth/ctrl/DeleteAutoProvPolicy
+  - name: DeleteAutoProvPolicy
     org:
     - AcmeAppCo
     type: audit
@@ -27,6 +27,7 @@
       email: user2@email.com
       hostname: ""
       lineno: ""
+      localuri: /api/v1/auth/ctrl/DeleteAutoProvPolicy
       method: POST
       org: AcmeAppCo
       policy: autoprovHA


### PR DESCRIPTION
This changes audit log names. Previously we used the URI path which is long, has unnecessary info, and in the case of federation, can be very long and contain path parameters. We now change it to the Go function name that handles the request, as this was the easiest way to get something short and sensible in an automated way. This info is already present in the echo router. The URI/URL is now logged as part of the tags.

For outgoing federation EWBI API requests we need to explicitly pass in an auditName.

Finally, added a few changes to be able to log the fields portion of multipart/form-data requests (ignores the files part).

TODO: we need some approach to be able to log GETs/Show commands without flooding the audit logs with them. Right now our Federation partner is running a GET per appinst every 7 seconds, and there's no need to log every single one. But it is useful to be able to see them when debugging.

