### PR TITLE
fix crm crash during cert renewal for nil ssh client

### DIFF
--- a/pkg/proxy/certs/certifications.go
+++ b/pkg/proxy/certs/certifications.go
@@ -254,6 +254,11 @@ func (s *ProxyCerts) refreshCerts(ctx context.Context) error {
 		// apply new cert
 		for _, lbname := range lbNames {
 			lbClient := lbClients[lbname]
+			if lbClient.Client == nil {
+				log.SpanLog(ctx, log.DebugLevelInfra, "refreshCerts skipping unexpected nil client", "lbname", lbname, "fqdn", lbClient.FQDN)
+				errs = append(errs, "no ssh client for "+lbname)
+				continue
+			}
 			err = s.writeCertToRootLb(ctx, &cert, lbClient.Client, lbname)
 			if err != nil {
 				log.SpanLog(ctx, log.DebugLevelInfra, "failed to write cert to lb", "wildcardName", wildcardName, "lbname", lbname, "err", err)


### PR DESCRIPTION
Fixes a CRM crash during cert renewal. The client was nil because of an intermittent openstack command failure. See #330 for more details. Fixes #330.

The ssh client is explicitly allowed to be nil by the code that generates the clients. So we need to check for it during cert renewal.