### PR TITLE
federation: add update HostZoneBase API

### DIFF
--- a/pkg/mc/orm/server.go
+++ b/pkg/mc/orm/server.go
@@ -919,6 +919,7 @@ func RunServer(config *ServerConfig) (retserver *Server, reterr error) {
 	auth.POST("/federation/provider/setnotifykey", SetFederationProviderNotifyKey)
 	auth.POST("/federation/provider/zonebase/create", CreateProviderZoneBase)
 	auth.POST("/federation/provider/zonebase/delete", DeleteProviderZoneBase)
+	auth.POST("/federation/provider/zonebase/update", UpdateProviderZoneBase)
 	auth.POST("/federation/provider/zonebase/show", ShowProviderZoneBase)
 	auth.POST("/federation/provider/zone/share", ShareProviderZone)
 	auth.POST("/federation/provider/zone/unshare", UnshareProviderZone)

--- a/pkg/mcctl/mctestclient/mctestclient_generatedfuncs.go
+++ b/pkg/mcctl/mctestclient/mctestclient_generatedfuncs.go
@@ -2592,6 +2592,23 @@ func (s *Client) DeleteHostZoneBase(uri string, token string, in *ormapi.Provide
 	return &out, rundata.RetStatus, rundata.RetError
 }
 
+func (s *Client) UpdateHostZoneBase(uri string, token string, in *cli.MapData, ops ...Op) (*ormapi.Result, int, error) {
+	rundata := RunData{}
+	applyOps(&rundata, ops...)
+	rundata.Uri = uri
+	rundata.Token = token
+	rundata.In = in
+	var out ormapi.Result
+	rundata.Out = &out
+
+	apiCmd := ormctl.MustGetCommand("UpdateHostZoneBase")
+	s.ClientRun.Run(apiCmd, &rundata)
+	if rundata.RetError != nil {
+		return nil, rundata.RetStatus, rundata.RetError
+	}
+	return &out, rundata.RetStatus, rundata.RetError
+}
+
 func (s *Client) ShowHostZoneBase(uri string, token string, in *cli.MapData, ops ...Op) ([]ormapi.ProviderZoneBase, int, error) {
 	rundata := RunData{}
 	applyOps(&rundata, ops...)

--- a/pkg/mcctl/ormctl/federation.go
+++ b/pkg/mcctl/ormctl/federation.go
@@ -124,6 +124,17 @@ func init() {
 			Path:         "/auth/federation/provider/zonebase/delete",
 		},
 		&ApiCommand{
+			Name:         "UpdateHostZoneBase",
+			Use:          "updatezonebase",
+			Short:        "Update Host Zone Base",
+			RequiredArgs: "zoneid operatorid",
+			OptionalArgs: "countrycode geolocation geographydetails",
+			Comments:     ormapi.ProviderZoneBaseComments,
+			ReqData:      &ormapi.ProviderZoneBase{},
+			ReplyData:    &ormapi.Result{},
+			Path:         "/auth/federation/provider/zonebase/update",
+		},
+		&ApiCommand{
 			Name:         "ShowHostZoneBase",
 			Use:          "showzonebase",
 			Short:        "Show Host Zone Bases",


### PR DESCRIPTION
Adds an update API for host zone bases. We do not currently allow updating the cloudlet(s) or region, as there can be existing objects deployed on it. To update that, a recreate of the zonebase is needed.
