### PR TITLE
Fix federation geo precision, Add accept header to requests

### DIFF
--- a/pkg/mc/federation/common/utils.go
+++ b/pkg/mc/federation/common/utils.go
@@ -53,10 +53,51 @@ func ParseGeoLocation(geoLoc string) (float64, float64, error) {
 	return lat, long, nil
 }
 
+// Removes trailing zeros from string.
+// If a decimal point exists and everything after it is zeros,
+// the decimal point is also removed.
+func RemoveTrailingZeros(val string) string {
+	if len(val) == 0 {
+		return val
+	}
+	decIdx := -1
+	countTrailingZeros := true
+	trailingZeros := 0
+	for ii := len(val) - 1; ii >= 0; ii-- {
+		if countTrailingZeros {
+			if val[ii] == '0' {
+				trailingZeros++
+			} else if val[ii] == '.' {
+				trailingZeros++
+				countTrailingZeros = false
+			} else {
+				countTrailingZeros = false
+			}
+		}
+		if val[ii] == '.' {
+			decIdx = ii
+		}
+	}
+	if decIdx == -1 || trailingZeros == 0 {
+		// not a decimal or no trailing zeros to strip
+		return val
+	}
+	return val[:len(val)-trailingZeros]
+}
+
 // Generate a geo location string.
+// Note that this is used for federation which has restrictions
+// on the precision produced.
 func GenGeoLocation(latitude, longitude float64) string {
-	lat := strconv.FormatFloat(latitude, 'g', -1, 64)
-	long := strconv.FormatFloat(longitude, 'g', -1, 64)
+	// Use 'f' since federation precision is the number
+	// of decimal places, not the entire number.
+	// Can't use 'g' because precision applies the number
+	// of non-zero digits, regardless of decimal place.
+	lat := strconv.FormatFloat(latitude, 'f', 4, 64)
+	long := strconv.FormatFloat(longitude, 'f', 4, 64)
+	// make it pretty
+	lat = RemoveTrailingZeros(lat)
+	long = RemoveTrailingZeros(long)
 	return lat + "," + long
 }
 

--- a/pkg/mc/federation/common/utils_test.go
+++ b/pkg/mc/federation/common/utils_test.go
@@ -7,14 +7,66 @@ import (
 	"github.com/test-go/testify/require"
 )
 
+func TestRemoveTrailingZeros(t *testing.T) {
+	tests := []struct {
+		in  string
+		out string
+	}{{
+		"1000", "1000", // identity tests
+	}, {
+		"100.001", "100.001",
+	}, {
+		"1239", "1239",
+	}, {
+		"-3030.012345931", "-3030.012345931",
+	}, {
+		"1", "1",
+	}, {
+		"0", "0",
+	}, {
+		"0000", "0000",
+	}, {
+		"", "",
+	}, {
+		"100.0", "100", // remove trailing zeros
+	}, {
+		"987.12300", "987.123",
+	}, {
+		"101.1001000", "101.1001",
+	}, {
+		"0.00001000", "0.00001",
+	}, {
+		"00.00", "00",
+	}, {
+		".", "",
+	}, {
+		"100.", "100",
+	}}
+	for _, test := range tests {
+		out := RemoveTrailingZeros(test.in)
+		require.Equal(t, test.out, out)
+	}
+}
+
 func TestGeoLocation(t *testing.T) {
 	lat, long := float64(1.54234), float64(-2.123445)
 	str := GenGeoLocation(lat, long)
-	require.Equal(t, "1.54234,-2.123445", str)
+	require.Equal(t, "1.5423,-2.1234", str)
 
+	// leading zeros
+	lat, long = float64(0.000111111), float64(-0.0001111111)
+	str = GenGeoLocation(lat, long)
+	require.Equal(t, "0.0001,-0.0001", str)
+
+	// max values
 	lat, long = float64(90.0), float64(-180.0)
 	str = GenGeoLocation(lat, long)
 	require.Equal(t, "90,-180", str)
+
+	// 4-digit decimal precision is after decimal, not entire number
+	lat, long = float64(-89.199199), float64(179.1991999)
+	str = GenGeoLocation(lat, long)
+	require.Equal(t, "-89.1992,179.1992", str)
 
 	tests := []struct {
 		in      string

--- a/pkg/mc/orm/federation_test.go
+++ b/pkg/mc/orm/federation_test.go
@@ -155,6 +155,10 @@ func SetupControllerService(t *testing.T, ctx context.Context, operatorIds []str
 					Value: ResourceValue,
 				},
 			}
+			// test that geo location is generated with
+			// correctly truncated precision
+			clObj.Location.Latitude = 1.1392349083
+			clObj.Location.Longitude = 2.3409209843
 			ds.CloudletCache.Update(ctx, &clObj, 0)
 		} else {
 			clObj := edgeproto.CloudletInfo{}

--- a/pkg/mc/ormclient/rest_client.go
+++ b/pkg/mc/ormclient/rest_client.go
@@ -255,6 +255,11 @@ func (s *Client) HttpJsonSendReq(method, uri, token string, reqData interface{},
 			req.Header.Add(k, v)
 		}
 	}
+	if req.Header.Get("accept") == "" {
+		// some APIs require that we specify the accept header;
+		// since none set by caller, assume we accept json
+		req.Header.Set("accept", "application/json")
+	}
 	if queryParams != nil {
 		vals := req.URL.Query()
 		for k, v := range queryParams {


### PR DESCRIPTION
Fixes two issues found during partner federation testing.

The geo location string generated by us may not be valid. It may include too many decimal precision points. This reworks the code that generates the geo location string to meet the federation geo location format spec (spec limited to 4 decimal precision places).

A partner API was rejecting our API calls since we did not supply an "accept" header. Add a default accept header to our requests. I don't think we have any requests that expect anything outside of json.