### PR TITLE
makefile tweaks

### DIFF
--- a/api/distributed_match_engine/dep.go
+++ b/api/distributed_match_engine/dep.go
@@ -1,0 +1,7 @@
+//go:build distributed_match_engine
+
+package distributed_match_engine
+
+import (
+	_ "github.com/edgexr/edge-proto/dme"
+)

--- a/api/edgeproto/Makefile
+++ b/api/edgeproto/Makefile
@@ -2,21 +2,24 @@
 
 REPO	:= github.com/edgexr/edge-cloud-platform
 
+# This makefile may be included in other Makefiles, to ensure
+# the correct deps are used, we need to use the correct directory
+# for the next go list call.
+REPODIR		?= $(shell go list -f '{{ .Dir }}' -m ${REPO})
+
 GOPATH		= ../../../../..
-PROTODEPS	:= $(shell go list -f '{{ .Dir }}' -m \
+PROTODEPS	:= $(shell cd ${REPODIR} && go list -f '{{ .Dir }}' -m \
 	github.com/grpc-ecosystem/grpc-gateway \
 	github.com/gogo/googleapis \
 	github.com/gogo/protobuf \
-	github.com/edgexr/edge-proto \
-	${REPO})
+	github.com/edgexr/edge-proto)
 GW		:= $(word 1,$(PROTODEPS))
 APIS		:= $(word 2,$(PROTODEPS))
 GOGO		:= $(word 3,$(PROTODEPS))
 EDGEPROTO	:= $(word 4,$(PROTODEPS))
-PROJECT		:= $(word 5,$(PROTODEPS))
 EDGEPROTOGENDIR	:= $(EDGEPROTO)/edgeprotogen
-PROTOGENDIR	:= $(PROJECT)/tools/protogen
-INCLUDE		:= -I. -I${GW} -I${APIS} -I${GOGO} -I${GOPATH} -I${EDGEPROTOGENDIR} -I${PROTOGENDIR} -I${PROJECT}
+PROTOGENDIR	:= $(REPODIR)/tools/protogen
+INCLUDE		:= -I. -I${GW} -I${APIS} -I${GOGO} -I${GOPATH} -I${EDGEPROTOGENDIR} -I${PROTOGENDIR} -I${REPODIR}
 
 # The M option specifies the package name for DME protos because they
 # live in a different repo and don't have a go_package option


### PR DESCRIPTION
Allow api/edgeproto Makefile to be included in other makefiles, to allow for other generates to leverage it.
Add import ref to ensure we have a versioned dependency on the edge-proto repo.