### PR TITLE
federation: add SupportedOSTypes to flavour

### DIFF
--- a/pkg/mc/federation/fed_zone.go
+++ b/pkg/mc/federation/fed_zone.go
@@ -312,6 +312,12 @@ func (p *PartnerApi) getZoneResources(ctx context.Context, base *ormapi.Provider
 	}}
 
 	flavorsSupported := []fedewapi.Flavour{}
+	supportedOSTypes := []fedewapi.OSType{{
+		Architecture: "x86",
+		Distribution: "OTHER",
+		Version:      "OTHER",
+		License:      "NOT_SPECIFIED",
+	}}
 
 	// Send Cloudlet-specific flavors if they exist.
 	// If there are no flavors, then use the platform flavors.
@@ -321,18 +327,13 @@ func (p *PartnerApi) getZoneResources(ctx context.Context, base *ormapi.Provider
 	if firstCloudletInfo != nil {
 		for _, flavor := range firstCloudletInfo.Flavors {
 			outFlavor := fedewapi.Flavour{
-				CpuArchType: fedewapi.CPUARCHTYPE_X86_64,
-				FlavourId:   flavor.Name,
-				Gpu:         nil, // TODO,
-				MemorySize:  int32(flavor.Ram),
-				NumCPU:      int32(flavor.Vcpus),
-				StorageSize: int32(flavor.Disk),
-				SupportedOSTypes: []fedewapi.OSType{{
-					Architecture: "ANY",
-					Distribution: "ANY",
-					Version:      "ANY",
-					License:      "ANY",
-				}},
+				CpuArchType:      fedewapi.CPUARCHTYPE_X86_64,
+				FlavourId:        flavor.Name,
+				Gpu:              nil, // TODO,
+				MemorySize:       int32(flavor.Ram),
+				NumCPU:           int32(flavor.Vcpus),
+				StorageSize:      int32(flavor.Disk),
+				SupportedOSTypes: supportedOSTypes,
 			}
 			flavorsSupported = append(flavorsSupported, outFlavor)
 		}
@@ -359,9 +360,7 @@ func (p *PartnerApi) getZoneResources(ctx context.Context, base *ormapi.Provider
 				MemorySize:       int32(flavor.Ram),
 				NumCPU:           int32(flavor.Vcpus),
 				StorageSize:      int32(flavor.Disk),
-				SupportedOSTypes: []fedewapi.OSType{
-					// TODO, not sure it's needed, maybe arch
-				},
+				SupportedOSTypes: supportedOSTypes,
 			}
 			flavorsSupported = append(flavorsSupported, outFlavor)
 		}

--- a/test/e2e-tests/data/fed_direct_get_show.yml
+++ b/test/e2e-tests/data/fed_direct_get_show.yml
@@ -67,20 +67,20 @@ zones:
   - flavourid: x1.small
     cpuarchtype: ISA_X86_64
     supportedostypes:
-    - architecture: ANY
-      distribution: ANY
-      version: ANY
-      license: ANY
+    - architecture: x86
+      distribution: OTHER
+      version: OTHER
+      license: NOT_SPECIFIED
     numcpu: 2
     memorysize: 4096
     storagesize: 40
   - flavourid: x1.tiny
     cpuarchtype: ISA_X86_64
     supportedostypes:
-    - architecture: ANY
-      distribution: ANY
-      version: ANY
-      license: ANY
+    - architecture: x86
+      distribution: OTHER
+      version: OTHER
+      license: NOT_SPECIFIED
     numcpu: 1
     memorysize: 1024
     storagesize: 20
@@ -97,20 +97,20 @@ zones:
   - flavourid: x1.small
     cpuarchtype: ISA_X86_64
     supportedostypes:
-    - architecture: ANY
-      distribution: ANY
-      version: ANY
-      license: ANY
+    - architecture: x86
+      distribution: OTHER
+      version: OTHER
+      license: NOT_SPECIFIED
     numcpu: 2
     memorysize: 4096
     storagesize: 40
   - flavourid: x1.tiny
     cpuarchtype: ISA_X86_64
     supportedostypes:
-    - architecture: ANY
-      distribution: ANY
-      version: ANY
-      license: ANY
+    - architecture: x86
+      distribution: OTHER
+      version: OTHER
+      license: NOT_SPECIFIED
     numcpu: 1
     memorysize: 1024
     storagesize: 20
@@ -127,20 +127,20 @@ zones:
   - flavourid: x1.small
     cpuarchtype: ISA_X86_64
     supportedostypes:
-    - architecture: ANY
-      distribution: ANY
-      version: ANY
-      license: ANY
+    - architecture: x86
+      distribution: OTHER
+      version: OTHER
+      license: NOT_SPECIFIED
     numcpu: 2
     memorysize: 4096
     storagesize: 40
   - flavourid: x1.tiny
     cpuarchtype: ISA_X86_64
     supportedostypes:
-    - architecture: ANY
-      distribution: ANY
-      version: ANY
-      license: ANY
+    - architecture: x86
+      distribution: OTHER
+      version: OTHER
+      license: NOT_SPECIFIED
     numcpu: 1
     memorysize: 1024
     storagesize: 20
@@ -157,20 +157,20 @@ zones:
   - flavourid: x1.small
     cpuarchtype: ISA_X86_64
     supportedostypes:
-    - architecture: ANY
-      distribution: ANY
-      version: ANY
-      license: ANY
+    - architecture: x86
+      distribution: OTHER
+      version: OTHER
+      license: NOT_SPECIFIED
     numcpu: 2
     memorysize: 4096
     storagesize: 40
   - flavourid: x1.tiny
     cpuarchtype: ISA_X86_64
     supportedostypes:
-    - architecture: ANY
-      distribution: ANY
-      version: ANY
-      license: ANY
+    - architecture: x86
+      distribution: OTHER
+      version: OTHER
+      license: NOT_SPECIFIED
     numcpu: 1
     memorysize: 1024
     storagesize: 20
@@ -187,20 +187,20 @@ zones:
   - flavourid: x1.small
     cpuarchtype: ISA_X86_64
     supportedostypes:
-    - architecture: ANY
-      distribution: ANY
-      version: ANY
-      license: ANY
+    - architecture: x86
+      distribution: OTHER
+      version: OTHER
+      license: NOT_SPECIFIED
     numcpu: 2
     memorysize: 4096
     storagesize: 40
   - flavourid: x1.tiny
     cpuarchtype: ISA_X86_64
     supportedostypes:
-    - architecture: ANY
-      distribution: ANY
-      version: ANY
-      license: ANY
+    - architecture: x86
+      distribution: OTHER
+      version: OTHER
+      license: NOT_SPECIFIED
     numcpu: 1
     memorysize: 1024
     storagesize: 20
@@ -217,20 +217,20 @@ zones:
   - flavourid: x1.small
     cpuarchtype: ISA_X86_64
     supportedostypes:
-    - architecture: ANY
-      distribution: ANY
-      version: ANY
-      license: ANY
+    - architecture: x86
+      distribution: OTHER
+      version: OTHER
+      license: NOT_SPECIFIED
     numcpu: 2
     memorysize: 4096
     storagesize: 40
   - flavourid: x1.tiny
     cpuarchtype: ISA_X86_64
     supportedostypes:
-    - architecture: ANY
-      distribution: ANY
-      version: ANY
-      license: ANY
+    - architecture: x86
+      distribution: OTHER
+      version: OTHER
+      license: NOT_SPECIFIED
     numcpu: 1
     memorysize: 1024
     storagesize: 20


### PR DESCRIPTION
Although it's not clear why it's needed, the SupportedOSTypes field is a required field for the Flavour for federation, so we will populate it with generic ANY values.