### PR TITLE
add cors to federation api endpoint

### DIFF
--- a/pkg/mc/orm/config.go
+++ b/pkg/mc/orm/config.go
@@ -256,6 +256,7 @@ func ResetConfig(c echo.Context) error {
 	rateLimitMgr.UpdateDisableRateLimit(defaultConfig.DisableRateLimit)
 	rateLimitMgr.UpdateMaxTrackedIps(defaultConfig.RateLimitMaxTrackedIps)
 	rateLimitMgr.UpdateMaxTrackedUsers(defaultConfig.RateLimitMaxTrackedUsers)
+	setConfig(&config)
 
 	return nil
 }

--- a/pkg/mc/orm/server.go
+++ b/pkg/mc/orm/server.go
@@ -1061,7 +1061,7 @@ func RunServer(config *ServerConfig) (retserver *Server, reterr error) {
 
 		// RateLimit based on auth
 		auditLogger := NewAuditLogger(fedErrorHandler)
-		federationEcho.Use(auditLogger.echoHandler, AuthCookie, FederationRateLimit)
+		federationEcho.Use(auditLogger.echoHandler, CorsHandler, AuthCookie, FederationRateLimit)
 		server.federationEcho = federationEcho
 
 		partnerApi = federation.NewPartnerApi(database, connCache, nodeMgr, config.vaultConfig, config.FederationExternalAddr, config.VmRegistryAddr, config.HarborAddr)


### PR DESCRIPTION
For federation PoC, also need to add CORS handler to the federation API endpoint.

We may eventually want to have separate CORS configs for the two different endpoints, but for now the config is shared.

Also fixed an issue with the in-memory config not being updated on config reset.
