### PR TITLE
MC is the source of truth for default support/legal emails

### DIFF
--- a/api/ormapi/api.comments.go
+++ b/api/ormapi/api.comments.go
@@ -110,6 +110,7 @@ var ControllerComments = map[string]string{
 var ConfigComments = map[string]string{
 	"locknewaccounts":               `Lock new accounts (must be unlocked by admin)`,
 	"notifyemailaddress":            `Email to notify when locked account is created, defaults to SupportEmail`,
+	"legalemail":                    `Email to display in generic acceptable use policy and terms and conditions.`,
 	"skipverifyemail":               `Skip email verification for new accounts (testing only)`,
 	"passwordmincracktimesec":       `User accounts min password crack time seconds (a measure of strength)`,
 	"adminpasswordmincracktimesec":  `Admin accounts min password crack time seconds (a measure of strength)`,

--- a/api/ormapi/api.go
+++ b/api/ormapi/api.go
@@ -255,6 +255,8 @@ type Config struct {
 	LockNewAccounts bool
 	// Email to notify when locked account is created, defaults to SupportEmail
 	NotifyEmailAddress string
+	// Email to display in generic acceptable use policy and terms and conditions.
+	LegalEmail string
 	// Skip email verification for new accounts (testing only)
 	SkipVerifyEmail bool
 	// User accounts min password crack time seconds (a measure of strength)

--- a/cmd/mc/mc.go
+++ b/cmd/mc/mc.go
@@ -59,6 +59,7 @@ var usageCollectionInterval = flag.Duration("usageCollectionInterval", -1*time.S
 var usageCheckpointInterval = flag.String("usageCheckpointInterval", "MONTH", "Checkpointing interval(must be same as controller's checkpointInterval)")
 var staticDir = flag.String("staticDir", "/", "Path to static data")
 var controllerNotifyPort = flag.String("controllerNotifyPort", "50001", "Controller notify listener port to connect to")
+var domain = flag.String("domain", "", "Domain name of deployment")
 
 // Following URL paths are UI console paths which will be used to send
 // appropriate links to user's email for actions like password-reset, email-verification
@@ -114,6 +115,7 @@ func main() {
 		ConsoleAddr:              *consoleAddr,
 		PasswordResetConsolePath: *passwordResetConsolePath,
 		VerifyEmailConsolePath:   *verifyEmailConsolePath,
+		Domain:                   *domain,
 	}
 	server, err := orm.RunServer(&config)
 	if err != nil {

--- a/pkg/mc/orm/config.go
+++ b/pkg/mc/orm/config.go
@@ -51,6 +51,11 @@ var defaultConfig = ormapi.Config{
 	WebsocketTokenValidDuration:   edgeproto.Duration(2 * time.Minute),
 }
 
+func setDefaultConfigEmails(domain string) {
+	defaultConfig.SupportEmail = "support@" + serverConfig.Domain
+	defaultConfig.LegalEmail = "legal@" + serverConfig.Domain
+}
+
 var curConfig ormapi.Config
 var curConfigMux sync.Mutex
 
@@ -123,6 +128,14 @@ func InitConfig(ctx context.Context) error {
 	}
 	if config.WebsocketTokenValidDuration == 0 {
 		config.WebsocketTokenValidDuration = defaultConfig.WebsocketTokenValidDuration
+		save = true
+	}
+	if config.SupportEmail == "" {
+		config.SupportEmail = defaultConfig.SupportEmail
+		save = true
+	}
+	if config.LegalEmail == "" {
+		config.LegalEmail = defaultConfig.LegalEmail
 		save = true
 	}
 
@@ -333,5 +346,7 @@ func PublicConfig(c echo.Context) error {
 	}
 	publicConfig := &ormapi.Config{}
 	publicConfig.PasswordMinCrackTimeSec = config.PasswordMinCrackTimeSec
+	publicConfig.SupportEmail = config.SupportEmail
+	publicConfig.LegalEmail = config.LegalEmail
 	return c.JSON(http.StatusOK, publicConfig)
 }

--- a/pkg/mc/orm/emails.go
+++ b/pkg/mc/orm/emails.go
@@ -275,7 +275,9 @@ func sendEmail(from *cloudcommon.EmailAccount, to string, contents *bytes.Buffer
 	tlsconfig := &tls.Config{
 		ServerName: from.Smtp,
 	}
-	client.StartTLS(tlsconfig)
+	if err = client.StartTLS(tlsconfig); err != nil {
+		return err
+	}
 	if err = client.Auth(auth); err != nil {
 		return err
 	}

--- a/pkg/mc/orm/server.go
+++ b/pkg/mc/orm/server.go
@@ -124,6 +124,7 @@ type ServerConfig struct {
 	ConsoleAddr              string
 	PasswordResetConsolePath string
 	VerifyEmailConsolePath   string
+	Domain                   string
 	oauth2Server             *oauth2server.Server
 	testTransport            http.RoundTripper // for unit-tests
 }
@@ -196,6 +197,7 @@ func RunServer(config *ServerConfig) (retserver *Server, reterr error) {
 	if serverConfig.LDAPPassword == "" && !config.IgnoreEnv {
 		serverConfig.LDAPPassword = os.Getenv("LDAP_PASSWORD")
 	}
+	setDefaultConfigEmails(serverConfig.Domain)
 	allRegionCaches.init()
 
 	if config.DeploymentTag == "" {

--- a/pkg/mc/orm/user.go
+++ b/pkg/mc/orm/user.go
@@ -201,7 +201,7 @@ func Login(c echo.Context) error {
 	}
 
 	if user.Locked {
-		return fmt.Errorf("Account is locked, please contact Edge Cloud support")
+		return fmt.Errorf("Account is locked, please contact %s to unlock it", config.SupportEmail)
 	}
 	if !getSkipVerifyEmail(ctx, nil) && !user.EmailVerified {
 		return fmt.Errorf("Email not verified yet")

--- a/pkg/process/process_mc.go
+++ b/pkg/process/process_mc.go
@@ -46,6 +46,7 @@ type MC struct {
 	ApiTlsCert              string
 	ApiTlsKey               string
 	StaticDir               string
+	Domain                  string
 	TestMode                bool
 	cmd                     *exec.Cmd
 }
@@ -124,6 +125,9 @@ func (p *MC) StartLocal(logfile string, opts ...StartOp) error {
 	}
 	if p.StaticDir != "" {
 		args = append(args, "--staticDir", p.StaticDir)
+	}
+	if p.Domain != "" {
+		args = append(args, "--domain", p.Domain)
 	}
 	if p.TestMode {
 		args = append(args, "--testMode")

--- a/test/e2e-tests/data/mcconfig.yml
+++ b/test/e2e-tests/data/mcconfig.yml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 notifyemailaddress: support@mobiledgex.com
+legalemail: legal@edgecloud.net
 skipverifyemail: true
 passwordmincracktimesec: 2.592e+06
 adminpasswordmincracktimesec: 6.3072e+07
@@ -28,3 +29,4 @@ failedloginlockouttimesec2: 300
 userlogintokenvalidduration: 24h0m0s
 apikeylogintokenvalidduration: 4h0m0s
 websockettokenvalidduration: 2m0s
+supportemail: support@edgecloud.net

--- a/test/e2e-tests/data/mcconfig_default.yml
+++ b/test/e2e-tests/data/mcconfig_default.yml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+legalemail: legal@edgecloud.net
 passwordmincracktimesec: 2.592e+06
 adminpasswordmincracktimesec: 6.3072e+07
 maxmetricsdatapoints: 10000
@@ -25,3 +26,4 @@ failedloginlockouttimesec2: 300
 userlogintokenvalidduration: 24h0m0s
 apikeylogintokenvalidduration: 4h0m0s
 websockettokenvalidduration: 2m0s
+supportemail: support@edgecloud.net

--- a/test/e2e-tests/data/mcconfig_partner1.yml
+++ b/test/e2e-tests/data/mcconfig_partner1.yml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 notifyemailaddress: support@mobiledgex.com
+legalemail: legal@edgecloud.net
 skipverifyemail: true
 passwordmincracktimesec: 2.592e+06
 adminpasswordmincracktimesec: 6.3072e+07
@@ -28,3 +29,4 @@ failedloginlockouttimesec2: 300
 userlogintokenvalidduration: 24h0m0s
 apikeylogintokenvalidduration: 4h0m0s
 websockettokenvalidduration: 2m0s
+supportemail: support@edgecloud.net

--- a/test/e2e-tests/data/mcconfig_ratelimit_show.yml
+++ b/test/e2e-tests/data/mcconfig_ratelimit_show.yml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 notifyemailaddress: support@mobiledgex.com
+legalemail: legal@edgecloud.net
 skipverifyemail: true
 passwordmincracktimesec: 2.592e+06
 adminpasswordmincracktimesec: 6.3072e+07
@@ -27,3 +28,4 @@ failedloginlockouttimesec2: 300
 userlogintokenvalidduration: 24h0m0s
 apikeylogintokenvalidduration: 4h0m0s
 websockettokenvalidduration: 2m0s
+supportemail: support@edgecloud.net

--- a/test/e2e-tests/setups/local_multi.yml
+++ b/test/e2e-tests/setups/local_multi.yml
@@ -541,6 +541,7 @@ mcs:
   apitlscert: "{{tlsoutdir}}/test-server.crt"
   apitlskey: "{{tlsoutdir}}/test-server.key"
   deploymenttag: dev
+  domain: edgecloud.net
   envvars:
     ES_SERVER_URLS: https://localhost:9201
     E2ETEST_TLS: true
@@ -565,6 +566,7 @@ mcs:
   apitlscert: "{{tlsoutdir}}/test-server.crt"
   apitlskey: "{{tlsoutdir}}/test-server.key"
   deploymenttag: dev
+  domain: edgecloud.net
   envvars:
     ES_SERVER_URLS: https://localhost:9201
     E2ETEST_TLS: true
@@ -585,6 +587,7 @@ mcs:
   apitlscert: "{{tlsoutdir}}/test-server.crt"
   apitlskey: "{{tlsoutdir}}/test-server.key"
   deploymenttag: dev
+  domain: edgecloud.net
   envvars:
     ES_SERVER_URLS: https://localhost:9201
     E2ETEST_TLS: true


### PR DESCRIPTION
Make MC the source of truth for the support and legal email addresses. Set sensible defaults which can be overridden. The UI will query MC for the current email values when needed. Previously the UI was getting the email addresses via REACT env vars, which had required the emails to be managed by the deployment tools.