### PR TITLE
fix redis subscribe race condition

### DIFF
--- a/cmd/controller/stream_api.go
+++ b/cmd/controller/stream_api.go
@@ -448,6 +448,7 @@ func (s *StreamObjApi) startStream(ctx context.Context, cctx *CallContext, strea
 	// Wait for confirmation that subscription is created before publishing anything.
 	_, err := pubsub.Receive(ctx)
 	if err != nil {
+		pubsub.Close()
 		return nil, fmt.Errorf("Failed to subscribe to stream %s, %v", streamKey, err)
 	}
 

--- a/cmd/shepherd/cloudlet-prom_test.go
+++ b/cmd/shepherd/cloudlet-prom_test.go
@@ -77,7 +77,7 @@ func TestCloudletPrometheusFuncs(t *testing.T) {
 	targetFileWorkers.WaitIdle()
 	// verify they all are here
 	content, err := ioutil.ReadFile(*promTargetsFile)
-	fmt.Print(content)
+	fmt.Print(string(content))
 	assert.Nil(t, err)
 	targets := TestJsonTargets{}
 	err = json.Unmarshal(content, &targets)

--- a/cmd/shepherd/envoy-stats_test.go
+++ b/cmd/shepherd/envoy-stats_test.go
@@ -60,7 +60,7 @@ cluster.udp_backend8765.upstream_cx_none_healthy: 16`
 
 func setupLog() context.Context {
 	log.InitTracer(nil)
-	ctx := log.StartTestSpan(context.Background())
+	ctx := log.StartTestSpan(context.Background(), log.WithSpanLineno(log.GetLineno(1)))
 	return ctx
 }
 func startServer() *httptest.Server {

--- a/pkg/log/jaeger.go
+++ b/pkg/log/jaeger.go
@@ -183,7 +183,7 @@ func SpanToString(ctx context.Context) string {
 }
 
 func NewSpanFromString(lvl uint64, val, spanName string) opentracing.Span {
-	linenoOpt := WithSpanLineno{GetLineno(1)}
+	linenoOpt := WithSpanLineno(GetLineno(1))
 	if val != "" {
 		carrier := SpanCarrier{
 			Data: TraceData{},

--- a/pkg/rediscache/dummy_redis_test.go
+++ b/pkg/rediscache/dummy_redis_test.go
@@ -85,10 +85,12 @@ func testDummyRedisServer(t *testing.T, client *redis.Client, server *DummyRedis
 	// =================
 
 	pubsub1 := client.Subscribe(ctx, "ch1")
+	_, err = pubsub1.Receive(ctx)
 	require.Nil(t, err, "initialize channel to recv messages")
 	require.NotNil(t, pubsub1)
 
 	pubsub2 := client.Subscribe(ctx, "ch2")
+	_, err = pubsub2.Receive(ctx)
 	require.Nil(t, err, "initialize another channel to recv messages")
 	require.NotNil(t, pubsub2)
 

--- a/pkg/rediscache/redis_msgs_test.go
+++ b/pkg/rediscache/redis_msgs_test.go
@@ -52,7 +52,8 @@ func TestRedisMessages(t *testing.T) {
 	tm := testMessage{
 		Key: "12345",
 	}
-	handler := Subscribe(ctx, client, &tm)
+	handler, err := Subscribe(ctx, client, &tm)
+	require.Nil(t, err)
 	require.NotNil(t, handler)
 
 	numMsgs := 3


### PR DESCRIPTION
Adds a call to receive() after subscribing to redis. This ensures that an immediate subsequent send will not get lost, due to the Subscribe() call being asynchronous.

Also some tweaks for spanlog in unit tests.