### PR TITLE
make default federation id constant for the platform

### DIFF
--- a/pkg/mc/orm/federation_mc.go
+++ b/pkg/mc/orm/federation_mc.go
@@ -221,9 +221,9 @@ func setMyFedId(fed *ormapi.Federator, name string) {
 	// Federation ID is supposed to be a globally unique identifier
 	// allocated to an operator platform. Not sure who decides what
 	// these are or manages global uniqueness. For now just hard code
-	// to name plus a random UUID.
+	// to a fixed UUID. Note that this can be overridden by user input.
 	if fed.FederationId == "" {
-		fed.FederationId = util.DNSSanitize(name) + "085d364c07fb4fe0b09979127f7c3d68"
+		fed.FederationId = "085d364c07fb4fe0b09979127f7c3d68"
 	}
 }
 

--- a/pkg/mc/orm/federation_test.go
+++ b/pkg/mc/orm/federation_test.go
@@ -581,6 +581,7 @@ func testFederationInterconnect(t *testing.T, ctx context.Context, clientRun mct
 	// Federation creation with same federation provider should fail
 	badConsReq := *consReq
 	badConsReq.Name = "testErr"
+	badConsReq.MyInfo.FederationId = "085d364cd"
 	_, _, err = mcClient.CreateFederationGuest(op.uri, consAttr.tokenOper, &badConsReq)
 	require.NotNil(t, err, "create federation consumer")
 	require.Contains(t, err.Error(), "already in use by another consumer")


### PR DESCRIPTION
The federation id is supposed to be a globally unique identifier of the platform. However there is no governance body that assigns these yet, so we are currently just using a default one (which can be overridden by user input).

This change makes it so the default one is per platform, not per federation. This makes it more consistent with the spec, although we will file an issue to discuss whether the spec actually makes sense or not in its requirements for the federation ID.
