### PR TITLE
flexible ansible-playbook path

### DIFF
--- a/pkg/platform/common/confignode/confignode.go
+++ b/pkg/platform/common/confignode/confignode.go
@@ -98,6 +98,9 @@ if [[ ${run_update} == true ]]; then
     echo "Running update"
     if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
         ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+        if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+            ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+        fi
     fi
     if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
         touch ansible_run_ok

--- a/pkg/platform/openstack/openstack-fip-test-heat-expected.yaml
+++ b/pkg/platform/openstack/openstack-fip-test-heat-expected.yaml
@@ -275,6 +275,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok
@@ -425,6 +428,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok
@@ -564,6 +570,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok
@@ -703,6 +712,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok
@@ -842,6 +854,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok

--- a/pkg/platform/openstack/openstack-fip-test-heat.yaml
+++ b/pkg/platform/openstack/openstack-fip-test-heat.yaml
@@ -261,6 +261,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok
@@ -411,6 +414,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok
@@ -550,6 +556,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok
@@ -689,6 +698,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok
@@ -828,6 +840,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok

--- a/pkg/platform/openstack/openstack-test-heat-expected.yaml
+++ b/pkg/platform/openstack/openstack-test-heat-expected.yaml
@@ -261,6 +261,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok
@@ -411,6 +414,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok
@@ -550,6 +556,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok
@@ -689,6 +698,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok
@@ -828,6 +840,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok

--- a/pkg/platform/openstack/openstack-test-heat.yaml
+++ b/pkg/platform/openstack/openstack-test-heat.yaml
@@ -247,6 +247,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok
@@ -397,6 +400,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok
@@ -536,6 +542,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok
@@ -675,6 +684,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok
@@ -814,6 +826,9 @@ resources:
                               echo "Running update"
                               if [[ -z "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
                                   ANSIBLE_PLAYBOOK_BIN=/usr/local/bin/ansible-playbook
+                                  if [[ ! -f "${ANSIBLE_PLAYBOOK_BIN}" ]]; then
+                                      ANSIBLE_PLAYBOOK_BIN=/usr/bin/ansible-playbook
+                                  fi
                               fi
                               if ${ANSIBLE_PLAYBOOK_BIN} -e @ansible/vars.yml ./ansible/playbook.yml -v; then
                                   touch ansible_run_ok


### PR DESCRIPTION
Sometimes ansible-playbook gets installed into /usr/bin, sometimes /usr/local/bin. This adjusts the script so it can use either one.