### PR TITLE
fix k8s command quotes

### DIFF
--- a/pkg/deploygen/kube.go
+++ b/pkg/deploygen/kube.go
@@ -73,7 +73,6 @@ func appID(app *AppSpec) string {
 // preserve the LBs current notion of reality, we detect the
 // presence of a port range, and if found exhaustive enumerate
 // each port in range with a suitable KubePort object.
-//
 func setKubePorts(ports []util.PortSpec) []kubePort {
 	kports := []kubePort{}
 	var kp kubePort
@@ -188,20 +187,13 @@ func (g *kubeBasicGen) kubeApp() {
 			}
 			return !quoted && rn == ' '
 		})
-		for ii, cmd := range cs {
-			cmd = strings.TrimSpace(cmd)
-			cmd, err := strconv.Unquote(cmd)
-			if err == nil {
-				cs[ii] = cmd
-			}
-			cmd = strings.TrimSpace(cs[ii])
-			cs[ii] = strconv.Quote(cmd)
+		for ii, _ := range cs {
+			cs[ii] = strings.TrimSpace(cs[ii])
 		}
 	}
 	if len(g.app.Args) > 0 {
 		for ii, arg := range g.app.Args {
-			arg = strings.TrimSpace(arg)
-			g.app.Args[ii] = strconv.Quote(arg)
+			g.app.Args[ii] = strings.TrimSpace(arg)
 		}
 	}
 

--- a/pkg/deploygen/kube_test.go
+++ b/pkg/deploygen/kube_test.go
@@ -110,8 +110,8 @@ spec:
         - containerPort: 8001
           protocol: UDP
         command:
-        - "bash"
+        - bash
         args:
-        - "-c"
-        - "echo foobar"
+        - -c
+        - echo foobar
 `

--- a/pkg/k8smgmt/appinst.go
+++ b/pkg/k8smgmt/appinst.go
@@ -440,19 +440,19 @@ func DeleteAppInst(ctx context.Context, client ssh.Client, names *KubeNames, app
 		}
 	}
 	log.SpanLog(ctx, log.DebugLevelInfra, "deleted deployment", "name", names.AppName)
-	// remove manifest file since directory contains all AppInst manifests for
-	// the ClusterInst.
-	log.SpanLog(ctx, log.DebugLevelInfra, "remove app manifest", "name", names.AppName, "file", file)
-	out, err = client.Output("rm " + file)
-	if err != nil {
-		log.SpanLog(ctx, log.DebugLevelInfra, "error deleting manifest", "file", file, "out", string(out), "err", err)
-	}
 	//Note wait for deletion of appinst can be done here in a generic place, but wait for creation is split
 	// out in each platform specific task so that we can optimize the time taken for create by allowing the
 	// wait to be run in parallel with other tasks
 	err = WaitForAppInst(ctx, client, names, app, WaitDeleted)
 	if err != nil {
 		return err
+	}
+	// remove manifest file since directory contains all AppInst manifests for
+	// the ClusterInst.
+	log.SpanLog(ctx, log.DebugLevelInfra, "remove app manifest", "name", names.AppName, "file", file)
+	err = pc.DeleteFile(client, file, pc.NoSudo)
+	if err != nil {
+		log.SpanLog(ctx, log.DebugLevelInfra, "error deleting manifest", "file", file, "err", err)
 	}
 	if names.MultitenantNamespace != "" {
 		// clean up namespace

--- a/pkg/platform/pc/pc.go
+++ b/pkg/platform/pc/pc.go
@@ -281,7 +281,7 @@ func RunSafeShell(client ssh.Client, sin io.Reader, sout, serr io.Writer, cmd st
 	if err != nil {
 		return err
 	}
-	//defer DeleteFile(client, cmdFile, NoSudo)
+	defer DeleteFile(client, cmdFile, NoSudo)
 	return client.Shell(sin, sout, serr, "python3 "+cmdFile)
 }
 


### PR DESCRIPTION
- Don't add quotes around k8s command and args, because the command and args may not be interpreted by a shell which would strip the quotes.
- Move the manifest file delete the to the end of the delete process, in case waiting for the pods to delete fails, and the delete aborts. Without the manifest file, the next delete will fail, since it cannot run `kubectl apply -f <manifest-file>`.
- Commented code for debug was erroneously left commented, it needs to be there to clean up command files.