### PR TITLE
change parse deps handling of source code mirror

### DIFF
--- a/tools/parsedeps/parsedeps.go
+++ b/tools/parsedeps/parsedeps.go
@@ -204,6 +204,11 @@ func getSourceMirror(pkgDir string) (string, error) {
 	for to, from := range pathXlat {
 		repo = strings.Replace(repo, to, from, -1)
 	}
+	if strings.HasPrefix(repo, "github.com/") {
+		// just point to github repo, we don't need to maintain a copy
+		repo = strings.Replace(repo, "@", "/releases/tag/", 1)
+		return repo, nil
+	}
 	repo = strings.Replace(repo, "/", "-", -1)
 	repo = strings.Replace(repo, "@", ".", -1)
 	repo += ".tar"


### PR DESCRIPTION
For libraries governed by the Mozilla license, a reference to where the source code can be found is needed. If the source code is hosted on github, point to the github repo rather than our own maintained copy of the source code.