### PR TITLE
image pull failed, unauthorized

### DIFF
--- a/pkg/cloudcommon/registry.go
+++ b/pkg/cloudcommon/registry.go
@@ -117,6 +117,11 @@ func (s *RegistryAuthMgr) getVaultRegistryPathUnfiltered(registry, org string) s
 	// internal registries at the time of App creation,
 	// therefore any user-provided credentials are used only
 	// once during App creation and are not needed afterwards.
+	// Note: registry and org are extracted from image path URL
+	// when seeding secrets, and are case-insensitive, so we
+	// keep them lower case.
+	registry = strings.ToLower(registry)
+	org = strings.ToLower(org)
 	if org == AllOrgs {
 		// registry key granting access to all orgs
 		// these are admin keys for internal use and should not


### PR DESCRIPTION
This a regression due to the changes to reduce the scope of harbor robot pull credentials by limiting them to org. If the organization name has upper case, the registry credentials were stored in vault with the upper case, but the org name extracted from the image path was lower case (as is typically the case with URLs).

The fix is to always set the Vault path to lowercase for all strings that are part of URLs.
