### PR TITLE
workarounds intermittent docker login and openstack failures

### DIFF
--- a/pkg/platform/openstack/openstack.go
+++ b/pkg/platform/openstack/openstack.go
@@ -32,12 +32,19 @@ type OpenstackPlatform struct {
 	openRCVars   map[string]string
 	VMProperties *vmlayer.VMProperties
 	caches       *platform.Caches
+	apiStats     APIStats
 }
 
 func NewPlatform() platform.Platform {
 	return &vmlayer.VMPlatform{
 		VMProvider: &OpenstackPlatform{},
 	}
+}
+
+type APIStats struct {
+	Successful    uint64
+	DiscoveryErrs uint64
+	OtherErrs     uint64
 }
 
 func (o *OpenstackPlatform) SetVMProperties(vmProperties *vmlayer.VMProperties) {


### PR DESCRIPTION
- docker login from new LB to pull envoy (proxy) container failed to contact harbor but worked later. Allow for retry. Previously the envoy container was hosted publicly and did not need docker login.
- openstack cli commands fail intermittently with `Failed to discover available identity versions when contacting https://bdgecloud.t.c:5000/v3. Attempting to parse version from URL.`. Allow for retry to avoid these intermittent failures causing the whole VM/cluster deploy process to fail.
