### PR TITLE
treat user emails as case insensitive

### DIFF
--- a/api/ormapi/api.go
+++ b/api/ormapi/api.go
@@ -30,7 +30,7 @@ type User struct {
 	// required: true
 	Name string `gorm:"primary_key;type:citext"`
 	// User email
-	Email string `gorm:"unique;not null"`
+	Email string `gorm:"unique;type:citext;not null"`
 	// Email address has been verified
 	// read only: true
 	EmailVerified bool

--- a/pkg/mc/orm/postgres.go
+++ b/pkg/mc/orm/postgres.go
@@ -123,6 +123,20 @@ func InitData(ctx context.Context, superuser, superpass string, pingInterval tim
 			}
 			continue
 		}
+		// upgrade functions
+		err = fixColumnType(ctx, db, "users", []ColType{{
+			"email",
+			"citext",
+		}})
+		if err != nil {
+			log.SpanLog(ctx, log.DebugLevelApi, "fix users table email column type", "err", err)
+			if unitTest {
+				initDone <- err
+				return
+			}
+			continue
+		}
+
 		// create initial database data
 		err = InitRolePerms(ctx)
 		if err != nil {

--- a/pkg/mc/orm/user.go
+++ b/pkg/mc/orm/user.go
@@ -395,6 +395,8 @@ func CreateUser(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+	// for consistency, emails are stored in lowercase
+	user.Email = strings.ToLower(user.Email)
 	if !util.ValidEmail(user.Email) {
 		return fmt.Errorf("Invalid email address")
 	}
@@ -1139,6 +1141,8 @@ func UpdateUser(c echo.Context) error {
 	if err := c.Bind(&cuser); err != nil {
 		return ormutil.BindErr(err)
 	}
+	// lowercase email that may have been input by user
+	cuser.User.Email = strings.ToLower(cuser.User.Email)
 	// check for fields that are not allowed to change
 	if old.Name != user.Name {
 		return fmt.Errorf("Cannot change username")


### PR DESCRIPTION
Fix for #253. Emails are now treated in a case-insensitive manner in two ways
- they are stored in postgres as citext, so any lookups by email will be done as a lowercase comparison. This also prevents two users with emails that differ only in case from being created
- anywhere we take user input to store an email to postgres, we lowercase it. This is because while postgres citext does case-insensitive comparison, it is still stored case sensitive, so that visually it's consistent that all emails are shown as lowercase, regardless of what case was used when the account was created.