### PR TITLE
crmutil package cleanup

### DIFF
--- a/pkg/access/access-config.go
+++ b/pkg/access/access-config.go
@@ -23,9 +23,8 @@ import (
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
+	"github.com/edgexr/edge-cloud-platform/pkg/deployvars"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
-
-	"github.com/edgexr/edge-cloud-platform/pkg/crmutil"
 )
 
 type AppAccessConfig struct {
@@ -43,7 +42,7 @@ type TLSCert struct {
 }
 
 func GetAppAccessConfig(ctx context.Context, configs []*edgeproto.ConfigFile, delims string) (*AppAccessConfig, error) {
-	deploymentVars, varsFound := ctx.Value(crmutil.DeploymentReplaceVarsKey).(*crmutil.DeploymentReplaceVars)
+	deploymentVars, varsFound := ctx.Value(deployvars.DeploymentReplaceVarsKey).(*deployvars.DeploymentReplaceVars)
 	var aac AppAccessConfig
 
 	log.SpanLog(ctx, log.DebugLevelInfra, "getAppAccessConfig", "deploymentVars", deploymentVars, "varsFound", varsFound)
@@ -59,7 +58,7 @@ func GetAppAccessConfig(ctx context.Context, configs []*edgeproto.ConfigFile, de
 				return nil, err
 			}
 			// Fill in the Deployment Vars passed as a variable through the context
-			cfg, err = crmutil.ReplaceDeploymentVars(cfg, delims, deploymentVars)
+			cfg, err = deployvars.ReplaceDeploymentVars(cfg, delims, deploymentVars)
 			if err != nil {
 				log.SpanLog(ctx, log.DebugLevelInfra, "getAppAccessConfig failed to replace CRM variables",
 					"config file", v.Config, "DeploymentVars", deploymentVars, "error", err)

--- a/pkg/crmutil/controller-data.go
+++ b/pkg/crmutil/controller-data.go
@@ -36,7 +36,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
-//ControllerData contains cache data for controller
+// ControllerData contains cache data for controller
 type ControllerData struct {
 	platform                             platform.Platform
 	cloudletKey                          edgeproto.CloudletKey
@@ -243,48 +243,6 @@ func (cd *ControllerData) flavorChanged(ctx context.Context, old *edgeproto.Flav
 	// } else {
 	// 	// CRM TODO: delete flavor?
 	// }
-}
-
-// GetCloudletTrustPolicy finds the policy from the cache.  If a blank policy name is specified, an empty policy is returned
-func GetCloudletTrustPolicy(ctx context.Context, name string, cloudletOrg string, privPolCache *edgeproto.TrustPolicyCache) (*edgeproto.TrustPolicy, error) {
-	log.SpanLog(ctx, log.DebugLevelInfo, "GetCloudletTrustPolicy")
-	if name != "" {
-		pp := edgeproto.TrustPolicy{}
-		pk := edgeproto.PolicyKey{
-			Name:         name,
-			Organization: cloudletOrg,
-		}
-		if !privPolCache.Get(&pk, &pp) {
-			log.SpanLog(ctx, log.DebugLevelInfra, "Cannot find Trust Policy from cache", "pk", pk, "pp", pp)
-			return nil, fmt.Errorf("fail to find Trust Policy from cache: %s", pk)
-		} else {
-			log.SpanLog(ctx, log.DebugLevelInfra, "Found Trust Policy from cache", "pk", pk, "pp", pp)
-			return &pp, nil
-		}
-	} else {
-		log.SpanLog(ctx, log.DebugLevelInfo, "Returning empty trust policy for empty name")
-		emptyPol := &edgeproto.TrustPolicy{}
-		return emptyPol, nil
-	}
-}
-
-func GetNetworksForClusterInst(ctx context.Context, clusterInst *edgeproto.ClusterInst, networkCache *edgeproto.NetworkCache) ([]*edgeproto.Network, error) {
-	log.SpanLog(ctx, log.DebugLevelInfo, "GetNetworksForClusterInst", "clusterInst", clusterInst)
-	networks := []*edgeproto.Network{}
-	for _, netName := range clusterInst.Networks {
-		net := edgeproto.Network{}
-		nk := edgeproto.NetworkKey{
-			Name:        netName,
-			CloudletKey: clusterInst.Key.CloudletKey,
-		}
-		if !networkCache.Get(&nk, &net) {
-			log.SpanLog(ctx, log.DebugLevelInfra, "Cannot find network from cache", "nk", nk)
-			return nil, fmt.Errorf("fail to find network from cache: %s", nk)
-		}
-		log.SpanLog(ctx, log.DebugLevelInfra, "Found network from cache", "nk", nk, "net", net)
-		networks = append(networks, &net)
-	}
-	return networks, nil
 }
 
 func (cd *ControllerData) vmResourceActionBegin() {

--- a/pkg/deployvars/deployment-vars.go
+++ b/pkg/deployvars/deployment-vars.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package crmutil
+package deployvars
 
 import (
 	"bytes"

--- a/pkg/deployvars/deployment-vars_test.go
+++ b/pkg/deployvars/deployment-vars_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package crmutil
+package deployvars
 
 import (
 	"testing"

--- a/pkg/k8smgmt/helm.go
+++ b/pkg/k8smgmt/helm.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
-	"github.com/edgexr/edge-cloud-platform/pkg/crmutil"
+	"github.com/edgexr/edge-cloud-platform/pkg/deployvars"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform/pc"
 	ssh "github.com/edgexr/golang-ssh"
@@ -41,7 +41,7 @@ var validHelmInstallOpts = map[string]struct{}{
 func getHelmOpts(ctx context.Context, client ssh.Client, appName, delims string, configs []*edgeproto.ConfigFile) (string, error) {
 	var ymls []string
 
-	deploymentVars, varsFound := ctx.Value(crmutil.DeploymentReplaceVarsKey).(*crmutil.DeploymentReplaceVars)
+	deploymentVars, varsFound := ctx.Value(deployvars.DeploymentReplaceVarsKey).(*deployvars.DeploymentReplaceVars)
 	// Walk the Configs in the App and generate the yaml files from the helm customization ones
 	for ii, v := range configs {
 		// skip non helm and empty configs
@@ -53,7 +53,7 @@ func getHelmOpts(ctx context.Context, client ssh.Client, appName, delims string,
 			}
 			// Fill in the Deployment Vars passed as a variable through the context
 			if varsFound {
-				cfg, err = crmutil.ReplaceDeploymentVars(cfg, delims, deploymentVars)
+				cfg, err = deployvars.ReplaceDeploymentVars(cfg, delims, deploymentVars)
 				if err != nil {
 					log.SpanLog(ctx, log.DebugLevelInfra, "failed to replace Crm variables",
 						"config file", v.Config, "DeploymentVars", deploymentVars, "error", err)

--- a/pkg/platform/common/vmlayer/appinst.go
+++ b/pkg/platform/common/vmlayer/appinst.go
@@ -27,7 +27,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/access"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
-	"github.com/edgexr/edge-cloud-platform/pkg/crmutil"
+	"github.com/edgexr/edge-cloud-platform/pkg/deployvars"
 	"github.com/edgexr/edge-cloud-platform/pkg/dockermgmt"
 	"github.com/edgexr/edge-cloud-platform/pkg/k8smgmt"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
@@ -118,15 +118,15 @@ func (v *VMPlatform) PerformOrchestrationForVMApp(ctx context.Context, app *edge
 	if err != nil {
 		return &orchVals, err
 	}
-	deploymentVars := crmutil.DeploymentReplaceVars{
-		Deployment: crmutil.CrmReplaceVars{
+	deploymentVars := deployvars.DeploymentReplaceVars{
+		Deployment: deployvars.CrmReplaceVars{
 			CloudletName: k8smgmt.NormalizeName(appInst.Key.CloudletKey.Name),
 			CloudletOrg:  k8smgmt.NormalizeName(appInst.Key.CloudletKey.Organization),
 			AppOrg:       k8smgmt.NormalizeName(app.Key.Organization),
 			DnsZone:      v.VMProperties.CommonPf.GetCloudletDNSZone(),
 		},
 	}
-	ctx = context.WithValue(ctx, crmutil.DeploymentReplaceVarsKey, &deploymentVars)
+	ctx = context.WithValue(ctx, deployvars.DeploymentReplaceVarsKey, &deploymentVars)
 
 	var vms []*VMRequestSpec
 	orchVals.externalServerName = appVmName
@@ -381,8 +381,8 @@ func (v *VMPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.C
 		if masterIpErr != nil {
 			return masterIpErr
 		}
-		deploymentVars := crmutil.DeploymentReplaceVars{
-			Deployment: crmutil.CrmReplaceVars{
+		deploymentVars := deployvars.DeploymentReplaceVars{
+			Deployment: deployvars.CrmReplaceVars{
 				ClusterIp:    masterIPs.IPV4ExternalAddr(),
 				ClusterIPV6:  masterIPs.IPV6ExternalAddr(),
 				CloudletName: k8smgmt.NormalizeName(clusterInst.Key.CloudletKey.Name),
@@ -392,7 +392,7 @@ func (v *VMPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.C
 				DnsZone:      v.VMProperties.CommonPf.GetCloudletDNSZone(),
 			},
 		}
-		ctx = context.WithValue(ctx, crmutil.DeploymentReplaceVarsKey, &deploymentVars)
+		ctx = context.WithValue(ctx, deployvars.DeploymentReplaceVarsKey, &deploymentVars)
 
 		if deployment == cloudcommon.DeploymentTypeKubernetes {
 			updateCallback(edgeproto.UpdateTask, "Creating Kubernetes App")
@@ -667,8 +667,8 @@ func (v *VMPlatform) cleanupAppInstInternal(ctx context.Context, clusterInst *ed
 			return err
 		}
 		// Add crm local replace variables
-		deploymentVars := crmutil.DeploymentReplaceVars{
-			Deployment: crmutil.CrmReplaceVars{
+		deploymentVars := deployvars.DeploymentReplaceVars{
+			Deployment: deployvars.CrmReplaceVars{
 				ClusterIp:    masterIPs.IPV4ExternalAddr(),
 				ClusterIPV6:  masterIPs.IPV6ExternalAddr(),
 				CloudletName: k8smgmt.NormalizeName(clusterInst.Key.CloudletKey.Name),
@@ -678,7 +678,7 @@ func (v *VMPlatform) cleanupAppInstInternal(ctx context.Context, clusterInst *ed
 				DnsZone:      v.VMProperties.CommonPf.GetCloudletDNSZone(),
 			},
 		}
-		ctx = context.WithValue(ctx, crmutil.DeploymentReplaceVarsKey, &deploymentVars)
+		ctx = context.WithValue(ctx, deployvars.DeploymentReplaceVarsKey, &deploymentVars)
 
 		// Clean up security rules and proxy if app is external
 		wlParams := infracommon.WhiteListParams{
@@ -852,8 +852,8 @@ func (v *VMPlatform) UpdateAppInst(ctx context.Context, clusterInst *edgeproto.C
 	}
 
 	// Add crm local replace variables
-	deploymentVars := crmutil.DeploymentReplaceVars{
-		Deployment: crmutil.CrmReplaceVars{
+	deploymentVars := deployvars.DeploymentReplaceVars{
+		Deployment: deployvars.CrmReplaceVars{
 			ClusterIp:    masterIPs.IPV4ExternalAddr(),
 			ClusterIPV6:  masterIPs.IPV6ExternalAddr(),
 			ClusterName:  k8smgmt.NormalizeName(clusterInst.Key.ClusterKey.Name),
@@ -862,7 +862,7 @@ func (v *VMPlatform) UpdateAppInst(ctx context.Context, clusterInst *edgeproto.C
 			DnsZone:      v.VMProperties.CommonPf.GetCloudletDNSZone(),
 		},
 	}
-	ctx = context.WithValue(ctx, crmutil.DeploymentReplaceVarsKey, &deploymentVars)
+	ctx = context.WithValue(ctx, deployvars.DeploymentReplaceVarsKey, &deploymentVars)
 	clientType := cloudcommon.GetAppClientType(app)
 	client, err := v.GetClusterPlatformClient(ctx, clusterInst, clientType)
 	if err != nil {

--- a/pkg/platform/common/vmlayer/cluster.go
+++ b/pkg/platform/common/vmlayer/cluster.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
-	"github.com/edgexr/edge-cloud-platform/pkg/crmutil"
 	"github.com/edgexr/edge-cloud-platform/pkg/k8smgmt"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/infracommon"
@@ -42,13 +41,13 @@ const (
 	updateClusterSetupMaxTime      = time.Minute * 15
 )
 
-//ClusterNodeFlavor contains details of flavor for the node
+// ClusterNodeFlavor contains details of flavor for the node
 type ClusterNodeFlavor struct {
 	Type string
 	Name string
 }
 
-//ClusterFlavor contains definitions of cluster flavor
+// ClusterFlavor contains definitions of cluster flavor
 type ClusterFlavor struct {
 	Kind           string
 	Name           string
@@ -689,7 +688,7 @@ func (v *VMPlatform) waitClusterReady(ctx context.Context, clusterInst *edgeprot
 	}
 }
 
-//IsClusterReady checks to see if cluster is read, i.e. rootLB is running and active.  returns ready,nodecount, error
+// IsClusterReady checks to see if cluster is read, i.e. rootLB is running and active.  returns ready,nodecount, error
 func (v *VMPlatform) isClusterReady(ctx context.Context, clusterInst *edgeproto.ClusterInst, masterName string, masterIPs ServerIPs, rootLBName string, updateCallback edgeproto.CacheUpdateCallback) (bool, uint32, error) {
 	log.SpanLog(ctx, log.DebugLevelInfra, "checking if cluster is ready", "masterIPs", masterIPs)
 
@@ -825,7 +824,7 @@ func (v *VMPlatform) PerformOrchestrationForCluster(ctx context.Context, imgName
 	var newSubnetName SubnetNames
 	var newSecgrpName string
 
-	networks, err := crmutil.GetNetworksForClusterInst(ctx, clusterInst, v.Caches.NetworkCache)
+	networks, err := edgeproto.GetNetworksForClusterInst(ctx, clusterInst, v.Caches.NetworkCache)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/platform/common/vmlayer/security.go
+++ b/pkg/platform/common/vmlayer/security.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
-	"github.com/edgexr/edge-cloud-platform/pkg/crmutil"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 )
 
@@ -31,7 +30,7 @@ func (v *VMPlatform) ConfigureCloudletSecurityRules(ctx context.Context, action 
 	egressRestricted := false
 	var err error
 	if privPolName != "" {
-		privPol, err = crmutil.GetCloudletTrustPolicy(ctx, privPolName, v.VMProperties.CommonPf.PlatformConfig.CloudletKey.Organization, v.Caches.TrustPolicyCache)
+		privPol, err = edgeproto.GetCloudletTrustPolicy(ctx, privPolName, v.VMProperties.CommonPf.PlatformConfig.CloudletKey.Organization, v.Caches.TrustPolicyCache)
 		if err != nil {
 			return err
 		}

--- a/pkg/platform/common/xind/xind-appinst.go
+++ b/pkg/platform/common/xind/xind-appinst.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
-	"github.com/edgexr/edge-cloud-platform/pkg/crmutil"
+	"github.com/edgexr/edge-cloud-platform/pkg/deployvars"
 	"github.com/edgexr/edge-cloud-platform/pkg/dockermgmt"
 	"github.com/edgexr/edge-cloud-platform/pkg/k8smgmt"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
@@ -89,8 +89,8 @@ func (s *Xind) CreateAppInstNoPatch(ctx context.Context, clusterInst *edgeproto.
 	}
 
 	// Add crm local replace variables
-	deploymentVars := crmutil.DeploymentReplaceVars{
-		Deployment: crmutil.CrmReplaceVars{
+	deploymentVars := deployvars.DeploymentReplaceVars{
+		Deployment: deployvars.CrmReplaceVars{
 			ClusterIp:    masterIP,
 			CloudletName: k8smgmt.NormalizeName(clusterInst.Key.CloudletKey.Name),
 			ClusterName:  k8smgmt.NormalizeName(clusterInst.Key.ClusterKey.Name),
@@ -98,7 +98,7 @@ func (s *Xind) CreateAppInstNoPatch(ctx context.Context, clusterInst *edgeproto.
 			AppOrg:       k8smgmt.NormalizeName(app.Key.Organization),
 		},
 	}
-	ctx = context.WithValue(ctx, crmutil.DeploymentReplaceVarsKey, &deploymentVars)
+	ctx = context.WithValue(ctx, deployvars.DeploymentReplaceVarsKey, &deploymentVars)
 
 	if DeploymentType == cloudcommon.DeploymentTypeKubernetes {
 		err = k8smgmt.CreateAppInst(ctx, nil, client, names, app, appInst, flavor)
@@ -202,8 +202,8 @@ func (s *Xind) UpdateAppInst(ctx context.Context, clusterInst *edgeproto.Cluster
 	}
 
 	// Add crm local replace variables
-	deploymentVars := crmutil.DeploymentReplaceVars{
-		Deployment: crmutil.CrmReplaceVars{
+	deploymentVars := deployvars.DeploymentReplaceVars{
+		Deployment: deployvars.CrmReplaceVars{
 			ClusterIp:    masterIP,
 			CloudletName: k8smgmt.NormalizeName(clusterInst.Key.CloudletKey.Name),
 			ClusterName:  k8smgmt.NormalizeName(clusterInst.Key.ClusterKey.Name),
@@ -211,7 +211,7 @@ func (s *Xind) UpdateAppInst(ctx context.Context, clusterInst *edgeproto.Cluster
 			AppOrg:       k8smgmt.NormalizeName(app.Key.Organization),
 		},
 	}
-	ctx = context.WithValue(ctx, crmutil.DeploymentReplaceVarsKey, &deploymentVars)
+	ctx = context.WithValue(ctx, deployvars.DeploymentReplaceVarsKey, &deploymentVars)
 
 	if DeploymentType == cloudcommon.DeploymentTypeKubernetes {
 		return k8smgmt.UpdateAppInst(ctx, nil, client, names, app, appInst, flavor)

--- a/pkg/platform/fake/fake.go
+++ b/pkg/platform/fake/fake.go
@@ -28,7 +28,6 @@ import (
 	dme "github.com/edgexr/edge-cloud-platform/api/distributed_match_engine"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
-	"github.com/edgexr/edge-cloud-platform/pkg/crmutil"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/fakecommon"
@@ -228,7 +227,7 @@ func (s *Platform) CreateClusterInst(ctx context.Context, clusterInst *edgeproto
 
 	// verify we can find any provisioned networks
 	if len(clusterInst.Networks) > 0 {
-		networks, err := crmutil.GetNetworksForClusterInst(ctx, clusterInst, s.caches.NetworkCache)
+		networks, err := edgeproto.GetNetworksForClusterInst(ctx, clusterInst, s.caches.NetworkCache)
 		if err != nil {
 			return fmt.Errorf("Error getting cluster networks - %v", err)
 		}

--- a/pkg/platform/k8s-baremetal/k8sbm-appinst.go
+++ b/pkg/platform/k8s-baremetal/k8sbm-appinst.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
-	"github.com/edgexr/edge-cloud-platform/pkg/crmutil"
+	"github.com/edgexr/edge-cloud-platform/pkg/deployvars"
 	"github.com/edgexr/edge-cloud-platform/pkg/k8smgmt"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/infracommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/proxy"
@@ -90,8 +90,8 @@ func (k *K8sBareMetalPlatform) CreateAppInst(ctx context.Context, clusterInst *e
 		if err != nil {
 			log.SpanLog(ctx, log.DebugLevelInfra, "GetClusterMasterNodeIp failed", "kconfName", kconfName, "err", err)
 		}
-		deploymentVars := crmutil.DeploymentReplaceVars{
-			Deployment: crmutil.CrmReplaceVars{
+		deploymentVars := deployvars.DeploymentReplaceVars{
+			Deployment: deployvars.CrmReplaceVars{
 				ClusterIp:    masterNodeIpAddr,
 				CloudletName: k8smgmt.NormalizeName(clusterInst.Key.CloudletKey.Name),
 				ClusterName:  k8smgmt.NormalizeName(clusterInst.Key.ClusterKey.Name),
@@ -100,7 +100,7 @@ func (k *K8sBareMetalPlatform) CreateAppInst(ctx context.Context, clusterInst *e
 				DnsZone:      k.commonPf.GetCloudletDNSZone(),
 			},
 		}
-		ctx = context.WithValue(ctx, crmutil.DeploymentReplaceVarsKey, &deploymentVars)
+		ctx = context.WithValue(ctx, deployvars.DeploymentReplaceVarsKey, &deploymentVars)
 
 		if deployment == cloudcommon.DeploymentTypeKubernetes {
 			updateCallback(edgeproto.UpdateTask, "Creating Kubernetes App")
@@ -194,8 +194,8 @@ func (k *K8sBareMetalPlatform) DeleteAppInst(ctx context.Context, clusterInst *e
 			return fmt.Errorf("get kube names failed: %s", err)
 		}
 		// Add crm local replace variables
-		deploymentVars := crmutil.DeploymentReplaceVars{
-			Deployment: crmutil.CrmReplaceVars{
+		deploymentVars := deployvars.DeploymentReplaceVars{
+			Deployment: deployvars.CrmReplaceVars{
 				CloudletName: k8smgmt.NormalizeName(clusterInst.Key.CloudletKey.Name),
 				ClusterName:  k8smgmt.NormalizeName(clusterInst.Key.ClusterKey.Name),
 				CloudletOrg:  k8smgmt.NormalizeName(clusterInst.Key.CloudletKey.Organization),
@@ -203,7 +203,7 @@ func (k *K8sBareMetalPlatform) DeleteAppInst(ctx context.Context, clusterInst *e
 				DnsZone:      k.commonPf.GetCloudletDNSZone(),
 			},
 		}
-		ctx = context.WithValue(ctx, crmutil.DeploymentReplaceVarsKey, &deploymentVars)
+		ctx = context.WithValue(ctx, deployvars.DeploymentReplaceVarsKey, &deploymentVars)
 		// Clean up security rules add proxy if app is external
 		secGrp := infracommon.GetServerSecurityGroupName(rootLBName)
 		containerName := k8smgmt.GetKconfName(clusterInst) + "-" + dockermgmt.GetContainerName(appInst)

--- a/pkg/platform/vcd/vcd-common-utils.go
+++ b/pkg/platform/vcd/vcd-common-utils.go
@@ -18,11 +18,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/vmlayer"
-	"github.com/edgexr/edge-cloud-platform/pkg/crmutil"
-	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/vmlayer"
 )
 
 func (v *VcdPlatform) GetFlavor(ctx context.Context, flavorName string) (*edgeproto.FlavorInfo, error) {
@@ -114,9 +113,9 @@ func (v *VcdPlatform) GetCloudletTrustPolicy(ctx context.Context) (*edgeproto.Tr
 		log.SpanLog(ctx, log.DebugLevelInfra, "vcd:GetCloudletTrustPolicy unable to retrieve cloudlet from cache", "cloudlet", cldlet.Key.Name, "cloudletOrg", key.Organization)
 		return nil, fmt.Errorf("Cloudlet Not Found")
 	}
-	tpol, err := crmutil.GetCloudletTrustPolicy(ctx, cldlet.TrustPolicy, key.Organization, trustcache)
+	tpol, err := edgeproto.GetCloudletTrustPolicy(ctx, cldlet.TrustPolicy, key.Organization, trustcache)
 	if err != nil {
-		log.SpanLog(ctx, log.DebugLevelInfra, "vcd:GetCloudletTrustPolicy crmutil failed", "cloudlet", cldlet.Key.Name, "cloudletOrg", key.Organization, "error", err)
+		log.SpanLog(ctx, log.DebugLevelInfra, "vcd:GetCloudletTrustPolicy failed", "cloudlet", cldlet.Key.Name, "cloudletOrg", key.Organization, "error", err)
 		return nil, err
 	}
 	log.SpanLog(ctx, log.DebugLevelInfra, "vcd:GetCloudletTrustPolicy fetched", "TrustPolicy", tpol.Key.Name, "cloudlet", cldlet.Key.Name)


### PR DESCRIPTION
The crmutil package makes up the bulk of the CRM code. Additionally, a bunch of other packages were dependent on this package only for a very small portion of the code in it, code that doesn't need to be part of crmutil. So I've moved that code out into /pkg/deployvars (for deployvars related stuff) and into /api/edgeproto (for edgeproto cache related funcs).