### PR TITLE
Fixed shared volume merging on heat stack update.

### DIFF
--- a/pkg/platform/common/vmlayer/vmparams.go
+++ b/pkg/platform/common/vmlayer/vmparams.go
@@ -587,6 +587,9 @@ type VMOrchestrationParams struct {
 	AuthPublicKey           string
 	DeploymentManifest      string
 	Command                 string
+	// TODO - Volumes should be just a reference here and
+	// and the volume definition should be in VMGroupOrchestrationParams
+	// similar how ports and handled.
 	Volumes                 []VolumeOrchestrationParams
 	Ports                   []PortResourceReference      // depending on the orchestrator, IPs may be assigned to ports or
 	FixedIPs                []FixedIPOrchestrationParams // to VMs directly

--- a/pkg/platform/openstack/openstack-fip-test-heat-expected.yaml
+++ b/pkg/platform/openstack/openstack-fip-test-heat-expected.yaml
@@ -1,17 +1,3 @@
-# Copyright 2024 EdgeXR, Inc
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 
 heat_template_version: 2016-10-14
 description: Create a group of VMs
@@ -330,6 +316,11 @@ resources:
             image: mobiledgex-v9.9.9
             name: master-xyz-volume
             size: 100
+    master-xyz-shared-volume:
+        type: OS::Cinder::Volume
+        properties:
+            name: master-xyz-shared-volume
+            size: 100
         
     master-xyz:
         type: OS::Nova::Server
@@ -343,6 +334,10 @@ resources:
             block_device_mapping:
                 - device_name: vda
                   volume_id: { get_resource: master-xyz-volume }
+                  delete_on_termination: "false"
+            block_device_mapping:
+                - device_name: vdb
+                  volume_id: { get_resource: master-xyz-shared-volume }
                   delete_on_termination: "false" 
             flavor: m1.medium
             config_drive: true
@@ -473,6 +468,28 @@ resources:
                  - echo EDGECLOUD doing ip addr show
                  - ip addr show
                  - /root/configure-node.sh >> /root/configure-node.log 2>&1
+                 - chown nobody:nogroup /share
+                 - chmod 777 /share 
+                 - systemctl enable nfs-kernel-server
+                 - systemctl start nfs-kernel-server
+                 - echo "/share *(rw,sync,no_subtree_check,no_root_squash)" >> /etc/exports
+                 - exportfs -a
+                 - echo "showing exported filesystems"
+                 - exportfs
+                disk_setup:
+                  /dev/vdb:
+                    table_type: 'gpt'
+                    overwrite: true
+                    layout: true
+                fs_setup:
+                 - label: share_fs
+                   filesystem: 'ext4'
+                   device: /dev/vdb
+                   partition: auto
+                   overwrite: true
+                   layout: true
+                mounts:
+                 - [ "/dev/vdb", "/share" ]
             metadata:
                 skipk8s: no
                 role: k8s-master

--- a/pkg/platform/openstack/openstack-fip-test-heat-expected.yaml
+++ b/pkg/platform/openstack/openstack-fip-test-heat-expected.yaml
@@ -1,3 +1,16 @@
+# Copyright 2024 EdgeXR, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 heat_template_version: 2016-10-14
 description: Create a group of VMs

--- a/pkg/platform/openstack/openstack-fip-test-heat.yaml
+++ b/pkg/platform/openstack/openstack-fip-test-heat.yaml
@@ -316,6 +316,11 @@ resources:
             image: mobiledgex-v9.9.9
             name: master-xyz-volume
             size: 100
+    master-xyz-shared-volume:
+        type: OS::Cinder::Volume
+        properties:
+            name: master-xyz-shared-volume
+            size: 100
         
     master-xyz:
         type: OS::Nova::Server
@@ -329,6 +334,10 @@ resources:
             block_device_mapping:
                 - device_name: vda
                   volume_id: { get_resource: master-xyz-volume }
+                  delete_on_termination: "false"
+            block_device_mapping:
+                - device_name: vdb
+                  volume_id: { get_resource: master-xyz-shared-volume }
                   delete_on_termination: "false" 
             flavor: m1.medium
             config_drive: true
@@ -459,6 +468,28 @@ resources:
                  - echo EDGECLOUD doing ip addr show
                  - ip addr show
                  - /root/configure-node.sh >> /root/configure-node.log 2>&1
+                 - chown nobody:nogroup /share
+                 - chmod 777 /share 
+                 - systemctl enable nfs-kernel-server
+                 - systemctl start nfs-kernel-server
+                 - echo "/share *(rw,sync,no_subtree_check,no_root_squash)" >> /etc/exports
+                 - exportfs -a
+                 - echo "showing exported filesystems"
+                 - exportfs
+                disk_setup:
+                  /dev/vdb:
+                    table_type: 'gpt'
+                    overwrite: true
+                    layout: true
+                fs_setup:
+                 - label: share_fs
+                   filesystem: 'ext4'
+                   device: /dev/vdb
+                   partition: auto
+                   overwrite: true
+                   layout: true
+                mounts:
+                 - [ "/dev/vdb", "/share" ]
             metadata:
                 skipk8s: no
                 role: k8s-master

--- a/pkg/platform/openstack/openstack-heat.go
+++ b/pkg/platform/openstack/openstack-heat.go
@@ -602,7 +602,7 @@ func (o *OpenstackPlatform) populateParams(ctx context.Context, VMGroupOrchestra
 		}
 	}
 
