### PR TITLE
Refresh k8s certs

### DIFF
--- a/tools/refresh-k8s-certs/refresh-k8s-certs.py
+++ b/tools/refresh-k8s-certs/refresh-k8s-certs.py
@@ -185,8 +185,8 @@ for cluster in clusterData:
     lbip = ""
     # Kubeconfig file used by CRM (yes, org here is the cloudlet org).
     # This matches pkg/k8smgmt/kubenames.go:GetKconfName()
-    # we need to make a copy with readable perms since scp can't sudo.
     kubeconfig = f"{clusterName}.{org}.kubeconfig"
+
     for vm in vms:
         vmtype = vm["type"]
         if vmtype == "cluster-master" or vmtype == "k8s-cluster-master":
@@ -243,6 +243,7 @@ for cluster in clusterData:
     runCmd(lbip, masterip, cmd)
 
     # copy new kubeconfig to LB.
+    # we need to make a copy with readable perms since scp can't sudo.
     cmd = f"sudo cp /etc/kubernetes/admin.conf /tmp/{kubeconfig}"
     runCmd(lbip, masterip, cmd)
     cmd = f"sudo chmod a+rw /tmp/{kubeconfig}"


### PR DESCRIPTION
This is a temporary script to manually update kubernetes certificates on existing clusters. Normally, certificates would get updated as part of normal kubernetes version upgrades. Certs expire after 1 year. Certificates are used to communicate with the cluster. Without valid certs, kubectl won't work, which means CRM won't be able to manage the cluster.

This script uses mcctl commands to get the IPs of k8s cluster master nodes and their associated LBs, and then uses vssh to run commands on the master or LB to update the certificates and the kubeconfigs. It requires that the user is already logged in as an admin via mcctl, and that Vault env vars are configured to be able to use vssh.

This assumes a VM-based cloudlet like Openstack or VCD, which can be accessed via vssh.