### PR TITLE
cloudlet ssh key provider

### DIFF
--- a/pkg/platform/common/cloudletssh/sshkey.go
+++ b/pkg/platform/common/cloudletssh/sshkey.go
@@ -1,0 +1,145 @@
+// Copyright 2024 EdgeXR, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cloudletssh provides for a shareable, on-demand provider
+// of signed ssh keys.
+package cloudletssh
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	ssh "github.com/edgexr/golang-ssh"
+	xssh "golang.org/x/crypto/ssh"
+)
+
+// SSHKey provides on-demand signed ssh certificates for authenticating
+// with VMs created by the platform.
+type SSHKey struct {
+	publicKey         string
+	signedPublicKey   string
+	privateKey        string
+	signer            KeySigner
+	mux               sync.Mutex
+	expiresAt         time.Time
+	refreshInProgress bool
+}
+
+// KeySigner is used to sign the user's public key
+type KeySigner interface {
+	// SignSSHKey signs the user's public key and returns a signed ssh certificate
+	SignSSHKey(ctx context.Context, publicKey string) (string, error)
+}
+
+var SignSSHKeyTimeout = 30 * time.Second
+var RefreshBufferDuration = 2 * time.Hour
+
+func NewSSHKey(signer KeySigner) *SSHKey {
+	return &SSHKey{
+		signer: signer,
+	}
+}
+
+func (s *SSHKey) getSignedKey(ctx context.Context) (string, time.Time, error) {
+	log.SpanLog(ctx, log.DebugLevelInfra, "Sign cloudlet public key from Vault")
+
+	ctx, cancel := context.WithTimeout(ctx, SignSSHKeyTimeout)
+	defer cancel()
+
+	signedKey, err := s.signer.SignSSHKey(ctx, s.publicKey)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to sign cloudlet ssh key, %s", err)
+	}
+	// set expiration time
+	pk, err := xssh.ParsePublicKey([]byte(signedKey))
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to parse signed cloudlet key, %s", err)
+	}
+	cert := pk.(*xssh.Certificate)
+	expiresAt := time.Unix(int64(cert.ValidBefore), 0)
+	return signedKey, expiresAt, nil
+}
+
+func (s *SSHKey) ensureSignedKeyLocked(ctx context.Context) error {
+	now := time.Now()
+	if s.signedPublicKey == "" || now.After(s.expiresAt) {
+		// no valid signed key, do network call inline under lock
+		// because we need to wait for the call to finish anyway
+		signedKey, expiresAt, err := s.getSignedKey(ctx)
+		if err != nil {
+			return err
+		}
+		s.signedPublicKey = signedKey
+		s.expiresAt = expiresAt
+	} else if now.After(s.expiresAt.Add(-RefreshBufferDuration)) && !s.refreshInProgress {
+		// current key is still valid but expiring soon, spawn
+		// thread to refresh it
+		s.refreshInProgress = true
+		go func() {
+			span := log.StartSpan(log.DebugLevelInfra, "thread sign cloudlet ssh key")
+			defer span.Finish()
+			ctx := log.ContextWithSpan(context.Background(), span)
+
+			signedKey, expiresAt, err := s.getSignedKey(ctx)
+			if err != nil {
+				log.SpanLog(ctx, log.DebugLevelInfra, "failed to refresh cloudlet ssh key", "err", err)
+				return
+			}
+			s.mux.Lock()
+			defer s.mux.Unlock()
+			s.signedPublicKey = signedKey
+			s.expiresAt = expiresAt
+			s.refreshInProgress = false
+		}()
+	}
+	return nil
+}
+
+func (s *SSHKey) genKeys(ctx context.Context) error {
+	log.SpanLog(ctx, log.DebugLevelInfra, "InitCloudletSSHKeys")
+	cloudletPubKey, cloudletPrivKey, err := ssh.GenKeyPair()
+	if err != nil {
+		return fmt.Errorf("failed to generate cloudlet SSH key pair: %v", err)
+	}
+	s.publicKey = cloudletPubKey
+	s.privateKey = cloudletPrivKey
+	return nil
+}
+
+func (s *SSHKey) GetKeyPairs(ctx context.Context) ([]ssh.KeyPair, error) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	if s.privateKey == "" {
+		if err := s.genKeys(ctx); err != nil {
+			return nil, err
+		}
+	}
+	if err := s.ensureSignedKeyLocked(ctx); err != nil {
+		return nil, err
+	}
+	keyPairs := []ssh.KeyPair{{
+		PublicRawKey:  []byte(s.signedPublicKey),
+		PrivateRawKey: []byte(s.privateKey),
+	}}
+	return keyPairs, nil
+}
+
+func (s *SSHKey) GetKeyPairsCb(ctx context.Context) func() ([]ssh.KeyPair, error) {
+	return func() ([]ssh.KeyPair, error) {
+		return s.GetKeyPairs(ctx)
+	}
+}

