### PR TITLE
remove unused version_embedded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,7 @@ check-go-vers:
 gen-test-certs:
 	(cd pkg/tls; ./gen-test-certs.sh)
 
-gen-vers:
-	(cd pkg/version; ./version.sh)
-
-generate: check-go-vers gen-vers gen-ansible
+generate: check-go-vers gen-ansible
 	go install $(GO_BUILD_FLAGS) \
 		github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
 		github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger \
@@ -46,7 +43,7 @@ generate: check-go-vers gen-vers gen-ansible
 gen-ansible:
 	make -C pkg/ccrm
 
-gobuild: check-go-vers gen-vers gen-ansible
+gobuild: check-go-vers gen-ansible
 	go build $(GO_BUILD_FLAGS) ./...
 	go vet ./...
 

--- a/pkg/version_embedded/.gitignore
+++ b/pkg/version_embedded/.gitignore
@@ -1,1 +1,0 @@
-version_embedded.go


### PR DESCRIPTION
Removed unused gen-vers. It was removed earlier to allow for binary files to remain unchanged if the source code stayed the same, so that docker builds could reuse existing layers. Many times a change causes the commit id to change, but it doesn't affect most of the binaries in this repo, so the version was moved to a yaml file instead of embedded code.