### PR TITLE
support private registry for CRM

### DIFF
--- a/pkg/ccrm/ansible/roles/dockercrm/tasks/services.yml
+++ b/pkg/ccrm/ansible/roles/dockercrm/tasks/services.yml
@@ -34,6 +34,13 @@
     path: /etc/mex-release
   register: mex_release
 
+- name: Docker login to private registry
+  community.docker.docker_login:
+    registry_url: "{{ docker_registry }}"
+    username: "{{ docker_username }}"
+    password: "{{ docker_password }}"
+  when: docker_password is defined and docker_password | length > 0
+
 - name: Deploy crm docker
   community.docker.docker_container: "{{ lookup('template', 'crm_docker.yml.j2') | from_yaml }}"
   register: deploy_crm

--- a/pkg/ccrm/ccrm_ansible_test.go
+++ b/pkg/ccrm/ccrm_ansible_test.go
@@ -55,6 +55,13 @@ var testFlags = Flags{
 	DebugLevels:                   "api,infra,notify",
 }
 
+var testAuth = &cloudcommon.RegistryAuth{
+	AuthType: cloudcommon.BasicAuth,
+	Hostname: "ghcr.io",
+	Username: "testuser",
+	Password: "testpass",
+}
+
 func getTestCloudlet() edgeproto.Cloudlet {
 	return edgeproto.Cloudlet{
 		Key: edgeproto.CloudletKey{
@@ -117,7 +124,7 @@ func TestNodeAttributesYaml(t *testing.T) {
 	caches := CCRMCaches{}
 	caches.Init(ctx, "ccrm", &nodeMgr, nil)
 	handler := CCRMHandler{}
-	handler.Init(ctx, "ccrm", &nodeMgr, &caches, nil, nil, &testFlags)
+	handler.Init(ctx, "ccrm", &nodeMgr, &caches, nil, nil, &testFlags, testAuth)
 
 	cloudlet := getTestCloudlet()
 	baseAttributes, err := handler.getCloudletPlatformAttributes(ctx, &cloudlet)
@@ -157,7 +164,7 @@ func TestAnsibleServer(t *testing.T) {
 
 	ccrmType := "ccrm"
 	ccrm.caches.Init(ctx, ccrmType, &ccrm.nodeMgr, nil)
-	ccrm.handler.Init(ctx, ccrmType, &ccrm.nodeMgr, &ccrm.caches, nil, nil, &ccrm.flags)
+	ccrm.handler.Init(ctx, ccrmType, &ccrm.nodeMgr, &ccrm.caches, nil, nil, &ccrm.flags, nil)
 	ccrm.echoServ = ccrm.initAnsibleServer(ctx)
 
 	// test cloudlet

--- a/pkg/ccrm/ccrm_cloudlet.go
+++ b/pkg/ccrm/ccrm_cloudlet.go
@@ -301,7 +301,7 @@ func (s *CCRMHandler) getCloudletPlatformAttributes(ctx context.Context, in *edg
 		return nil, err
 	}
 	log.SpanLog(ctx, log.DebugLevelApi, "getPlatformConfig", "pfConfig", *pfConfig)
-	return confignode.GetCloudletAttributes(ctx, in, pfConfig)
+	return confignode.GetCloudletAttributes(ctx, in, pfConfig, s.registryAuth)
 }
 
 func (s *CCRMHandler) updateNodeAttributes(ctx context.Context, baseAttributes map[string]interface{}, node *edgeproto.CloudletNode) {

--- a/pkg/ccrm/ccrm_handler.go
+++ b/pkg/ccrm/ccrm_handler.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/accessapi"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
 	"github.com/edgexr/edge-cloud-platform/pkg/rediscache"
 	"github.com/go-redis/redis/v8"
@@ -41,6 +42,7 @@ type CCRMHandler struct {
 	CancelHandlers      func()
 	nodeAttributesCache NodeAttributesCache
 	vaultClient         *accessapi.VaultClient
+	registryAuth        *cloudcommon.RegistryAuth
 }
 
 type NodeAttributesCache struct {
@@ -55,12 +57,13 @@ type NodeAttributesData struct {
 
 type MessageHandler func(ctx context.Context, redisMsg *redis.Message) error
 
-func (s *CCRMHandler) Init(ctx context.Context, nodeType string, nodeMgr *node.NodeMgr, caches *CCRMCaches, redisClient *redis.Client, ctrlConn *grpc.ClientConn, flags *Flags) {
+func (s *CCRMHandler) Init(ctx context.Context, nodeType string, nodeMgr *node.NodeMgr, caches *CCRMCaches, redisClient *redis.Client, ctrlConn *grpc.ClientConn, flags *Flags, registryAuth *cloudcommon.RegistryAuth) {
 	s.caches = caches
 	s.nodeMgr = nodeMgr
 	s.redisClient = redisClient
 	s.ctrlConn = ctrlConn
 	s.flags = flags
+	s.registryAuth = registryAuth
 	s.nodeAttributesCache.Init()
 
 	// notify handlers

--- a/pkg/ccrm/test_node_attributes_exp.yml
+++ b/pkg/ccrm/test_node_attributes_exp.yml
@@ -54,6 +54,9 @@ crmserver:
     BAR_ONLY: no-bar
     FOO: foo
     JAEGER_ENDPOINT: http://jaeger.test.domain:1425
+docker_password: testpass
+docker_registry: ghcr.io
+docker_username: testuser
 edgeCloudImage: ghcr.io/company/crm-image
 edgeCloudVersion: 1234-99-XX
 mobiledgeXPackageVersion: 5.0.0

--- a/pkg/platform/common/confignode/attributes.go
+++ b/pkg/platform/common/confignode/attributes.go
@@ -107,7 +107,7 @@ func GetDockerArgs(cmdArgs []string) map[string]interface{} {
 	return args
 }
 
-func GetCloudletAttributes(ctx context.Context, cl *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig) (map[string]interface{}, error) {
+func GetCloudletAttributes(ctx context.Context, cl *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig, registryAuth *cloudcommon.RegistryAuth) (map[string]interface{}, error) {
 	log.SpanLog(ctx, log.DebugLevelInfra, "GetCloudletAttributes", "region", pfConfig.Region, "cloudletKey", cl.Key)
 
 	// Make copy because this function modifies cloudlet
@@ -131,6 +131,12 @@ func GetCloudletAttributes(ctx context.Context, cl *edgeproto.Cloudlet, pfConfig
 	attributes["notifyAddrs"] = pfConfig.NotifyCtrlAddrs
 
 	attributes["mobiledgeXPackageVersion"] = version.MobiledgeXPackageVersion
+
+	if registryAuth != nil && registryAuth.AuthType == cloudcommon.BasicAuth {
+		attributes["docker_registry"] = registryAuth.Hostname
+		attributes["docker_username"] = registryAuth.Username
+		attributes["docker_password"] = registryAuth.Password
+	}
 
 	if pfConfig.ThanosRecvAddr != "" {
 		attributes["thanosRecvAddr"] = pfConfig.ThanosRecvAddr


### PR DESCRIPTION
Adds support for CRM in a private docker registry. The authentication credentials need to be set in the ansible variables so that when ansible runs on the Platform VM to start the CRM service, it can run docker login to allow pulling from a private registry.