### PR TITLE
federation: clear guest token cache after updating API key

### DIFF
--- a/pkg/federationmgmt/client.go
+++ b/pkg/federationmgmt/client.go
@@ -125,6 +125,14 @@ func (s *TokenSourceCache) Get(ctx context.Context, fedKey *FedKey) (oauth2.Toke
 	return tokenSource, nil
 }
 
+// Clear will remove the cached token source. This is needed
+// if the credentials have been changed.
+func (s *TokenSourceCache) Clear(ctx context.Context, fedKey *FedKey) {
+	s.Lock()
+	defer s.Unlock()
+	delete(s.sources, *fedKey)
+}
+
 func (s *TokenSourceCache) Client(ctx context.Context, addr string, fedKey *FedKey, auditLogCb AuditLogCb) (*Client, error) {
 	tokenSource, err := s.Get(ctx, fedKey)
 	if err != nil {

--- a/pkg/mc/federation/federation_op.go
+++ b/pkg/mc/federation/federation_op.go
@@ -212,6 +212,11 @@ func (p *PartnerApi) ConsumerPartnerClient(ctx context.Context, consumer *ormapi
 	return p.tokenSources.Client(ctx, consumer.PartnerAddr, fedKey, p.auditCb)
 }
 
+func (p *PartnerApi) ConsumerPartnerClearCredentialsCache(ctx context.Context, consumer *ormapi.FederationConsumer) {
+	fedKey := ConsumerFedKey(consumer)
+	p.tokenSources.Clear(ctx, fedKey)
+}
+
 func (p *PartnerApi) validateCallbackLink(link string) error {
 	if link == "" || link == federationmgmt.CallbackNotSupported {
 		return nil

--- a/pkg/mc/orm/federation_mc.go
+++ b/pkg/mc/orm/federation_mc.go
@@ -1025,6 +1025,8 @@ func SetFederationConsumerAPIKey(c echo.Context) error {
 	if err != nil {
 		return ormutil.DbErr(err)
 	}
+	partnerApi.ConsumerPartnerClearCredentialsCache(ctx, consumer)
+
 	return ormutil.SetReply(c, ormutil.Msg(fmt.Sprintf("Federation Guest %s api key set", consumer.Name)))
 }
 


### PR DESCRIPTION
Changing the federation Guest API key (to authenticate with the Host) requires clearing the token cache, otherwise it will continue to use the token in the cache until it expires.