--- a/pkg/platform/common/cloudletssh/sshkey_test.go
+++ b/pkg/platform/common/cloudletssh/sshkey_test.go
@@ -89,7 +89,8 @@ func TestSSHKeyRefresh(t *testing.T) {
 	ctx := log.StartTestSpan(context.Background())
 
 	SignSSHKeyTimeout = 2 * time.Second
-	RefreshBufferDuration = time.Minute
+	RefreshInlineBufferDuration = time.Second
+	RefreshLazyBufferDuration = time.Minute
 
 	validDur := time.Hour
 	ks := keySigner{}
@@ -118,7 +119,7 @@ func TestSSHKeyRefresh(t *testing.T) {
 	require.NotEqual(t, curCert, string(pair[0].PublicRawKey)) // should get new cert
 	// test go thread refresh
 	curCert = sshKey.signedPublicKey
-	sshKey.expiresAt = time.Now().Add(RefreshBufferDuration / 2)
+	sshKey.expiresAt = time.Now().Add(RefreshLazyBufferDuration / 2)
 	pair, err = sshKey.GetKeyPairs(ctx)
 	require.Nil(t, err)
 	require.Equal(t, 1, len(pair))

--- a/pkg/platform/common/cloudletssh/sshkey_test.go
+++ b/pkg/platform/common/cloudletssh/sshkey_test.go
@@ -1,0 +1,141 @@
+// Copyright 2024 EdgeXR, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudletssh
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+type keySigner struct {
+	signer      ssh.MultiAlgorithmSigner
+	signedCount int
+	validDur    time.Duration
+}
+
+func (s *keySigner) init(validDur time.Duration) error {
+	caKey, err := rsa.GenerateKey(rand.Reader, 3072)
+	if err != nil {
+		return err
+	}
+	signer, err := ssh.NewSignerFromKey(caKey)
+	if err != nil {
+		return err
+	}
+	mas, err := ssh.NewSignerWithAlgorithms(signer.(ssh.AlgorithmSigner), []string{ssh.KeyAlgoRSASHA256})
+	if err != nil {
+		return err
+	}
+	s.signer = mas
+	s.validDur = validDur
+	return nil
+}
+
+func (s *keySigner) SignSSHKey(ctx context.Context, publicKey string) (string, error) {
+	keyParts := strings.Split(publicKey, " ")
+	if len(keyParts) > 1 {
+		// Someone has sent the 'full' public key rather than just the base64 encoded part that the ssh library wants
+		publicKey = keyParts[1]
+	}
+	decodedKey, err := base64.StdEncoding.DecodeString(publicKey)
+	if err != nil {
+		return "", fmt.Errorf("key signer failed to decode user public key, %s", err)
+	}
+	userPubKey, err := ssh.ParsePublicKey([]byte(decodedKey))
+	if err != nil {
+		return "", fmt.Errorf("key signer parse user public key failed, %s", err)
+	}
+	now := time.Now()
+	cert := ssh.Certificate{
+		Key:         userPubKey,
+		CertType:    ssh.UserCert,
+		ValidAfter:  uint64(now.Add(-time.Second).In(time.UTC).Unix()),
+		ValidBefore: uint64(now.Add(s.validDur).In(time.UTC).Unix()),
+	}
+	if err := cert.SignCert(rand.Reader, s.signer); err != nil {
+		return "", fmt.Errorf("key signer sign cert failed, %s", err)
+	}
+	s.signedCount++
+	out := cert.Marshal()
+	return string(out), nil
+}
+
+func TestSSHKeyRefresh(t *testing.T) {
+	log.SetDebugLevel(log.DebugLevelInfra)
+	log.InitTracer(nil)
+	defer log.FinishTracer()
+	ctx := log.StartTestSpan(context.Background())
+
+	SignSSHKeyTimeout = 2 * time.Second
+	RefreshBufferDuration = time.Minute
+
+	validDur := time.Hour
+	ks := keySigner{}
+	err := ks.init(validDur)
+	require.Nil(t, err)
+
+	sshKey := NewSSHKey(&ks)
+	_, err = sshKey.GetKeyPairs(ctx)
+	require.Nil(t, err)
+	require.Equal(t, 1, ks.signedCount)
+	// ensure we parsed the correct expiration time
+	now := time.Now()
+	require.Greater(t, sshKey.expiresAt, now.Add(validDur).Add(-time.Minute))
+	require.Less(t, sshKey.expiresAt, now.Add(validDur).Add(time.Minute))
+	// getting the key should not trigger a refresh
+	_, err = sshKey.GetKeyPairs(ctx)
+	require.Nil(t, err)
+	require.Equal(t, 1, ks.signedCount)
+	// test inline refresh
+	curCert := sshKey.signedPublicKey
+	sshKey.expiresAt = now.Add(-time.Minute)
+	pair, err := sshKey.GetKeyPairs(ctx)
+	require.Nil(t, err)
+	require.Equal(t, 2, ks.signedCount)
+	require.Equal(t, 1, len(pair))
+	require.NotEqual(t, curCert, string(pair[0].PublicRawKey)) // should get new cert
+	// test go thread refresh
+	curCert = sshKey.signedPublicKey
+	sshKey.expiresAt = time.Now().Add(RefreshBufferDuration / 2)
+	pair, err = sshKey.GetKeyPairs(ctx)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(pair))
+	require.Equal(t, curCert, string(pair[0].PublicRawKey)) // should get cur cert
+	updated := false
+	for ii := 0; ii < 20; ii++ {
+		// thread finishes when it updates the cert
+		sshKey.mux.Lock()
+		if curCert != sshKey.signedPublicKey {
+			updated = true
+		}
+		sshKey.mux.Unlock()
+		if updated {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.True(t, updated)
+	require.Equal(t, 3, ks.signedCount)
+}


### PR DESCRIPTION
This adds a cloudlet ssh key provider which provides on-demand signed keys. This is intended to replace the code in `pkg/platform/common/infracommon/common-ssh.go` which forces each platform instance to maintain a pair of ssh keys, which require a persistent thread to refresh the signed keys every 24h. And this ssh key is always set up on platform init.

With the intent to move to CRM functionality into the CCRM, the platform instance needs to be ephermal and created on demand. The current ssh key handling means that, in the CCRM:
- we may instantiate a platform to run an API call which doesn't need any ssh keys
- we may instantiate a platform that doesn't actually use ssh keys (public cloud)
- we have no way of keeping a persistent thread set up by the platform around

So instead, this library allows for replacing the forced, fixed ssh keys with an on-demand one. It only initializes keys when needed and doesn't need a refresh thread - it can detect if the current key is expired and refresh it automatically.

The other thing we will do here is share this ssh key signer between all platforms, so new platforms in the CCRM will not pay any overhead for setting up ssh keys.