### PR TITLE
certgen: fix certbot path in crontab

### DIFF
--- a/pkg/vault/letsencrypt-plugin/docker/crontab
+++ b/pkg/vault/letsencrypt-plugin/docker/crontab
@@ -1,1 +1,2 @@
+PATH=/usr/local/bundle/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 9 4,16 * * * root certbot renew --dns-cloudflare-propagation-seconds 30 >/proc/1/fd/1 2>/proc/1/fd/2


### PR DESCRIPTION
Certbot was failing to run, because it was installed in /usr/local/bin and that directory was not on the default path for crontab.

To fix, the path is not specified in the crontab.
