### PR TITLE
add call to go mod download in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ generate: check-go-vers gen-ansible
 		github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
 		github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger \
 		github.com/gogo/protobuf/protoc-gen-gogofast
+	go mod download
 	make -C tools/protogen
 	make -C tools/edgeprotogen
 	go install $(GO_BUILD_FLAGS) \


### PR DESCRIPTION
For the `api/edgeproto/Makefile` to properly run `go list`, we need to run `go mod download` first, otherwise `go list` won't have any local directory information for the dependencies.