### PR TITLE
registry auth missing token for www-auth to Azure

### DIFF
--- a/pkg/cloudcommon/registry.go
+++ b/pkg/cloudcommon/registry.go
@@ -519,6 +519,7 @@ func handleWWWAuth(ctx context.Context, method, regUrl, authHeader string, auth 
 				authTok.Token = authResp[AuthRespAccessToken]
 			} else {
 				log.SpanLog(ctx, log.DebugLevelApi, "no token found in www-auth request", "resp", authResp, "decodeErr", decErr)
+				return nil, fmt.Errorf("no token found in auth response for URL %s", authURL)
 			}
 			authTok.AuthType = TokenAuth
 


### PR DESCRIPTION
When authenticating to an Azure-hosted container registry, the www-auth redirect to an oauth endpoint returns a token using the json key "access_token", rather than what was previously expected as just "token". This change accepts either "token" or "access_token" in the authentication response.