### PR TITLE
fix redisapi race condition and ccrm redisapi default timeout

### DIFF
--- a/cmd/controller/settings_api.go
+++ b/cmd/controller/settings_api.go
@@ -20,11 +20,11 @@ import (
 	"strings"
 	"time"
 
-	"go.etcd.io/etcd/client/v3/concurrency"
-	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
-	influxq "github.com/edgexr/edge-cloud-platform/cmd/controller/influxq_client"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	influxq "github.com/edgexr/edge-cloud-platform/cmd/controller/influxq_client"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
 type SettingsApi struct {
@@ -159,6 +159,10 @@ func (s *SettingsApi) initDefaults(ctx context.Context) error {
 		}
 		if cur.PlatformHaInstancePollInterval == 0 {
 			cur.PlatformHaInstancePollInterval = edgeproto.GetDefaultSettings().PlatformHaInstancePollInterval
+			modified = true
+		}
+		if cur.CcrmRedisapiTimeout == 0 {
+			cur.CcrmRedisapiTimeout = edgeproto.GetDefaultSettings().CcrmRedisapiTimeout
 			modified = true
 		}
 		if modified {

--- a/pkg/rediscache/redis_msgs.go
+++ b/pkg/rediscache/redis_msgs.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/go-redis/redis/v8"
 )
 
@@ -23,18 +24,21 @@ type MessageHandler struct {
 // message being sent. After that code, call WaitForMessage().
 // The desired Message parameter must have its key value set.
 // An example of this would be:
-// desired := &edgeproto.Info{
-//   Key: someKey,
-// }
+//
+//	desired := &edgeproto.Info{
+//	  Key: someKey,
+//	}
+//
 // h := Subscribe(ctx, client, desired)
 // defer h.Close()
 // <code to trigger message send>
-// err := h.WaitForMessage(10*time.Second, func() bool {
-//   if desired.State == TARGET_STATE {
-//     return true
-//   }
-//   return false
-// })
+//
+//	err := h.WaitForMessage(10*time.Second, func() bool {
+//	  if desired.State == TARGET_STATE {
+//	    return true
+//	  }
+//	  return false
+//	})
 func Subscribe(ctx context.Context, client *redis.Client, desired Message) *MessageHandler {
 	h := MessageHandler{}
 	h.desired = desired
@@ -85,6 +89,7 @@ func waitForMessage(ctx context.Context, ch <-chan *redis.Message, cb waitForHan
 			if !ok {
 				return errors.New("unexpected channel close while waiting for reply")
 			}
+			log.SpanLog(ctx, log.DebugLevelApi, "redis got reply", "message", msg)
 			done, err := cb(msg.Payload)
 			if err != nil {
 				return err


### PR DESCRIPTION
This fixes a race condition where subscribing to a redis channel to get the reply for the redisapi was non-blocking, so the reply was issued before the subscribe went through.

Also the default value for the ccrm redisapi timeout was not being set, causing it to be 0.

Also changed some of the logging to also log the reply and the actual redis channel names.