### PR TITLE
Fix access vars update function

### DIFF
--- a/cmd/controller/cloudlet_api.go
+++ b/cmd/controller/cloudlet_api.go
@@ -1043,7 +1043,7 @@ func (s *CloudletApi) UpdateCloudlet(in *edgeproto.Cloudlet, inCb edgeproto.Clou
 			return err
 		}
 		if len(accessVars) > 0 {
-			err = cloudletPlatform.UpdateCloudletAccessVars(ctx, in, accessVars, pfConfig, nodeMgr.VaultConfig, updatecb.cb)
+			err = cloudletPlatform.UpdateCloudletAccessVars(ctx, cur, accessVars, pfConfig, nodeMgr.VaultConfig, updatecb.cb)
 			if err != nil {
 				return err
 			}

--- a/pkg/platform/openstack/openstack-cloudlet.go
+++ b/pkg/platform/openstack/openstack-cloudlet.go
@@ -90,7 +90,7 @@ func buildVaultDataFromAccessVars(accessVars map[string]string) map[string]inter
 func (o *OpenstackPlatform) UpdateCloudletAccessVars(ctx context.Context, cloudlet *edgeproto.Cloudlet, accessVarsIn map[string]string, pfConfig *edgeproto.PlatformConfig, vaultConfig *vault.Config, updateCallback edgeproto.CacheUpdateCallback) error {
 	var err error
 
-	log.SpanLog(ctx, log.DebugLevelInfra, "Update cloudlet access vars in vault", "cloudletName", cloudlet.Key.Name)
+	log.SpanLog(ctx, log.DebugLevelInfra, "Update cloudlet access vars in vault", "cloudletName", cloudlet.Key.Name, "cloudlet", cloudlet)
 
 	updateVars := map[string]string{}
 	openrcData, ok := accessVarsIn["OPENRC_DATA"]
@@ -107,7 +107,7 @@ func (o *OpenstackPlatform) UpdateCloudletAccessVars(ctx context.Context, cloudl
 		if err != nil {
 			return err
 		}
-		updateVars["CACERT_DATA"] = certData
+		updateVars["OS_CACERT_DATA"] = certData
 	}
 	// 1. get stored vars
 	path := o.GetVaultCloudletAccessPath(&cloudlet.Key, pfConfig.Region, cloudlet.PhysicalName)
@@ -117,6 +117,7 @@ func (o *OpenstackPlatform) UpdateCloudletAccessVars(ctx context.Context, cloudl
 		log.SpanLog(ctx, log.DebugLevelInfra, err.Error(), "cloudletName", cloudlet.Key.Name)
 		return fmt.Errorf("Failed to update access vars in vault: %v", err)
 	}
+
 	// 3. update map
 	for k, v := range updateVars {
 		accessVars[k] = v


### PR DESCRIPTION
This is a follow up to https://github.com/edgexr/edge-cloud-platform/pull/168
   - need to have a full cloudlet struct to the update, because we use physical name for the vault address
   - fixed cacert update var key - we were using the wrong one