### PR TITLE
federation: ewbi api generate enum value checks, fix invalid values

### DIFF
--- a/doc/fedapi/templates/model_simple.mustache
+++ b/doc/fedapi/templates/model_simple.mustache
@@ -50,6 +50,18 @@ func (s *{{classname}}) Validate() error {
 	if s.{{name}} == "" {
 		return errors.New("{{baseName}} is required")
 	}
+{{#isEnum}}
+	{{name}}EnumVals := map[string]struct{}{
+		{{#allowableValues}}
+		{{#enumVars}}
+		{{{value}}}: {},
+		{{/enumVars}}
+		{{/allowableValues}}
+	}
+	if _, found := {{name}}EnumVals[s.{{name}}]; !found {
+		return errors.New("{{classname}} {{baseName}} value \""+s.{{name}}+"\" is not a valid enum value")
+	}
+{{/isEnum}}
 {{/isString}}
 {{/required}}
 {{! check if field matches specified pattern}}

--- a/pkg/fedewapi/model___federation_context_id__application_onboarding_post_request_status_info_inner.go
+++ b/pkg/fedewapi/model___federation_context_id__application_onboarding_post_request_status_info_inner.go
@@ -41,6 +41,16 @@ func (s *FederationContextIdApplicationOnboardingPostRequestStatusInfoInner) Val
 	if s.OnboardStatusInfo == "" {
 		return errors.New("onboardStatusInfo is required")
 	}
+	OnboardStatusInfoEnumVals := map[string]struct{}{
+		"PENDING":    {},
+		"ONBOARDED":  {},
+		"DEBOARDING": {},
+		"REMOVED":    {},
+		"FAILED":     {},
+	}
+	if _, found := OnboardStatusInfoEnumVals[s.OnboardStatusInfo]; !found {
+		return errors.New("FederationContextIdApplicationOnboardingPostRequestStatusInfoInner onboardStatusInfo value \"" + s.OnboardStatusInfo + "\" is not a valid enum value")
+	}
 	return nil
 }
 

--- a/pkg/fedewapi/model__partner_post_request.go
+++ b/pkg/fedewapi/model__partner_post_request.go
@@ -60,8 +60,28 @@ func (s *PartnerPostRequest) Validate() error {
 	if s.ObjectType == "" {
 		return errors.New("objectType is required")
 	}
+	ObjectTypeEnumVals := map[string]struct{}{
+		"FEDERATION":             {},
+		"ZONES":                  {},
+		"EDGE_DISCOVERY_SERVICE": {},
+		"LCM_SERVICE":            {},
+		"MOBILE_NETWORK_CODES":   {},
+		"FIXED_NETWORK_CODES":    {},
+	}
+	if _, found := ObjectTypeEnumVals[s.ObjectType]; !found {
+		return errors.New("PartnerPostRequest objectType value \"" + s.ObjectType + "\" is not a valid enum value")
+	}
 	if s.OperationType == "" {
 		return errors.New("operationType is required")
+	}
+	OperationTypeEnumVals := map[string]struct{}{
+		"STATUS": {},
+		"UPDATE": {},
+		"ADD":    {},
+		"REMOVE": {},
+	}
+	if _, found := OperationTypeEnumVals[s.OperationType]; !found {
+		return errors.New("PartnerPostRequest operationType value \"" + s.OperationType + "\" is not a valid enum value")
 	}
 	if s.EdgeDiscoverySvcEndPoint != nil {
 		if err := s.EdgeDiscoverySvcEndPoint.Validate(); err != nil {

--- a/pkg/fedewapi/model_app_qo_s_profile.go
+++ b/pkg/fedewapi/model_app_qo_s_profile.go
@@ -36,6 +36,14 @@ func (s *AppQoSProfile) Validate() error {
 	if s.LatencyConstraints == "" {
 		return errors.New("latencyConstraints is required")
 	}
+	LatencyConstraintsEnumVals := map[string]struct{}{
+		"NONE":     {},
+		"LOW":      {},
+		"ULTRALOW": {},
+	}
+	if _, found := LatencyConstraintsEnumVals[s.LatencyConstraints]; !found {
+		return errors.New("AppQoSProfile latencyConstraints value \"" + s.LatencyConstraints + "\" is not a valid enum value")
+	}
 	return nil
 }
 

--- a/pkg/fedewapi/model_client_location_rad_location_inner.go
+++ b/pkg/fedewapi/model_client_location_rad_location_inner.go
@@ -35,6 +35,13 @@ func (s *ClientLocationRadLocationInner) Validate() error {
 	if s.Carrier == "" {
 		return errors.New("carrier is required")
 	}
+	CarrierEnumVals := map[string]struct{}{
+		"5G":  {},
+		"LTE": {},
+	}
+	if _, found := CarrierEnumVals[s.Carrier]; !found {
+		return errors.New("ClientLocationRadLocationInner carrier value \"" + s.Carrier + "\" is not a valid enum value")
+	}
 	return nil
 }
 

--- a/pkg/fedewapi/model_comp_env_params.go
+++ b/pkg/fedewapi/model_comp_env_params.go
@@ -46,6 +46,15 @@ func (s *CompEnvParams) Validate() error {
 	if s.EnvValueType == "" {
 		return errors.New("envValueType is required")
 	}
+	EnvValueTypeEnumVals := map[string]struct{}{
+		"USER_DEFINED":                  {},
+		"PLATFORM_DEFINED_DYNAMIC_PORT": {},
+		"PLATFORM_DEFINED_DNS":          {},
+		"PLATFORM_DEFINED_IP":           {},
+	}
+	if _, found := EnvValueTypeEnumVals[s.EnvValueType]; !found {
+		return errors.New("CompEnvParams envValueType value \"" + s.EnvValueType + "\" is not a valid enum value")
+	}
 	if s.EnvVarValue != nil && !CompEnvParamsEnvVarValueRE.MatchString(*s.EnvVarValue) {
 		return errors.New("envVarValue " + *s.EnvVarValue + " does not match format " + CompEnvParamsEnvVarValuePattern)
 	}

--- a/pkg/fedewapi/model_component_spec.go
+++ b/pkg/fedewapi/model_component_spec.go
@@ -53,6 +53,13 @@ func (s *ComponentSpec) Validate() error {
 	if s.RestartPolicy == "" {
 		return errors.New("restartPolicy is required")
 	}
+	RestartPolicyEnumVals := map[string]struct{}{
+		"RESTART_POLICY_ALWAYS": {},
+		"RESTART_POLICY_NEVER":  {},
+	}
+	if _, found := RestartPolicyEnumVals[s.RestartPolicy]; !found {
+		return errors.New("ComponentSpec restartPolicy value \"" + s.RestartPolicy + "\" is not a valid enum value")
+	}
 	if s.CommandLineParams != nil {
 		if err := s.CommandLineParams.Validate(); err != nil {
 			return err

--- a/pkg/fedewapi/model_compute_resource_info.go
+++ b/pkg/fedewapi/model_compute_resource_info.go
@@ -47,6 +47,13 @@ func (s *ComputeResourceInfo) Validate() error {
 	if s.CpuArchType == "" {
 		return errors.New("cpuArchType is required")
 	}
+	CpuArchTypeEnumVals := map[string]struct{}{
+		"ISA_X86_64": {},
+		"ISA_ARM_64": {},
+	}
+	if _, found := CpuArchTypeEnumVals[s.CpuArchType]; !found {
+		return errors.New("ComputeResourceInfo cpuArchType value \"" + s.CpuArchType + "\" is not a valid enum value")
+	}
 	if s.NumCPU == "" {
 		return errors.New("numCPU is required")
 	}

--- a/pkg/fedewapi/model_deployment_config.go
+++ b/pkg/fedewapi/model_deployment_config.go
@@ -30,6 +30,15 @@ func (s *DeploymentConfig) Validate() error {
 	if s.ConfigType == "" {
 		return errors.New("configType is required")
 	}
+	ConfigTypeEnumVals := map[string]struct{}{
+		"DOCKER_COMPOSE":      {},
+		"KUBERNETES_MANIFEST": {},
+		"CLOUD_INIT":          {},
+		"HELM_VALUES":         {},
+	}
+	if _, found := ConfigTypeEnumVals[s.ConfigType]; !found {
+		return errors.New("DeploymentConfig configType value \"" + s.ConfigType + "\" is not a valid enum value")
+	}
 	if s.Contents == "" {
 		return errors.New("contents is required")
 	}

--- a/pkg/fedewapi/model_get_artefact_200_response.go
+++ b/pkg/fedewapi/model_get_artefact_200_response.go
@@ -78,8 +78,22 @@ func (s *GetArtefact200Response) Validate() error {
 	if s.ArtefactVirtType == "" {
 		return errors.New("artefactVirtType is required")
 	}
+	ArtefactVirtTypeEnumVals := map[string]struct{}{
+		"VM_TYPE":        {},
+		"CONTAINER_TYPE": {},
+	}
+	if _, found := ArtefactVirtTypeEnumVals[s.ArtefactVirtType]; !found {
+		return errors.New("GetArtefact200Response artefactVirtType value \"" + s.ArtefactVirtType + "\" is not a valid enum value")
+	}
 	if s.ArtefactDescriptorType == "" {
 		return errors.New("artefactDescriptorType is required")
+	}
+	ArtefactDescriptorTypeEnumVals := map[string]struct{}{
+		"HELM":          {},
+		"COMPONENTSPEC": {},
+	}
+	if _, found := ArtefactDescriptorTypeEnumVals[s.ArtefactDescriptorType]; !found {
+		return errors.New("GetArtefact200Response artefactDescriptorType value \"" + s.ArtefactDescriptorType + "\" is not a valid enum value")
 	}
 	if s.ArtefactRepoLocation != nil {
 		if err := s.ArtefactRepoLocation.Validate(); err != nil {

--- a/pkg/fedewapi/model_gpu_info.go
+++ b/pkg/fedewapi/model_gpu_info.go
@@ -34,6 +34,13 @@ func (s *GpuInfo) Validate() error {
 	if s.GpuVendorType == "" {
 		return errors.New("gpuVendorType is required")
 	}
+	GpuVendorTypeEnumVals := map[string]struct{}{
+		"GPU_PROVIDER_NVIDIA": {},
+		"GPU_PROVIDER_AMD":    {},
+	}
+	if _, found := GpuVendorTypeEnumVals[s.GpuVendorType]; !found {
+		return errors.New("GpuInfo gpuVendorType value \"" + s.GpuVendorType + "\" is not a valid enum value")
+	}
 	if s.GpuModeName == "" {
 		return errors.New("gpuModeName is required")
 	}

--- a/pkg/fedewapi/model_huge_page.go
+++ b/pkg/fedewapi/model_huge_page.go
@@ -30,6 +30,14 @@ func (s *HugePage) Validate() error {
 	if s.PageSize == "" {
 		return errors.New("pageSize is required")
 	}
+	PageSizeEnumVals := map[string]struct{}{
+		"2MB": {},
+		"4MB": {},
+		"1GB": {},
+	}
+	if _, found := PageSizeEnumVals[s.PageSize]; !found {
+		return errors.New("HugePage pageSize value \"" + s.PageSize + "\" is not a valid enum value")
+	}
 	return nil
 }
 

--- a/pkg/fedewapi/model_interface_details.go
+++ b/pkg/fedewapi/model_interface_details.go
@@ -53,8 +53,23 @@ func (s *InterfaceDetails) Validate() error {
 	if s.CommProtocol == "" {
 		return errors.New("commProtocol is required")
 	}
+	CommProtocolEnumVals := map[string]struct{}{
+		"TCP":        {},
+		"UDP":        {},
+		"HTTP_HTTPS": {},
+	}
+	if _, found := CommProtocolEnumVals[s.CommProtocol]; !found {
+		return errors.New("InterfaceDetails commProtocol value \"" + s.CommProtocol + "\" is not a valid enum value")
+	}
 	if s.VisibilityType == "" {
 		return errors.New("visibilityType is required")
+	}
+	VisibilityTypeEnumVals := map[string]struct{}{
+		"VISIBILITY_EXTERNAL": {},
+		"VISIBILITY_INTERNAL": {},
+	}
+	if _, found := VisibilityTypeEnumVals[s.VisibilityType]; !found {
+		return errors.New("InterfaceDetails visibilityType value \"" + s.VisibilityType + "\" is not a valid enum value")
 	}
 	if s.Network != nil && !InterfaceDetailsNetworkRE.MatchString(*s.Network) {
 		return errors.New("network " + *s.Network + " does not match format " + InterfaceDetailsNetworkPattern)

--- a/pkg/fedewapi/model_os_type.go
+++ b/pkg/fedewapi/model_os_type.go
@@ -30,14 +30,52 @@ func (s *OSType) Validate() error {
 	if s.Architecture == "" {
 		return errors.New("architecture is required")
 	}
+	ArchitectureEnumVals := map[string]struct{}{
+		"x86_64": {},
+		"x86":    {},
+	}
+	if _, found := ArchitectureEnumVals[s.Architecture]; !found {
+		return errors.New("OSType architecture value \"" + s.Architecture + "\" is not a valid enum value")
+	}
 	if s.Distribution == "" {
 		return errors.New("distribution is required")
+	}
+	DistributionEnumVals := map[string]struct{}{
+		"RHEL":    {},
+		"UBUNTU":  {},
+		"COREOS":  {},
+		"FEDORA":  {},
+		"WINDOWS": {},
+		"OTHER":   {},
+	}
+	if _, found := DistributionEnumVals[s.Distribution]; !found {
+		return errors.New("OSType distribution value \"" + s.Distribution + "\" is not a valid enum value")
 	}
 	if s.Version == "" {
 		return errors.New("version is required")
 	}
+	VersionEnumVals := map[string]struct{}{
+		"OS_VERSION_UBUNTU_2204_LTS": {},
+		"OS_VERSION_RHEL_8":          {},
+		"OS_VERSION_RHEL_7":          {},
+		"OS_VERSION_DEBIAN_11":       {},
+		"OS_VERSION_COREOS_STABLE":   {},
+		"OS_MS_WINDOWS_2012_R2":      {},
+		"OTHER":                      {},
+	}
+	if _, found := VersionEnumVals[s.Version]; !found {
+		return errors.New("OSType version value \"" + s.Version + "\" is not a valid enum value")
+	}
 	if s.License == "" {
 		return errors.New("license is required")
+	}
+	LicenseEnumVals := map[string]struct{}{
+		"OS_LICENSE_TYPE_FREE":      {},
+		"OS_LICENSE_TYPE_ON_DEMAND": {},
+		"NOT_SPECIFIED":             {},
+	}
+	if _, found := LicenseEnumVals[s.License]; !found {
+		return errors.New("OSType license value \"" + s.License + "\" is not a valid enum value")
 	}
 	return nil
 }

--- a/pkg/fedewapi/model_persistent_volume_details.go
+++ b/pkg/fedewapi/model_persistent_volume_details.go
@@ -38,6 +38,15 @@ func (s *PersistentVolumeDetails) Validate() error {
 	if s.VolumeSize == "" {
 		return errors.New("volumeSize is required")
 	}
+	VolumeSizeEnumVals := map[string]struct{}{
+		"10Gi":  {},
+		"20Gi":  {},
+		"50Gi":  {},
+		"100Gi": {},
+	}
+	if _, found := VolumeSizeEnumVals[s.VolumeSize]; !found {
+		return errors.New("PersistentVolumeDetails volumeSize value \"" + s.VolumeSize + "\" is not a valid enum value")
+	}
 	if s.VolumeMountPath == "" {
 		return errors.New("volumeMountPath is required")
 	}

--- a/pkg/fedewapi/model_update_federation_request.go
+++ b/pkg/fedewapi/model_update_federation_request.go
@@ -37,8 +37,23 @@ func (s *UpdateFederationRequest) Validate() error {
 	if s.ObjectType == "" {
 		return errors.New("objectType is required")
 	}
+	ObjectTypeEnumVals := map[string]struct{}{
+		"MOBILE_NETWORK_CODES": {},
+		"FIXED_NETWORK_CODES":  {},
+	}
+	if _, found := ObjectTypeEnumVals[s.ObjectType]; !found {
+		return errors.New("UpdateFederationRequest objectType value \"" + s.ObjectType + "\" is not a valid enum value")
+	}
 	if s.OperationType == "" {
 		return errors.New("operationType is required")
+	}
+	OperationTypeEnumVals := map[string]struct{}{
+		"ADD_CODES":    {},
+		"REMOVE_CODES": {},
+		"UPDATE_CODES": {},
+	}
+	if _, found := OperationTypeEnumVals[s.OperationType]; !found {
+		return errors.New("UpdateFederationRequest operationType value \"" + s.OperationType + "\" is not a valid enum value")
 	}
 	if s.AddMobileNetworkIds != nil {
 		if err := s.AddMobileNetworkIds.Validate(); err != nil {

--- a/pkg/fedewapi/model_update_isv_res_pool_request_inner.go
+++ b/pkg/fedewapi/model_update_isv_res_pool_request_inner.go
@@ -33,6 +33,14 @@ func (s *UpdateISVResPoolRequestInner) Validate() error {
 	if s.UpdateType == "" {
 		return errors.New("updateType is required")
 	}
+	UpdateTypeEnumVals := map[string]struct{}{
+		"ADD":      {},
+		"REMOVE":   {},
+		"DURATION": {},
+	}
+	if _, found := UpdateTypeEnumVals[s.UpdateType]; !found {
+		return errors.New("UpdateISVResPoolRequestInner updateType value \"" + s.UpdateType + "\" is not a valid enum value")
+	}
 	if s.FlavourId == "" {
 		return errors.New("flavourId is required")
 	}

--- a/pkg/fedewapi/model_upload_artefact_request.go
+++ b/pkg/fedewapi/model_upload_artefact_request.go
@@ -81,8 +81,22 @@ func (s *UploadArtefactRequest) Validate() error {
 	if s.ArtefactVirtType == "" {
 		return errors.New("artefactVirtType is required")
 	}
+	ArtefactVirtTypeEnumVals := map[string]struct{}{
+		"VM_TYPE":        {},
+		"CONTAINER_TYPE": {},
+	}
+	if _, found := ArtefactVirtTypeEnumVals[s.ArtefactVirtType]; !found {
+		return errors.New("UploadArtefactRequest artefactVirtType value \"" + s.ArtefactVirtType + "\" is not a valid enum value")
+	}
 	if s.ArtefactDescriptorType == "" {
 		return errors.New("artefactDescriptorType is required")
+	}
+	ArtefactDescriptorTypeEnumVals := map[string]struct{}{
+		"HELM":          {},
+		"COMPONENTSPEC": {},
+	}
+	if _, found := ArtefactDescriptorTypeEnumVals[s.ArtefactDescriptorType]; !found {
+		return errors.New("UploadArtefactRequest artefactDescriptorType value \"" + s.ArtefactDescriptorType + "\" is not a valid enum value")
 	}
 	if s.ArtefactRepoLocation != nil {
 		if err := s.ArtefactRepoLocation.Validate(); err != nil {

--- a/pkg/mc/federation/federation_op.go
+++ b/pkg/mc/federation/federation_op.go
@@ -733,11 +733,11 @@ func (p *PartnerApi) PartnerStatusEvent(c echo.Context) error {
 	}
 	log.SpanLog(ctx, log.DebugLevelApi, "partner notify", "consumer", consumer.Name, "operatorid", consumer.OperatorId)
 	switch in.OperationType {
-	case "ADD_ZONES":
+	case "ADD":
 		err = p.AddConsumerZones(ctx, consumer, in.AddZones)
-	case "REMOVE_ZONES":
+	case "REMOVE":
 		err = p.RemoveConsumerZones(ctx, consumer, in.RemoveZones)
-	case "UPDATE_ZONES":
+	case "UPDATE":
 		err = p.SetConsumerZones(ctx, consumer, in.AddZones)
 	default:
 		err = fmt.Errorf("Unsupported operationtype %q", in.OperationType)

--- a/pkg/mc/orm/federation_mc.go
+++ b/pkg/mc/orm/federation_mc.go
@@ -1443,7 +1443,7 @@ func ShareProviderZone(c echo.Context) (reterr error) {
 		req := fedewapi.PartnerPostRequest{
 			FederationContextId: provider.FederationContextId,
 			ObjectType:          "ZONES",
-			OperationType:       "ADD_ZONES",
+			OperationType:       "ADD",
 			AddZones:            zoneDetails,
 		}
 		_, _, err = fedClient.SendRequest(ctx, "ShareZone Callback", "POST", "", &req, nil, nil)
@@ -1523,7 +1523,7 @@ func UnshareProviderZone(c echo.Context) error {
 		req := fedewapi.PartnerPostRequest{
 			FederationContextId: provider.FederationContextId,
 			ObjectType:          "ZONES",
-			OperationType:       "REMOVE_ZONES",
+			OperationType:       "REMOVE",
 			RemoveZones:         rmZones,
 		}
 		_, _, err = fedClient.SendRequest(ctx, "UnshareZone Callback", "POST", "", &req, nil, nil)

--- a/pkg/mc/orm/fedmc_file.go
+++ b/pkg/mc/orm/fedmc_file.go
@@ -201,7 +201,7 @@ func createFederatedImageObj(ctx context.Context, image *ormapi.ConsumerImage) (
 		}
 	}()
 	osType := fedewapi.OSType{
-		Architecture: federation.CPUArchTypeX8664,
+		Architecture: "x86_64",
 		Distribution: "OTHER",
 		Version:      "OTHER",
 		License:      "NOT_SPECIFIED",


### PR DESCRIPTION
We had some incorrect values in some of the Federation APIs. This was caught during PoC testing by the partner. In order to make sure we are using the correct values, I've added enum value checking to the auto-generated validation functions that get generated from the OpenAPI spec.

I've also fixed the places with invalid enum values.