-	// Get chef keys for existing VMs
+	// Get existing VMs definition
 	existingVMs := make(map[string]string)
 	if action == heatUpdate {
 		stackTemplate, err := o.getHeatStackTemplateDetail(ctx, VMGroupOrchestrationParams.GroupName)

--- a/pkg/platform/openstack/openstack-heat.go
+++ b/pkg/platform/openstack/openstack-heat.go
@@ -162,9 +162,6 @@ resources:
     {{- end}}
 
     {{- range .VMs}}
-    {{- if .ExistingData }}
-{{ .ExistingData }}
-    {{- else }}
     {{- range .Volumes}}
     {{.Name}}:
         type: OS::Cinder::Volume
@@ -178,6 +175,9 @@ resources:
             availability_zone: {{.AvailabilityZone}}
             {{- end}}
     {{- end}}
+	{{- if .ExistingData }}
+{{ .ExistingData }}
+    {{- else }}
         
     {{.Name}}:
         type: OS::Nova::Server

--- a/pkg/platform/openstack/openstack-test-heat-expected.yaml
+++ b/pkg/platform/openstack/openstack-test-heat-expected.yaml
@@ -1,3 +1,16 @@
+# Copyright 2024 EdgeXR, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 heat_template_version: 2016-10-14
 description: Create a group of VMs

--- a/pkg/platform/openstack/openstack-test-heat-expected.yaml
+++ b/pkg/platform/openstack/openstack-test-heat-expected.yaml
@@ -1,17 +1,3 @@
-# Copyright 2024 EdgeXR, Inc
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 
 heat_template_version: 2016-10-14
 description: Create a group of VMs
@@ -316,6 +302,11 @@ resources:
             image: mobiledgex-v9.9.9
             name: master-xyz-volume
             size: 100
+    master-xyz-shared-volume:
+        type: OS::Cinder::Volume
+        properties:
+            name: master-xyz-shared-volume
+            size: 100
         
     master-xyz:
         type: OS::Nova::Server
@@ -329,6 +320,10 @@ resources:
             block_device_mapping:
                 - device_name: vda
                   volume_id: { get_resource: master-xyz-volume }
+                  delete_on_termination: "false"
+            block_device_mapping:
+                - device_name: vdb
+                  volume_id: { get_resource: master-xyz-shared-volume }
                   delete_on_termination: "false" 
             flavor: m1.medium
             config_drive: true
@@ -459,6 +454,28 @@ resources:
                  - echo EDGECLOUD doing ip addr show
                  - ip addr show
                  - /root/configure-node.sh >> /root/configure-node.log 2>&1
+                 - chown nobody:nogroup /share
+                 - chmod 777 /share 
+                 - systemctl enable nfs-kernel-server
+                 - systemctl start nfs-kernel-server
+                 - echo "/share *(rw,sync,no_subtree_check,no_root_squash)" >> /etc/exports
+                 - exportfs -a
+                 - echo "showing exported filesystems"
+                 - exportfs
+                disk_setup:
+                  /dev/vdb:
+                    table_type: 'gpt'
+                    overwrite: true
+                    layout: true
+                fs_setup:
+                 - label: share_fs
+                   filesystem: 'ext4'
+                   device: /dev/vdb
+                   partition: auto
+                   overwrite: true
+                   layout: true
+                mounts:
+                 - [ "/dev/vdb", "/share" ]
             metadata:
                 skipk8s: no
                 role: k8s-master

--- a/pkg/platform/openstack/openstack-test-heat.yaml
+++ b/pkg/platform/openstack/openstack-test-heat.yaml
@@ -302,6 +302,11 @@ resources:
             image: mobiledgex-v9.9.9
             name: master-xyz-volume
             size: 100
+    master-xyz-shared-volume:
+        type: OS::Cinder::Volume
+        properties:
+            name: master-xyz-shared-volume
+            size: 100
         
     master-xyz:
         type: OS::Nova::Server
@@ -315,6 +320,10 @@ resources:
             block_device_mapping:
                 - device_name: vda
                   volume_id: { get_resource: master-xyz-volume }
+                  delete_on_termination: "false"
+            block_device_mapping:
+                - device_name: vdb
+                  volume_id: { get_resource: master-xyz-shared-volume }
                   delete_on_termination: "false" 
             flavor: m1.medium
             config_drive: true
@@ -445,6 +454,28 @@ resources:
                  - echo EDGECLOUD doing ip addr show
                  - ip addr show
                  - /root/configure-node.sh >> /root/configure-node.log 2>&1
+                 - chown nobody:nogroup /share
+                 - chmod 777 /share 
+                 - systemctl enable nfs-kernel-server
+                 - systemctl start nfs-kernel-server
+                 - echo "/share *(rw,sync,no_subtree_check,no_root_squash)" >> /etc/exports
+                 - exportfs -a
+                 - echo "showing exported filesystems"
+                 - exportfs
+                disk_setup:
+                  /dev/vdb:
+                    table_type: 'gpt'
+                    overwrite: true
+                    layout: true
+                fs_setup:
+                 - label: share_fs
+                   filesystem: 'ext4'
+                   device: /dev/vdb
+                   partition: auto
+                   overwrite: true
+                   layout: true
+                mounts:
+                 - [ "/dev/vdb", "/share" ]
             metadata:
                 skipk8s: no
                 role: k8s-master

--- a/pkg/platform/openstack/openstack_heat_test.go
+++ b/pkg/platform/openstack/openstack_heat_test.go
@@ -17,7 +17,7 @@ package openstack
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -55,6 +55,7 @@ var vms = []*vmlayer.VMRequestSpec{
 		ExternalVolumeSize:      100,
 		ConnectToExternalNet:    true,
 		ConnectToSubnets:        subnetNames,
+		SharedVolumeSize:        100,
 	},
 	{
 		Name:                    "node1-xyz",
@@ -111,9 +112,9 @@ func validateStack(ctx context.Context, t *testing.T, vmgp *vmlayer.VMGroupOrche
 
 	generatedFile := vmgp.GroupName + "-heat.yaml"
 	expectedResultsFile := vmgp.GroupName + "-heat-expected.yaml"
-	genDat, err := ioutil.ReadFile(generatedFile)
+	genDat, err := os.ReadFile(generatedFile)
 	require.Nil(t, err)
-	expDat, err := ioutil.ReadFile(expectedResultsFile)
+	expDat, err := os.ReadFile(expectedResultsFile)
 	require.Nil(t, err)
 	genObj := &OSHeatStackTemplate{}
 	err = yaml.Unmarshal(genDat, &genObj)
@@ -127,7 +128,7 @@ func validateStack(ctx context.Context, t *testing.T, vmgp *vmlayer.VMGroupOrche
 		require.True(t, false, "should be equal")
 	}
 
-	stackTemplateData, err := ioutil.ReadFile(generatedFile)
+	stackTemplateData, err := os.ReadFile(generatedFile)
 	require.Nil(t, err)
 
 	stackTemplate := &OSHeatStackTemplate{}


### PR DESCRIPTION
### Issues Fixed

[* Heat stack failed to update on cluster scale up](https://github.com/edgexr/edge-cloud-platform/issues/331)

### Description

Shared volumes were treated as being part of the VM spec, which they shouldn't be. Moved the block for shared volumes, so when we re-use the VM template we still add the shared volume block.