### PR TITLE
parsedeps updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,10 @@ tools:
 external-doc:
 	make -C edgeproto external-doc
 
+CMDS	= ./cmd/alertmgr-sidecar ./cmd/autoprov ./cmd/ccrm ./cmd/cluster-svc ./cmd/controller ./cmd/crm ./cmd/dme ./cmd/edgeturn ./cmd/frm ./cmd/mc ./cmd/mcctl ./cmd/notifyroot ./cmd/shepherd ./pkg/platform/ ./pkg/plugin/edgeevents ./pkg/plugin/platform ./pkg/shepherd_platform
+
 third_party:
-	parsedeps --gennotice ./cmd/crmserver ./cmd/controller ./cmd/dme-server ./cmd/cluster-svc ./cmd/edgeturn ./cmd/notifyroot ./pkg/plugin/platform/ ./pkg/plugin/edgeevents ./cmd/shepherd ./pkg/shepherd_platform ./cmd/mc ./cmd/alertmgr-sidecar ./cmd/autoprov> THIRD-PARTY-NOTICES
+	parsedeps --gennotice ${CMDS} > THIRD-PARTY-NOTICES
 
 $(APICOMMENTS): ./tools/apidoc/apidoc.go ./api/ormapi/api.go ./api/ormapi/federation_api.go
 	go install ./tools/apidoc

--- a/tools/parsedeps/licenses.go
+++ b/tools/parsedeps/licenses.go
@@ -9,6 +9,7 @@ const (
 	MozillaPublicLicense2 = "Mozilla Public License Version 2.0"
 	BSD2ClauseLicense     = `BSD 2-Clause "Simplified" License`
 	BSD3ClauseLicense     = `BSD 3-Clause "New" or "Revised" License`
+	Unlicense             = "Free unlicense"
 	UnknownLicense        = "Unknown License"
 )
 
@@ -745,4 +746,30 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 
   This Source Code Form is "Incompatible With Secondary Licenses", as
   defined by the Mozilla Public License, v. 2.0.`,
+}, {
+	Name: Unlicense,
+	Text: `This is free and unencumbered software released into the public domain.
+
+    Anyone is free to copy, modify, publish, use, compile, sell, or
+    distribute this software, either in source code form or as a compiled
+    binary, for any purpose, commercial or non-commercial, and by any
+    means.
+    
+    In jurisdictions that recognize copyright laws, the author or authors
+    of this software dedicate any and all copyright interest in the
+    software to the public domain. We make this dedication for the benefit
+    of the public at large and to the detriment of our heirs and
+    successors. We intend this dedication to be an overt act of
+    relinquishment in perpetuity of all present and future rights to this
+    software under copyright law.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+    OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+    ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+    OTHER DEALINGS IN THE SOFTWARE.
+    
+    For more information, please refer to <http://unlicense.org/>`,
 }}

--- a/tools/parsedeps/parsedeps.go
+++ b/tools/parsedeps/parsedeps.go
@@ -180,7 +180,7 @@ type PkgDep struct {
 }
 
 func getLicensePath(pkgDir string) string {
-	files := []string{"LICENSE", "LICENSE.txt", "LICENSE.md", "NOTICE"}
+	files := []string{"LICENSE", "License", "LICENSE.txt", "LICENSE.md", "license.md", "NOTICE"}
 	for {
 		if len(pkgDir) == 0 || strings.HasSuffix(pkgDir, "go/pkg/mod") {
 			break


### PR DESCRIPTION
For parsedeps, add "free" license detection. Update makefile with correct paths for distributed binaries and plugins.