### PR TITLE
remove session cookie from swagger config examples

### DIFF
--- a/api/dme-proto/swagger_config.yaml
+++ b/api/dme-proto/swagger_config.yaml
@@ -57,7 +57,7 @@ info:
       ```java
       distributed_match_engine.AppClient$RegisterClientReply@e3d72edd
 
-      session_cookie: "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1ODA0OTgwMTksImlhdCI6MTU4MDQxMTYxOSwia2V5Ijp7InBlZXJpcCI6IjEwLjI0MC4wLjgiLCJkZXZuYW1lIjoiTW9iaWxlZGdlWCIsImFwcG5hbWUiOiJNb2JpbGVkZ2VYIFNESyBEZW1vIiwiYXBwdmVycyI6IjEuMCIsInVuaXF1ZWlkdHlwZSI6ImRtZS1rc3VpZCIsInVuaXF1ZWlkIjoiMVg3eXFjdEZJNFA4R2lYNkhNYjFVQTRiUU1LIiwia2lkIjo0fX0.9kM38-mqfcRZhT59YRb3f3ZE1OuwchQgcBEHlRufg07gwgt55CkrMNubUeZvPmyGbwKHUYKr4z3cG8i4PfR1sA"
+      session_cookie: "***"
       status: RS_SUCCESS
       status_value: 1
       token_server_uri: "http://mexdemo.tok.mobiledgex.net:9999/its?followURL=https://dme.mobiledgex.net/verifyLoc"
@@ -281,10 +281,7 @@ info:
       ```swift
       ["unique_id": ,
       "status": RS_SUCCESS,
-      "session_cookie": eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1ODA1MDAxMzIsImlhdCI6MTU4MDQxMzczMiwia2V5Ijp7InBlZXJpcCI6IjE
-      yNy4wLjAuMSIsImRldm5hbWUiOiJNb2JpbGVkZ2VYIiwiYXBwbmFtZSI6Ik1vYmlsZWRnZVggU0RLIERlbW8iLCJhcHB2ZXJzIjoiMS4wIiwidW5pcXVlaWR0eXBlI
-      joiZG1lLWtzdWlkIiwidW5pcXVlaWQiOiIxWDgzOEVNbWJsNjYzSlNnT0dSVHFPYko1M3AiLCJraWQiOjR9fQ.kcrmNOYRLV_irLpYpdN6-oCgj4EakuTgMbIInNs1
-      JvCPm5vCjshO3CCbY_pCbcovUL-EemXZcWXqxYmz_SqIow,
+      "session_cookie": "***",
       "tags": <__NSArray0 0x7fff80615170>(),
       "unique_id_type": ,
       "ver": 0,


### PR DESCRIPTION
Remove session cookies from examples because they flag security scanners.