### PR TITLE
audit log include header values

### DIFF
--- a/pkg/federationmgmt/client.go
+++ b/pkg/federationmgmt/client.go
@@ -190,7 +190,7 @@ func (c *Client) SendRequest(ctx context.Context, eventName, method, endpoint st
 func (c *Client) audit(ctx context.Context, eventName string, fedKey *FedKey, data *ormclient.AuditLogData) {
 	data.RespBody = ClientSecretFieldClearer.Clear(data.RespBody)
 
-	log.SpanLog(ctx, log.DebugLevelApi, eventName, "method", data.Method, "remoteurl", data.Url.String(), "reqContentType", data.ReqContentType, "req", string(data.ReqBody), "status", data.Status, "respContentType", data.RespContentType, "resp", string(data.RespBody), "err", data.Err, "took", data.End.Sub(data.Start).String())
+	log.SpanLog(ctx, log.DebugLevelApi, eventName, "method", data.Method, "remoteurl", data.Url.String(), "reqContentType", data.ReqContentType, "req", string(data.ReqBody), "reqheaders", util.GetHeadersString(data.ReqHeader), "status", data.Status, "respContentType", data.RespContentType, "respheaders", util.GetHeadersString(data.RespHeader), "resp", string(data.RespBody), "err", data.Err, "took", data.End.Sub(data.Start).String())
 	if c.auditLogCb != nil {
 		c.auditLogCb(ctx, eventName, fedKey, data)
 	}

--- a/pkg/mc/orm/auditlog.go
+++ b/pkg/mc/orm/auditlog.go
@@ -122,6 +122,7 @@ func (s *AuditLogger) echoHandler(next echo.HandlerFunc) echo.HandlerFunc {
 
 		reqBody := []byte{}
 		resBody := []byte{}
+		reqHeaders := util.GetHeadersString(req.Header)
 		if strings.HasPrefix(req.RequestURI, "/ws/") {
 			// can't use bodydump on websocket-upgraded connection,
 			// as it tries to write the response back in the body
@@ -153,6 +154,7 @@ func (s *AuditLogger) echoHandler(next echo.HandlerFunc) echo.HandlerFunc {
 		}
 
 		response := ""
+		resHeaders := util.GetHeadersString(res.Header())
 		if ws := ormutil.GetWs(ec); ws != nil {
 			wsRequest, wsResponse := ormutil.GetWsLogData(ec)
 			if len(wsRequest) > 0 {
@@ -366,6 +368,8 @@ func (s *AuditLogger) echoHandler(next echo.HandlerFunc) echo.HandlerFunc {
 			eventTags["status"] = fmt.Sprintf("%d", code)
 			eventOrg := ""
 			eventTags["localuri"] = req.RequestURI
+			eventTags["reqheaders"] = reqHeaders
+			eventTags["respheaders"] = resHeaders
 			for k, v := range log.GetTags(span) {
 				if k == "level" || k == "error" || log.IgnoreSpanTag(k) {
 					continue

--- a/pkg/mc/ormclient/rest_client.go
+++ b/pkg/mc/ormclient/rest_client.go
@@ -37,6 +37,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/mcctl/mctestclient"
 	"github.com/edgexr/edge-cloud-platform/pkg/mcctl/ormctl"
+	"github.com/edgexr/edge-cloud-platform/pkg/util"
 	"github.com/gorilla/websocket"
 	"github.com/mitchellh/mapstructure"
 )
@@ -581,12 +582,12 @@ func (s *Client) EnablePrintTransformations() {
 
 func (s *AuditLogData) GetEventTags() map[string]string {
 	return map[string]string{
-		"method":            s.Method,
-		"remoteurl":         s.Url.String(),
-		"req-content-type":  s.ReqContentType,
-		"request":           string(s.ReqBody),
-		"status":            fmt.Sprintf("%d", s.Status),
-		"resp-content-type": s.RespContentType,
-		"response":          string(s.RespBody),
+		"method":      s.Method,
+		"remoteurl":   s.Url.String(),
+		"reqheaders":  util.GetHeadersString(s.ReqHeader),
+		"request":     string(s.ReqBody),
+		"status":      fmt.Sprintf("%d", s.Status),
+		"response":    string(s.RespBody),
+		"respheaders": util.GetHeadersString(s.RespHeader),
 	}
 }

--- a/test/e2e-tests/data/mc_admin_eventsshow_exp.yml
+++ b/test/e2e-tests/data/mc_admin_eventsshow_exp.yml
@@ -137,7 +137,9 @@
       policyorg: AcmeAppCo
       region: local
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"405","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"AutoProvPolicy":{"cloudlets":[{"key":{"name":"dmuus-cloud-1","organization":"dmuus"}},{"key":{"name":"dmuus-cloud-2","organization":"dmuus"}},{"key":{"name":"azure-cloud-4","organization":"azure"}},{"key":{"name":"gcp-cloud-5","organization":"gcp"}}],"key":{"name":"autoprovHA","organization":"AcmeAppCo"},"max_instances":4,"min_active_instances":2},"Region":"local"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"
@@ -160,7 +162,9 @@
       org: AcmeAppCo
       region: local
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"381","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"App":{"access_ports":"tcp:82","auto_prov_policies":["autoprovHA"],"default_flavor":{"name":"x1.small"},"deployment":"kubernetes","image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":"Docker","key":{"name":"autoprovHA","organization":"AcmeAppCo","version":"1.0"}},"Region":"local"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"
@@ -183,7 +187,9 @@
       org: dmuus
       region: local
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"123","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"Cloudlet":{"key":{"name":"dmuus-cloud-1","organization":"dmuus"}},"Region":"local"}'
+      respheaders: '{"Content-Type":"application/json"}'
       response: |
         {"data":{"message":"Cloudlet is back to normal operation"}}
       spanid: ""
@@ -206,7 +212,9 @@
       policyorg: AcmeAppCo
       region: local
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"163","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"AutoProvPolicyCloudlet":{"cloudlet_key":{"name":"dmuus-cloud-2","organization":"dmuus"},"key":{"name":"autoprovHA","organization":"AcmeAppCo"}},"Region":"local"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"
@@ -229,7 +237,9 @@
       org: dmuus
       region: local
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"124","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"Cloudlet":{"key":{"name":"dmuus-cloud-1","organization":"dmuus"},"maintenance_state":"MaintenanceStart"},"Region":"local"}'
+      respheaders: '{"Content-Type":"application/json"}'
       response: |
         {"data":{"message":"Starting AutoProv failover"}}
         {"data":{"message":"Created AppInst {\"app_key\":{\"organization\":\"AcmeAppCo\",\"name\":\"autoprovHA\",\"version\":\"1.0\"},\"cluster_inst_key\":{\"cluster_key\":{\"name\":\"autocluster-autoprov\"},\"cloudlet_key\":{\"organization\":\"azure\",\"name\":\"azure-cloud-4\"},\"organization\":\"edgecloudorg\"}} to meet policy autoprovHA min constraint 2"}}
@@ -259,7 +269,9 @@
       method: POST
       org: platos
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"97","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"Name":"platos"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{"message":"Organization platos in use or check failed: region local:
         in use by some App; region locala: in use by some App"}'
       spanid: ""
@@ -279,7 +291,9 @@
       method: POST
       org: gcp
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"94","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"Name":"gcp"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{"message":"Organization gcp in use or check failed: region local:
         in use by some AppInst, Cloudlet, ClusterInst"}'
       spanid: ""
@@ -299,7 +313,9 @@
       method: POST
       org: azure
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"96","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"Name":"azure"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{"message":"Organization azure in use or check failed: region local:
         in use by some AppInst, Cloudlet, ClusterInst"}'
       spanid: ""
@@ -328,7 +344,9 @@
       policyorg: AcmeAppCo
       region: local
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"405","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"AutoProvPolicy":{"cloudlets":[{"key":{"name":"dmuus-cloud-1","organization":"dmuus"}},{"key":{"name":"dmuus-cloud-2","organization":"dmuus"}},{"key":{"name":"azure-cloud-4","organization":"azure"}},{"key":{"name":"gcp-cloud-5","organization":"gcp"}}],"key":{"name":"autoprovHA","organization":"AcmeAppCo"},"max_instances":4,"min_active_instances":2},"Region":"local"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"
@@ -400,7 +418,9 @@
       org: AcmeAppCo
       region: locala
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"399","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"AppInst":{"flavor":{"name":"x1.small"},"key":{"app_key":{"name":"someapplication1","organization":"AcmeAppCo","version":"1.0"},"cluster_inst_key":{"cloudlet_key":{"name":"dmuus-cloud-4","organization":"dmuus"},"cluster_key":{"name":"SmallCluster"},"organization":"AcmeAppCo"}}},"Region":"locala"}'
+      respheaders: '{"Content-Type":"application/json"}'
       response: |
         {"data":{"message":"Creating"}}
         {"data":{"message":"Creating App Inst"}}
@@ -432,7 +452,9 @@
       org: AcmeAppCo
       region: locala
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"399","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"AppInst":{"flavor":{"name":"x1.small"},"key":{"app_key":{"name":"someapplication1","organization":"AcmeAppCo","version":"1.0"},"cluster_inst_key":{"cloudlet_key":{"name":"dmuus-cloud-3","organization":"dmuus"},"cluster_key":{"name":"SmallCluster"},"organization":"AcmeAppCo"}}},"Region":"locala"}'
+      respheaders: '{"Content-Type":"application/json"}'
       response: |
         {"data":{"message":"Creating"}}
         {"data":{"message":"Creating App Inst"}}
@@ -459,9 +481,11 @@
       org: AcmeAppCo
       region: locala
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"902","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"App":{"access_ports":"tcp:80,tcp:443,udp:10002","android_package_name":"com.acme.someapplication1","auth_public_key":"-----BEGIN
         PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Spdynjh+MPcziCH2Gij\nTkK9fspTH4onMtPTgxo+MQC+OZTwetvYFJjGV8jnYebtuvWWUCctYmt0SIPmA0F0\nVU6qzSlrBOKZ9yA7Rj3jSQtNrI5vfBIzK1wPDm7zuy5hytzauFupyfboXf4qS4uC\nGJCm9EOzUSCLRryyh7kTxa4cYHhhTTKNTTy06lc7YyxBsRsN/4jgxjjkxe3J0SfS\nz3eaHmfFn/GNwIAqy1dddTJSPugRkK7ZjFR+9+sscY9u1+F5QPwxa8vTB0U6hh1m\nQnhVd1d9osRwbyALfBY8R+gMgGgEBCPYpL3u5iSjgD6+n4d9RQS5zYRpeMJ1fX0C\n/QIDAQAB\n-----END
         PUBLIC KEY-----\n","default_flavor":{"name":"x1.small"},"deployment":"kubernetes","image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":"Docker","key":{"name":"someapplication1","organization":"AcmeAppCo","version":"1.0"}},"Region":"locala"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"
@@ -490,7 +514,9 @@
       org: AcmeAppCo
       region: local
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"381","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"App":{"access_ports":"tcp:82","auto_prov_policies":["autoprovHA"],"default_flavor":{"name":"x1.small"},"deployment":"kubernetes","image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":"Docker","key":{"name":"autoprovHA","organization":"AcmeAppCo","version":"1.0"}},"Region":"local"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"
@@ -513,7 +539,9 @@
       org: user3org
       region: local
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"341","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"App":{"access_ports":"tcp:80,tcp:443,udp:10002","default_flavor":{"name":"x1.small"},"deployment":"kubernetes","image_path":"registry.mobiledgex.net/user3org/ep1:1.0","image_type":"Docker","key":{"name":"ep1","organization":"user3org","version":"1.0"}},"Region":"local"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"
@@ -536,7 +564,9 @@
       org: platos
       region: locala
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"342","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"App":{"access_ports":"tcp:64000","default_flavor":{"name":"x1.small"},"deployment":"kubernetes","image_path":"registry.mobiledgex.net/platos/dummyvalue","image_type":"Docker","key":{"name":"platosEnablingLayer","organization":"platos","version":"1.0"}},"Region":"locala"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"

--- a/test/e2e-tests/data/mc_admin_eventsterms_exp.yml
+++ b/test/e2e-tests/data/mc_admin_eventsterms_exp.yml
@@ -109,7 +109,9 @@
     - key: reason
     - key: region
     - key: remote-ip
+    - key: reqheaders
     - key: request
+    - key: respheaders
     - key: response
     - key: spanid
     - key: state

--- a/test/e2e-tests/data/mc_admin_orgeventsshow_exp.yml
+++ b/test/e2e-tests/data/mc_admin_orgeventsshow_exp.yml
@@ -31,7 +31,9 @@
       method: POST
       org: AcmeAppCo
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"184","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"Address":"123 Maple Street, Gainesville, FL 32604","Name":"AcmeAppCo","Phone":"123-123-1234","Type":"developer"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{"message":"Organization deleted"}'
       spanid: ""
       status: "200"
@@ -50,7 +52,9 @@
       method: POST
       org: AcmeAppCo
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"184","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"Address":"123 Maple Street, Gainesville, FL 32604","Name":"AcmeAppCo","Phone":"123-123-1234","Type":"developer"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{"message":"Organization created"}'
       spanid: ""
       status: "200"
@@ -69,7 +73,9 @@
       method: POST
       org: AcmeAppCo
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"184","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"Address":"123 Maple Street, Gainesville, FL 32604","Name":"AcmeAppCo","Phone":"123-123-1234","Type":"developer"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{"message":"Organization deleted"}'
       spanid: ""
       status: "200"

--- a/test/e2e-tests/data/mc_user1_eventsshow_exp.yml
+++ b/test/e2e-tests/data/mc_user1_eventsshow_exp.yml
@@ -41,7 +41,9 @@
       org: user3org
       region: local
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"387","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"AppInst":{"flavor":{"name":"x1.small"},"key":{"app_key":{"name":"ep1","organization":"user3org","version":"1.0"},"cluster_inst_key":{"cloudlet_key":{"name":"enterprise-1","organization":"enterprise"},"cluster_key":{"name":"SmallCluster"},"organization":"user3org"}}},"Region":"local"}'
+      respheaders: '{"Content-Type":"application/json"}'
       response: |
         {"data":{"message":"Creating"}}
         {"data":{"message":"Creating App Inst"}}

--- a/test/e2e-tests/data/mc_user2_eventsshow_exp.yml
+++ b/test/e2e-tests/data/mc_user2_eventsshow_exp.yml
@@ -34,7 +34,9 @@
       method: POST
       org: platos
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"97","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"Name":"platos"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{"message":"Organization platos in use or check failed: region local:
         in use by some App; region locala: in use by some App"}'
       spanid: ""
@@ -54,7 +56,9 @@
       method: POST
       org: AcmeAppCo
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"100","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"Name":"AcmeAppCo"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{"message":"Organization AcmeAppCo in use or check failed: region
         local: in use by some App, AppInst, AutoProvPolicy, AutoScalePolicy, ClusterInst;
         region locala: in use by some App, AppInst, AutoProvPolicy, AutoScalePolicy,
@@ -90,7 +94,9 @@
       policyorg: AcmeAppCo
       region: local
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"405","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"AutoProvPolicy":{"cloudlets":[{"key":{"name":"dmuus-cloud-1","organization":"dmuus"}},{"key":{"name":"dmuus-cloud-2","organization":"dmuus"}},{"key":{"name":"azure-cloud-4","organization":"azure"}},{"key":{"name":"gcp-cloud-5","organization":"gcp"}}],"key":{"name":"autoprovHA","organization":"AcmeAppCo"},"max_instances":4,"min_active_instances":2},"Region":"local"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"
@@ -162,7 +168,9 @@
       org: AcmeAppCo
       region: locala
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"399","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"AppInst":{"flavor":{"name":"x1.small"},"key":{"app_key":{"name":"someapplication1","organization":"AcmeAppCo","version":"1.0"},"cluster_inst_key":{"cloudlet_key":{"name":"dmuus-cloud-4","organization":"dmuus"},"cluster_key":{"name":"SmallCluster"},"organization":"AcmeAppCo"}}},"Region":"locala"}'
+      respheaders: '{"Content-Type":"application/json"}'
       response: |
         {"data":{"message":"Creating"}}
         {"data":{"message":"Creating App Inst"}}
@@ -194,7 +202,9 @@
       org: AcmeAppCo
       region: locala
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"399","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"AppInst":{"flavor":{"name":"x1.small"},"key":{"app_key":{"name":"someapplication1","organization":"AcmeAppCo","version":"1.0"},"cluster_inst_key":{"cloudlet_key":{"name":"dmuus-cloud-3","organization":"dmuus"},"cluster_key":{"name":"SmallCluster"},"organization":"AcmeAppCo"}}},"Region":"locala"}'
+      respheaders: '{"Content-Type":"application/json"}'
       response: |
         {"data":{"message":"Creating"}}
         {"data":{"message":"Creating App Inst"}}
@@ -221,9 +231,11 @@
       org: AcmeAppCo
       region: locala
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"902","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"App":{"access_ports":"tcp:80,tcp:443,udp:10002","android_package_name":"com.acme.someapplication1","auth_public_key":"-----BEGIN
         PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Spdynjh+MPcziCH2Gij\nTkK9fspTH4onMtPTgxo+MQC+OZTwetvYFJjGV8jnYebtuvWWUCctYmt0SIPmA0F0\nVU6qzSlrBOKZ9yA7Rj3jSQtNrI5vfBIzK1wPDm7zuy5hytzauFupyfboXf4qS4uC\nGJCm9EOzUSCLRryyh7kTxa4cYHhhTTKNTTy06lc7YyxBsRsN/4jgxjjkxe3J0SfS\nz3eaHmfFn/GNwIAqy1dddTJSPugRkK7ZjFR+9+sscY9u1+F5QPwxa8vTB0U6hh1m\nQnhVd1d9osRwbyALfBY8R+gMgGgEBCPYpL3u5iSjgD6+n4d9RQS5zYRpeMJ1fX0C\n/QIDAQAB\n-----END
         PUBLIC KEY-----\n","default_flavor":{"name":"x1.small"},"deployment":"kubernetes","image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":"Docker","key":{"name":"someapplication1","organization":"AcmeAppCo","version":"1.0"}},"Region":"locala"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"
@@ -252,7 +264,9 @@
       org: AcmeAppCo
       region: local
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"381","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"App":{"access_ports":"tcp:82","auto_prov_policies":["autoprovHA"],"default_flavor":{"name":"x1.small"},"deployment":"kubernetes","image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":"Docker","key":{"name":"autoprovHA","organization":"AcmeAppCo","version":"1.0"}},"Region":"local"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"
@@ -275,7 +289,9 @@
       org: platos
       region: locala
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"342","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"App":{"access_ports":"tcp:64000","default_flavor":{"name":"x1.small"},"deployment":"kubernetes","image_path":"registry.mobiledgex.net/platos/dummyvalue","image_type":"Docker","key":{"name":"platosEnablingLayer","organization":"platos","version":"1.0"}},"Region":"locala"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"
@@ -298,7 +314,9 @@
       org: AcmeAppCo
       region: locala
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"382","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"App":{"access_ports":"tcp:81","auto_prov_policies":["autoprov1"],"default_flavor":{"name":"x1.small"},"deployment":"kubernetes","image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":"Docker","key":{"name":"autoprovapp","organization":"AcmeAppCo","version":"1.0"}},"Region":"locala"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"
@@ -464,7 +482,9 @@
       org: AcmeAppCo
       region: locala
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"399","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"AppInst":{"flavor":{"name":"x1.small"},"key":{"app_key":{"name":"someapplication1","organization":"AcmeAppCo","version":"1.0"},"cluster_inst_key":{"cloudlet_key":{"name":"dmuus-cloud-4","organization":"dmuus"},"cluster_key":{"name":"SmallCluster"},"organization":"AcmeAppCo"}}},"Region":"locala"}'
+      respheaders: '{"Content-Type":"application/json"}'
       response: |
         {"data":{"message":"Creating"}}
         {"data":{"message":"Creating App Inst"}}
@@ -496,7 +516,9 @@
       org: AcmeAppCo
       region: locala
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"399","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"AppInst":{"flavor":{"name":"x1.small"},"key":{"app_key":{"name":"someapplication1","organization":"AcmeAppCo","version":"1.0"},"cluster_inst_key":{"cloudlet_key":{"name":"dmuus-cloud-3","organization":"dmuus"},"cluster_key":{"name":"SmallCluster"},"organization":"AcmeAppCo"}}},"Region":"locala"}'
+      respheaders: '{"Content-Type":"application/json"}'
       response: |
         {"data":{"message":"Creating"}}
         {"data":{"message":"Creating App Inst"}}
@@ -642,7 +664,9 @@
       policyorg: AcmeAppCo
       region: local
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"405","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"AutoProvPolicy":{"cloudlets":[{"key":{"name":"dmuus-cloud-1","organization":"dmuus"}},{"key":{"name":"dmuus-cloud-2","organization":"dmuus"}},{"key":{"name":"azure-cloud-4","organization":"azure"}},{"key":{"name":"gcp-cloud-5","organization":"gcp"}}],"key":{"name":"autoprovHA","organization":"AcmeAppCo"},"max_instances":4,"min_active_instances":2},"Region":"local"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"
@@ -665,7 +689,9 @@
       org: AcmeAppCo
       region: local
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"381","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"App":{"access_ports":"tcp:82","auto_prov_policies":["autoprovHA"],"default_flavor":{"name":"x1.small"},"deployment":"kubernetes","image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":"Docker","key":{"name":"autoprovHA","organization":"AcmeAppCo","version":"1.0"}},"Region":"local"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"
@@ -687,7 +713,9 @@
       policyorg: AcmeAppCo
       region: local
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"163","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"AutoProvPolicyCloudlet":{"cloudlet_key":{"name":"dmuus-cloud-2","organization":"dmuus"},"key":{"name":"autoprovHA","organization":"AcmeAppCo"}},"Region":"local"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"
@@ -715,7 +743,9 @@
       policyorg: AcmeAppCo
       region: local
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"405","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"AutoProvPolicy":{"cloudlets":[{"key":{"name":"dmuus-cloud-1","organization":"dmuus"}},{"key":{"name":"dmuus-cloud-2","organization":"dmuus"}},{"key":{"name":"azure-cloud-4","organization":"azure"}},{"key":{"name":"gcp-cloud-5","organization":"gcp"}}],"key":{"name":"autoprovHA","organization":"AcmeAppCo"},"max_instances":4,"min_active_instances":2},"Region":"local"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"
@@ -738,7 +768,9 @@
       org: AcmeAppCo
       region: local
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"381","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"App":{"access_ports":"tcp:82","auto_prov_policies":["autoprovHA"],"default_flavor":{"name":"x1.small"},"deployment":"kubernetes","image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":"Docker","key":{"name":"autoprovHA","organization":"AcmeAppCo","version":"1.0"}},"Region":"local"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"
@@ -760,7 +792,9 @@
       policyorg: AcmeAppCo
       region: local
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"163","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"AutoProvPolicyCloudlet":{"cloudlet_key":{"name":"dmuus-cloud-2","organization":"dmuus"},"key":{"name":"autoprovHA","organization":"AcmeAppCo"}},"Region":"local"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"
@@ -785,7 +819,9 @@
       method: POST
       org: platos
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"179","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"Address":"1 Samstreet, platos Town, South Korea","Name":"platos","Phone":"123-123-1234","Type":"developer"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{"message":"Organization created"}'
       spanid: ""
       status: "200"
@@ -804,7 +840,9 @@
       method: POST
       org: AcmeAppCo
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"184","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"Address":"123 Maple Street, Gainesville, FL 32604","Name":"AcmeAppCo","Phone":"123-123-1234","Type":"developer"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{"message":"Organization created"}'
       spanid: ""
       status: "200"

--- a/test/e2e-tests/data/mc_user2_eventsterms_exp.yml
+++ b/test/e2e-tests/data/mc_user2_eventsterms_exp.yml
@@ -65,7 +65,9 @@
     - key: reason
     - key: region
     - key: remote-ip
+    - key: reqheaders
     - key: request
+    - key: respheaders
     - key: response
     - key: spanid
     - key: status

--- a/test/e2e-tests/data/mc_user2_orgeventsshow_empty.yml
+++ b/test/e2e-tests/data/mc_user2_orgeventsshow_empty.yml
@@ -31,7 +31,9 @@
       method: POST
       org: AcmeAppCo
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"184","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"Address":"123 Maple Street, Gainesville, FL 32604","Name":"AcmeAppCo","Phone":"123-123-1234","Type":"developer"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{"message":"Organization created"}'
       spanid: ""
       status: "200"

--- a/test/e2e-tests/data/mc_user2_orgeventsshow_exp.yml
+++ b/test/e2e-tests/data/mc_user2_orgeventsshow_exp.yml
@@ -34,7 +34,9 @@
       policyorg: AcmeAppCo
       region: local
       remote-ip: 127.0.0.1
+      reqheaders: '{"Accept":"application/json","Accept-Encoding":"gzip","Authorization":"****","Connection":"close","Content-Length":"405","Content-Type":"application/json","User-Agent":"Go-http-client/1.1","X-Api-Key":"****"}'
       request: '{"AutoProvPolicy":{"cloudlets":[{"key":{"name":"dmuus-cloud-1","organization":"dmuus"}},{"key":{"name":"dmuus-cloud-2","organization":"dmuus"}},{"key":{"name":"azure-cloud-4","organization":"azure"}},{"key":{"name":"gcp-cloud-5","organization":"gcp"}}],"key":{"name":"autoprovHA","organization":"AcmeAppCo"},"max_instances":4,"min_active_instances":2},"Region":"local"}'
+      respheaders: '{"Content-Type":"application/json; charset=UTF-8"}'
       response: '{}'
       spanid: ""
       status: "200"


### PR DESCRIPTION
Recent federation testing has shown a need for being able to verify the headers both sent and received in our API calls. This adds header logging to our audit and federation api calls.