### PR TITLE
ipv6 fix and dns wildcard fix

### DIFF
--- a/cmd/controller/appinst_api.go
+++ b/cmd/controller/appinst_api.go
@@ -999,6 +999,7 @@ func (s *AppInstApi) createAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 			clusterInst.Deployment = cloudcommon.DeploymentTypeKubernetes
 			clusterInst.NumMasters = 1
 			clusterInst.NumNodes = 1 // TODO support 1 master, zero nodes
+			clusterInst.EnableIpv6 = false
 			if cloudletFeatures.NoClusterSupport {
 				log.SpanLog(ctx, log.DebugLevelApi, "Setting num nodes to 0 as platform does not support clusters", "platform", cloudletFeatures.PlatformType)
 				clusterInst.NumNodes = 0

--- a/pkg/ccrm/ccrm_cloudlet.go
+++ b/pkg/ccrm/ccrm_cloudlet.go
@@ -209,6 +209,12 @@ func getCrmEnv(vars map[string]string) {
 		// external endpoint.
 		vars["JAEGER_ENDPOINT"] = val
 	}
+	if val, ok := os.LookupEnv("ES_SERVER_URLS_EXTERNAL"); ok {
+		// ES_SERVER_URLS may point to the internal DNS name in
+		// the kubernetes cluster, in which case CRM will need
+		// the external endpoint.
+		vars["ES_SERVER_URLS"] = val
+	}
 }
 
 func (s *CCRMHandler) GetCloudletManifest(ctx context.Context, key *edgeproto.CloudletKey) (*edgeproto.CloudletManifest, error) {

--- a/pkg/cloudcommon/node/publicnode.go
+++ b/pkg/cloudcommon/node/publicnode.go
@@ -198,6 +198,8 @@ func (s *PublicCertManager) GetCertificateFunc() func(*tls.ClientHelloInfo) (*tl
 		} else {
 			// do substring match to allow for wild cards
 			for cn, pubcert := range s.certs {
+				cn = strings.TrimPrefix(cn, "_")
+				cn = strings.TrimPrefix(cn, "*")
 				if strings.HasSuffix(info.ServerName, cn) {
 					return pubcert.cert, nil
 				}


### PR DESCRIPTION
Kubernetes auto-cluster on Openstack was failing due to the ipv6. It was inheriting the enable state of the cloudlet (which is True for Openstack), but we do not yet have support for Kubernetes, so was failing. Until we add support for ipv6 on Kubernetes clusters, the auto-cluster will need to keep ipv6 disabled for k8s clusters.

The public DNS cert lookup was failing for wildcard names. We were doing a substring match assuming a substring, but we actually needed to remove the wildcard label first.

Finally, for a regional cluster running in the global cluster, the CCRM's opensearch URL will be an internal URL, but CRM needs the external one.
