### PR TITLE
spanlog grpc logging, no-log-start-finish

### DIFF
--- a/pkg/log/jaeger.go
+++ b/pkg/log/jaeger.go
@@ -182,7 +182,7 @@ func SpanToString(ctx context.Context) string {
 	return string(val)
 }
 
-func NewSpanFromString(lvl uint64, val, spanName string) opentracing.Span {
+func NewSpanFromString(lvl uint64, val, spanName string, opts ...opentracing.StartSpanOption) opentracing.Span {
 	linenoOpt := WithSpanLineno(GetLineno(1))
 	if val != "" {
 		carrier := SpanCarrier{
@@ -192,14 +192,15 @@ func NewSpanFromString(lvl uint64, val, spanName string) opentracing.Span {
 		if err == nil {
 			spanCtx, err := tracer.Extract(opentracing.TextMap, carrier.Data)
 			if err == nil {
-				opts := []opentracing.StartSpanOption{
+				opts = append(opts,
 					ext.RPCServerOption(spanCtx),
 					linenoOpt,
-				}
+				)
 				opts = append(opts, carrier.Config.ToOptions()...)
 				return StartSpan(lvl, spanName, opts...)
 			}
 		}
 	}
-	return StartSpan(lvl, spanName, linenoOpt)
+	opts = append(opts, linenoOpt)
+	return StartSpan(lvl, spanName, opts...)
 }

--- a/pkg/log/spangrpc.go
+++ b/pkg/log/spangrpc.go
@@ -16,6 +16,8 @@ package log
 
 import (
 	"context"
+	"io"
+	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
 	grpc "google.golang.org/grpc"
@@ -29,7 +31,15 @@ func UnaryClientTraceGrpc(ctx context.Context, method string, req, resp interfac
 	if val != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, spanKey, val)
 	}
-	return invoker(ctx, method, req, resp, cc, opts...)
+	start := time.Now()
+	SpanLog(ctx, DebugLevelApi, "grpc client unary start", "method", method, "req", req)
+	err := invoker(ctx, method, req, resp, cc, opts...)
+	if err == nil {
+		SpanLog(ctx, DebugLevelApi, "grpc client unary done", "method", method, "resp", resp, "dur", time.Since(start))
+	} else {
+		SpanLog(ctx, DebugLevelApi, "grpc client unary failed", "method", method, "resp", resp, "dur", time.Since(start), "err", err)
+	}
+	return err
 }
 
 func StreamClientTraceGrpc(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
@@ -37,7 +47,16 @@ func StreamClientTraceGrpc(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.
 	if val != "" {
 		ctx = metadata.AppendToOutgoingContext(ctx, spanKey, val)
 	}
-	return streamer(ctx, desc, cc, method, opts...)
+	clientStream, err := streamer(ctx, desc, cc, method, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &loggedClientStream{
+		ClientStream: clientStream,
+		ctx:          ctx,
+		startTime:    time.Now(),
+		method:       desc.StreamName,
+	}, nil
 }
 
 // NewSpanFromGrpc is used on server-side in controller/audit.go to extract span
@@ -49,4 +68,30 @@ func NewSpanFromGrpc(ctx context.Context, lvl uint64, spanName string) opentraci
 		}
 	}
 	return NewSpanFromString(lvl, val, spanName)
+}
+
+type loggedClientStream struct {
+	grpc.ClientStream
+	ctx       context.Context
+	startTime time.Time
+	method    string
+}
+
+func (s *loggedClientStream) SendMsg(m any) error {
+	SpanLog(s.ctx, DebugLevelApi, "grpc client stream send", "method", s.method, "obj", m)
+	return s.ClientStream.SendMsg(m)
+}
+
+func (s *loggedClientStream) RecvMsg(m any) error {
+	err := s.ClientStream.RecvMsg(m)
+	SpanLog(s.ctx, DebugLevelApi, "grpc client stream recv", "method", s.method, "obj", m, "err", err)
+	if err == nil {
+		return nil
+	}
+	if err == io.EOF {
+		SpanLog(s.ctx, DebugLevelApi, "grpc client stream done", "method", s.method, "dur", time.Since(s.startTime))
+	} else {
+		SpanLog(s.ctx, DebugLevelApi, "grpc client stream failed", "method", s.method, "dur", time.Since(s.startTime), "err", err)
+	}
+	return err
 }


### PR DESCRIPTION
This adds additional logging capabilities to our GRPC interceptors, allowing for better debuggability on both client and server. I also added a new span option to avoid logging to disk the "start" and "finish" logs of the span. This is for quick go threads that need their own span but don't want to be noisy printing the start/stop messages.