### PR TITLE
netplan config files require sudo to read them

### DIFF
--- a/pkg/platform/common/infracommon/netplan.go
+++ b/pkg/platform/common/infracommon/netplan.go
@@ -148,7 +148,7 @@ func GenerateNetworkFileDetailsForIP(ctx context.Context, portName string, ifNam
 
 func getNetplanInfo(ctx context.Context, client ssh.Client, fileName string) (*NetplanInfo, string, error) {
 	log.SpanLog(ctx, log.DebugLevelInfra, "GetNetplanInfo", "fileName", fileName)
-	out, err := client.Output("cat " + fileName)
+	out, err := pc.ReadFile(ctx, client, fileName, pc.SudoOn)
 	if err != nil {
 		if strings.Contains(out, "No such file") {
 			return nil, "", fmt.Errorf("%s - %s", NetplanFileNotFound, fileName)

--- a/pkg/platform/common/infracommon/netplan_test.go
+++ b/pkg/platform/common/infracommon/netplan_test.go
@@ -53,6 +53,12 @@ func TestNetplanFile(t *testing.T) {
 			return string(out), err
 		} else if strings.HasPrefix(cmd, "sudo netplan apply") {
 			return "", nil
+		} else if strings.HasPrefix(cmd, "sudo cat") {
+			// pc.ReadFile
+			cmd = strings.TrimPrefix(cmd, "sudo ")
+			cmd = strings.ReplaceAll(cmd, "/etc/netplan/", "")
+			out, err := exec.Command("/bin/bash", "-c", cmd).CombinedOutput()
+			return string(out), err
 		}
 		return "", fmt.Errorf("unsupported command %s", cmd)
 	}


### PR DESCRIPTION
### Description
While testing a new base image I hit an issue where netplan files require sudo to be read. This seems to be expected behavior.