### PR TITLE
move etcd code to regiondata package

### DIFF
--- a/api/edgeproto/caches.go
+++ b/api/edgeproto/caches.go
@@ -33,6 +33,15 @@ const (
 	NoResetStatus bool = false
 )
 
+type ObjCache interface {
+	SyncUpdate(ctx context.Context, key, val []byte, rev, modRev int64)
+	SyncDelete(ctx context.Context, key []byte, rev, modRev int64)
+	SyncListStart(ctx context.Context)
+	SyncListEnd(ctx context.Context)
+	GetTypeString() string
+	UsesOrg(org string) bool
+}
+
 type ClusterInstCacheUpdateParms struct {
 	cache      *ClusterInstInfoCache
 	updateType CacheUpdateType

--- a/pkg/controller/addrefs_test.go
+++ b/pkg/controller/addrefs_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 )
 
@@ -34,10 +35,10 @@ func TestAddRefsChecks(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/alert_api_test.go
+++ b/pkg/controller/alert_api_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/objstore"
 	"github.com/edgexr/edge-cloud-platform/pkg/process"
 	"github.com/edgexr/edge-cloud-platform/pkg/rediscache"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/pkg/vault"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/stretchr/testify/require"
@@ -43,10 +44,10 @@ func TestAlertApi(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()
@@ -117,10 +118,10 @@ func TestAppInstDownAlert(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/alertpolicy.auto_test.go
+++ b/pkg/controller/alertpolicy.auto_test.go
@@ -227,7 +227,7 @@ func deleteAlertPolicyChecks(t *testing.T, ctx context.Context, all *AllApis, da
 	testObj, supportData := dataGen.GetAlertPolicyTestObj()
 	supportData.put(t, ctx, all)
 	defer supportData.delete(t, ctx, all)
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	// Positive test, delete should succeed without any references.
 	// The overrided store checks that delete prepare was set on the
@@ -239,7 +239,7 @@ func deleteAlertPolicyChecks(t *testing.T, ctx context.Context, all *AllApis, da
 	// Negative test, inject testObj with delete prepare already set.
 	testObj, _ = dataGen.GetAlertPolicyTestObj()
 	testObj.DeletePrepare = true
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 	// delete should fail with already being deleted
 	testObj, _ = dataGen.GetAlertPolicyTestObj()
 	_, err = api.DeleteAlertPolicy(ctx, testObj)
@@ -250,7 +250,7 @@ func deleteAlertPolicyChecks(t *testing.T, ctx context.Context, all *AllApis, da
 
 	// inject testObj for ref tests
 	testObj, _ = dataGen.GetAlertPolicyTestObj()
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	{
 		// Negative test, App refers to AlertPolicy.
@@ -258,7 +258,7 @@ func deleteAlertPolicyChecks(t *testing.T, ctx context.Context, all *AllApis, da
 		refBy, supportData := dataGen.GetAppAlertPoliciesRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
 		deleteStore.putDeletePrepareCb = func() {
-			all.appApi.store.Put(ctx, refBy, all.appApi.sync.syncWait)
+			all.appApi.store.Put(ctx, refBy, all.appApi.sync.SyncWait)
 		}
 		testObj, _ = dataGen.GetAlertPolicyTestObj()
 		_, err = api.DeleteAlertPolicy(ctx, testObj)
@@ -267,7 +267,7 @@ func deleteAlertPolicyChecks(t *testing.T, ctx context.Context, all *AllApis, da
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove App obj
-		_, err = all.appApi.store.Delete(ctx, refBy, all.appApi.sync.syncWait)
+		_, err = all.appApi.store.Delete(ctx, refBy, all.appApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from App must succeed")
 		deleteStore.putDeletePrepareCb = nil
 		supportData.delete(t, ctx, all)

--- a/pkg/controller/alertpolicy_api_test.go
+++ b/pkg/controller/alertpolicy_api_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/ccrmdummy"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -34,11 +35,11 @@ func TestAlertPolicyApi(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 	defer dummy.Stop()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/alldata.auto_test.go
+++ b/pkg/controller/alldata.auto_test.go
@@ -26,190 +26,190 @@ type testSupportData edgeproto.AllData
 
 func (s *testSupportData) put(t *testing.T, ctx context.Context, all *AllApis) {
 	for _, obj := range s.Flavors {
-		_, err := all.flavorApi.store.Put(ctx, &obj, all.flavorApi.sync.syncWait)
+		_, err := all.flavorApi.store.Put(ctx, &obj, all.flavorApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	if s.Settings != nil {
-		_, err := all.settingsApi.store.Put(ctx, s.Settings, all.settingsApi.sync.syncWait)
+		_, err := all.settingsApi.store.Put(ctx, s.Settings, all.settingsApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.OperatorCodes {
-		_, err := all.operatorCodeApi.store.Put(ctx, &obj, all.operatorCodeApi.sync.syncWait)
+		_, err := all.operatorCodeApi.store.Put(ctx, &obj, all.operatorCodeApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.ResTagTables {
-		_, err := all.resTagTableApi.store.Put(ctx, &obj, all.resTagTableApi.sync.syncWait)
+		_, err := all.resTagTableApi.store.Put(ctx, &obj, all.resTagTableApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.TrustPolicies {
-		_, err := all.trustPolicyApi.store.Put(ctx, &obj, all.trustPolicyApi.sync.syncWait)
+		_, err := all.trustPolicyApi.store.Put(ctx, &obj, all.trustPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.GpuDrivers {
-		_, err := all.gpuDriverApi.store.Put(ctx, &obj, all.gpuDriverApi.sync.syncWait)
+		_, err := all.gpuDriverApi.store.Put(ctx, &obj, all.gpuDriverApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.PlatformFeatures {
-		_, err := all.platformFeaturesApi.store.Put(ctx, &obj, all.platformFeaturesApi.sync.syncWait)
+		_, err := all.platformFeaturesApi.store.Put(ctx, &obj, all.platformFeaturesApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.Cloudlets {
-		_, err := all.cloudletApi.store.Put(ctx, &obj, all.cloudletApi.sync.syncWait)
+		_, err := all.cloudletApi.store.Put(ctx, &obj, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.CloudletInfos {
-		_, err := all.cloudletInfoApi.store.Put(ctx, &obj, all.cloudletInfoApi.sync.syncWait)
+		_, err := all.cloudletInfoApi.store.Put(ctx, &obj, all.cloudletInfoApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.CloudletPools {
-		_, err := all.cloudletPoolApi.store.Put(ctx, &obj, all.cloudletPoolApi.sync.syncWait)
+		_, err := all.cloudletPoolApi.store.Put(ctx, &obj, all.cloudletPoolApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.Networks {
-		_, err := all.networkApi.store.Put(ctx, &obj, all.networkApi.sync.syncWait)
+		_, err := all.networkApi.store.Put(ctx, &obj, all.networkApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.AutoProvPolicies {
-		_, err := all.autoProvPolicyApi.store.Put(ctx, &obj, all.autoProvPolicyApi.sync.syncWait)
+		_, err := all.autoProvPolicyApi.store.Put(ctx, &obj, all.autoProvPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.AutoScalePolicies {
-		_, err := all.autoScalePolicyApi.store.Put(ctx, &obj, all.autoScalePolicyApi.sync.syncWait)
+		_, err := all.autoScalePolicyApi.store.Put(ctx, &obj, all.autoScalePolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.ClusterInsts {
-		_, err := all.clusterInstApi.store.Put(ctx, &obj, all.clusterInstApi.sync.syncWait)
+		_, err := all.clusterInstApi.store.Put(ctx, &obj, all.clusterInstApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.Apps {
-		_, err := all.appApi.store.Put(ctx, &obj, all.appApi.sync.syncWait)
+		_, err := all.appApi.store.Put(ctx, &obj, all.appApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.AppInstances {
-		_, err := all.appInstApi.store.Put(ctx, &obj, all.appInstApi.sync.syncWait)
+		_, err := all.appInstApi.store.Put(ctx, &obj, all.appInstApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.AppInstRefs {
-		_, err := all.appInstRefsApi.store.Put(ctx, &obj, all.appInstRefsApi.sync.syncWait)
+		_, err := all.appInstRefsApi.store.Put(ctx, &obj, all.appInstRefsApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.ClusterRefs {
-		_, err := all.clusterRefsApi.store.Put(ctx, &obj, all.clusterRefsApi.sync.syncWait)
+		_, err := all.clusterRefsApi.store.Put(ctx, &obj, all.clusterRefsApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.VmPools {
-		_, err := all.vmPoolApi.store.Put(ctx, &obj, all.vmPoolApi.sync.syncWait)
+		_, err := all.vmPoolApi.store.Put(ctx, &obj, all.vmPoolApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.AlertPolicies {
-		_, err := all.alertPolicyApi.store.Put(ctx, &obj, all.alertPolicyApi.sync.syncWait)
+		_, err := all.alertPolicyApi.store.Put(ctx, &obj, all.alertPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.FlowRateLimitSettings {
-		_, err := all.flowRateLimitSettingsApi.store.Put(ctx, &obj, all.flowRateLimitSettingsApi.sync.syncWait)
+		_, err := all.flowRateLimitSettingsApi.store.Put(ctx, &obj, all.flowRateLimitSettingsApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.MaxReqsRateLimitSettings {
-		_, err := all.maxReqsRateLimitSettingsApi.store.Put(ctx, &obj, all.maxReqsRateLimitSettingsApi.sync.syncWait)
+		_, err := all.maxReqsRateLimitSettingsApi.store.Put(ctx, &obj, all.maxReqsRateLimitSettingsApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.TrustPolicyExceptions {
-		_, err := all.trustPolicyExceptionApi.store.Put(ctx, &obj, all.trustPolicyExceptionApi.sync.syncWait)
+		_, err := all.trustPolicyExceptionApi.store.Put(ctx, &obj, all.trustPolicyExceptionApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 }
 
 func (s *testSupportData) delete(t *testing.T, ctx context.Context, all *AllApis) {
 	for _, obj := range s.TrustPolicyExceptions {
-		_, err := all.trustPolicyExceptionApi.store.Delete(ctx, &obj, all.trustPolicyExceptionApi.sync.syncWait)
+		_, err := all.trustPolicyExceptionApi.store.Delete(ctx, &obj, all.trustPolicyExceptionApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.MaxReqsRateLimitSettings {
-		_, err := all.maxReqsRateLimitSettingsApi.store.Delete(ctx, &obj, all.maxReqsRateLimitSettingsApi.sync.syncWait)
+		_, err := all.maxReqsRateLimitSettingsApi.store.Delete(ctx, &obj, all.maxReqsRateLimitSettingsApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.FlowRateLimitSettings {
-		_, err := all.flowRateLimitSettingsApi.store.Delete(ctx, &obj, all.flowRateLimitSettingsApi.sync.syncWait)
+		_, err := all.flowRateLimitSettingsApi.store.Delete(ctx, &obj, all.flowRateLimitSettingsApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.AlertPolicies {
-		_, err := all.alertPolicyApi.store.Delete(ctx, &obj, all.alertPolicyApi.sync.syncWait)
+		_, err := all.alertPolicyApi.store.Delete(ctx, &obj, all.alertPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.VmPools {
-		_, err := all.vmPoolApi.store.Delete(ctx, &obj, all.vmPoolApi.sync.syncWait)
+		_, err := all.vmPoolApi.store.Delete(ctx, &obj, all.vmPoolApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.ClusterRefs {
-		_, err := all.clusterRefsApi.store.Delete(ctx, &obj, all.clusterRefsApi.sync.syncWait)
+		_, err := all.clusterRefsApi.store.Delete(ctx, &obj, all.clusterRefsApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.AppInstRefs {
-		_, err := all.appInstRefsApi.store.Delete(ctx, &obj, all.appInstRefsApi.sync.syncWait)
+		_, err := all.appInstRefsApi.store.Delete(ctx, &obj, all.appInstRefsApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.AppInstances {
-		_, err := all.appInstApi.store.Delete(ctx, &obj, all.appInstApi.sync.syncWait)
+		_, err := all.appInstApi.store.Delete(ctx, &obj, all.appInstApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.Apps {
-		_, err := all.appApi.store.Delete(ctx, &obj, all.appApi.sync.syncWait)
+		_, err := all.appApi.store.Delete(ctx, &obj, all.appApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.ClusterInsts {
-		_, err := all.clusterInstApi.store.Delete(ctx, &obj, all.clusterInstApi.sync.syncWait)
+		_, err := all.clusterInstApi.store.Delete(ctx, &obj, all.clusterInstApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.AutoScalePolicies {
-		_, err := all.autoScalePolicyApi.store.Delete(ctx, &obj, all.autoScalePolicyApi.sync.syncWait)
+		_, err := all.autoScalePolicyApi.store.Delete(ctx, &obj, all.autoScalePolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.AutoProvPolicies {
-		_, err := all.autoProvPolicyApi.store.Delete(ctx, &obj, all.autoProvPolicyApi.sync.syncWait)
+		_, err := all.autoProvPolicyApi.store.Delete(ctx, &obj, all.autoProvPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.Networks {
-		_, err := all.networkApi.store.Delete(ctx, &obj, all.networkApi.sync.syncWait)
+		_, err := all.networkApi.store.Delete(ctx, &obj, all.networkApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.CloudletPools {
-		_, err := all.cloudletPoolApi.store.Delete(ctx, &obj, all.cloudletPoolApi.sync.syncWait)
+		_, err := all.cloudletPoolApi.store.Delete(ctx, &obj, all.cloudletPoolApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.CloudletInfos {
-		_, err := all.cloudletInfoApi.store.Delete(ctx, &obj, all.cloudletInfoApi.sync.syncWait)
+		_, err := all.cloudletInfoApi.store.Delete(ctx, &obj, all.cloudletInfoApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.Cloudlets {
-		_, err := all.cloudletApi.store.Delete(ctx, &obj, all.cloudletApi.sync.syncWait)
+		_, err := all.cloudletApi.store.Delete(ctx, &obj, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.PlatformFeatures {
-		_, err := all.platformFeaturesApi.store.Delete(ctx, &obj, all.platformFeaturesApi.sync.syncWait)
+		_, err := all.platformFeaturesApi.store.Delete(ctx, &obj, all.platformFeaturesApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.GpuDrivers {
-		_, err := all.gpuDriverApi.store.Delete(ctx, &obj, all.gpuDriverApi.sync.syncWait)
+		_, err := all.gpuDriverApi.store.Delete(ctx, &obj, all.gpuDriverApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.TrustPolicies {
-		_, err := all.trustPolicyApi.store.Delete(ctx, &obj, all.trustPolicyApi.sync.syncWait)
+		_, err := all.trustPolicyApi.store.Delete(ctx, &obj, all.trustPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.ResTagTables {
-		_, err := all.resTagTableApi.store.Delete(ctx, &obj, all.resTagTableApi.sync.syncWait)
+		_, err := all.resTagTableApi.store.Delete(ctx, &obj, all.resTagTableApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.OperatorCodes {
-		_, err := all.operatorCodeApi.store.Delete(ctx, &obj, all.operatorCodeApi.sync.syncWait)
+		_, err := all.operatorCodeApi.store.Delete(ctx, &obj, all.operatorCodeApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	if s.Settings != nil {
-		_, err := all.settingsApi.store.Delete(ctx, s.Settings, all.settingsApi.sync.syncWait)
+		_, err := all.settingsApi.store.Delete(ctx, s.Settings, all.settingsApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	for _, obj := range s.Flavors {
-		_, err := all.flavorApi.store.Delete(ctx, &obj, all.flavorApi.sync.syncWait)
+		_, err := all.flavorApi.store.Delete(ctx, &obj, all.flavorApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 }

--- a/pkg/controller/app.auto_test.go
+++ b/pkg/controller/app.auto_test.go
@@ -155,7 +155,7 @@ func deleteAppChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen Ap
 	testObj, supportData := dataGen.GetAppTestObj()
 	supportData.put(t, ctx, all)
 	defer supportData.delete(t, ctx, all)
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	// Positive test, delete should succeed without any references.
 	// The overrided store checks that delete prepare was set on the
@@ -177,7 +177,7 @@ func deleteAppChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen Ap
 	// Negative test, inject testObj with delete prepare already set.
 	testObj, _ = dataGen.GetAppTestObj()
 	testObj.DeletePrepare = true
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 	// delete should fail with already being deleted
 	testObj, _ = dataGen.GetAppTestObj()
 	_, err = api.DeleteApp(ctx, testObj)
@@ -188,7 +188,7 @@ func deleteAppChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen Ap
 
 	// inject testObj for ref tests
 	testObj, _ = dataGen.GetAppTestObj()
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	{
 		// Negative test, TrustPolicyException refers to App.
@@ -196,7 +196,7 @@ func deleteAppChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen Ap
 		refBy, supportData := dataGen.GetTrustPolicyExceptionKeyAppKeyRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
 		deleteStore.putDeletePrepareCb = func() {
-			all.trustPolicyExceptionApi.store.Put(ctx, refBy, all.trustPolicyExceptionApi.sync.syncWait)
+			all.trustPolicyExceptionApi.store.Put(ctx, refBy, all.trustPolicyExceptionApi.sync.SyncWait)
 		}
 		testObj, _ = dataGen.GetAppTestObj()
 		_, err = api.DeleteApp(ctx, testObj)
@@ -205,7 +205,7 @@ func deleteAppChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen Ap
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove TrustPolicyException obj
-		_, err = all.trustPolicyExceptionApi.store.Delete(ctx, refBy, all.trustPolicyExceptionApi.sync.syncWait)
+		_, err = all.trustPolicyExceptionApi.store.Delete(ctx, refBy, all.trustPolicyExceptionApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from TrustPolicyException must succeed")
 		deleteStore.putDeletePrepareCb = nil
 		supportData.delete(t, ctx, all)
@@ -215,7 +215,7 @@ func deleteAppChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen Ap
 		// Inject the refs object to trigger an "in use" error.
 		refBy, supportData := dataGen.GetAppAppInstInstsRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
-		_, err = all.appInstRefsApi.store.Put(ctx, refBy, all.appInstRefsApi.sync.syncWait)
+		_, err = all.appInstRefsApi.store.Put(ctx, refBy, all.appInstRefsApi.sync.SyncWait)
 		require.Nil(t, err)
 		testObj, _ = dataGen.GetAppTestObj()
 		_, err = api.DeleteApp(ctx, testObj)
@@ -224,7 +224,7 @@ func deleteAppChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen Ap
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove AppInstRefs obj
-		_, err = all.appInstRefsApi.store.Delete(ctx, refBy, all.appInstRefsApi.sync.syncWait)
+		_, err = all.appInstRefsApi.store.Delete(ctx, refBy, all.appInstRefsApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from AppInstRefs must succeed")
 		supportData.delete(t, ctx, all)
 	}
@@ -245,7 +245,7 @@ func CreateAppAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis, dat
 		ref := supportData.getOneFlavor()
 		require.NotNil(t, ref, "support data must include one referenced Flavor")
 		ref.DeletePrepare = true
-		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.syncWait)
+		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateAppTestObj()
@@ -254,7 +254,7 @@ func CreateAppAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis, dat
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced Flavor
 		ref.DeletePrepare = false
-		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.syncWait)
+		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	{
@@ -262,7 +262,7 @@ func CreateAppAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis, dat
 		ref := supportData.getOneAutoProvPolicy()
 		require.NotNil(t, ref, "support data must include one referenced AutoProvPolicy")
 		ref.DeletePrepare = true
-		_, err = all.autoProvPolicyApi.store.Put(ctx, ref, all.autoProvPolicyApi.sync.syncWait)
+		_, err = all.autoProvPolicyApi.store.Put(ctx, ref, all.autoProvPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateAppTestObj()
@@ -271,7 +271,7 @@ func CreateAppAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis, dat
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced AutoProvPolicy
 		ref.DeletePrepare = false
-		_, err = all.autoProvPolicyApi.store.Put(ctx, ref, all.autoProvPolicyApi.sync.syncWait)
+		_, err = all.autoProvPolicyApi.store.Put(ctx, ref, all.autoProvPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	{
@@ -279,7 +279,7 @@ func CreateAppAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis, dat
 		ref := supportData.getOneAlertPolicy()
 		require.NotNil(t, ref, "support data must include one referenced AlertPolicy")
 		ref.DeletePrepare = true
-		_, err = all.alertPolicyApi.store.Put(ctx, ref, all.alertPolicyApi.sync.syncWait)
+		_, err = all.alertPolicyApi.store.Put(ctx, ref, all.alertPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateAppTestObj()
@@ -288,7 +288,7 @@ func CreateAppAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis, dat
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced AlertPolicy
 		ref.DeletePrepare = false
-		_, err = all.alertPolicyApi.store.Put(ctx, ref, all.alertPolicyApi.sync.syncWait)
+		_, err = all.alertPolicyApi.store.Put(ctx, ref, all.alertPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 
@@ -334,7 +334,7 @@ func UpdateAppAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis, dat
 		ref := supportData.getOneFlavor()
 		require.NotNil(t, ref, "support data must include one referenced Flavor")
 		ref.DeletePrepare = true
-		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.syncWait)
+		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetUpdateAppTestObj()
@@ -343,7 +343,7 @@ func UpdateAppAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis, dat
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced Flavor
 		ref.DeletePrepare = false
-		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.syncWait)
+		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	{
@@ -351,7 +351,7 @@ func UpdateAppAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis, dat
 		ref := supportData.getOneAutoProvPolicy()
 		require.NotNil(t, ref, "support data must include one referenced AutoProvPolicy")
 		ref.DeletePrepare = true
-		_, err = all.autoProvPolicyApi.store.Put(ctx, ref, all.autoProvPolicyApi.sync.syncWait)
+		_, err = all.autoProvPolicyApi.store.Put(ctx, ref, all.autoProvPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetUpdateAppTestObj()
@@ -360,7 +360,7 @@ func UpdateAppAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis, dat
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced AutoProvPolicy
 		ref.DeletePrepare = false
-		_, err = all.autoProvPolicyApi.store.Put(ctx, ref, all.autoProvPolicyApi.sync.syncWait)
+		_, err = all.autoProvPolicyApi.store.Put(ctx, ref, all.autoProvPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	{
@@ -368,7 +368,7 @@ func UpdateAppAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis, dat
 		ref := supportData.getOneAlertPolicy()
 		require.NotNil(t, ref, "support data must include one referenced AlertPolicy")
 		ref.DeletePrepare = true
-		_, err = all.alertPolicyApi.store.Put(ctx, ref, all.alertPolicyApi.sync.syncWait)
+		_, err = all.alertPolicyApi.store.Put(ctx, ref, all.alertPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetUpdateAppTestObj()
@@ -377,7 +377,7 @@ func UpdateAppAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis, dat
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced AlertPolicy
 		ref.DeletePrepare = false
-		_, err = all.alertPolicyApi.store.Put(ctx, ref, all.alertPolicyApi.sync.syncWait)
+		_, err = all.alertPolicyApi.store.Put(ctx, ref, all.alertPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 
@@ -419,7 +419,7 @@ func AddAppAutoProvPolicyAddRefsChecks(t *testing.T, ctx context.Context, all *A
 		ref := supportData.getOneAutoProvPolicy()
 		require.NotNil(t, ref, "support data must include one referenced AutoProvPolicy")
 		ref.DeletePrepare = true
-		_, err = all.autoProvPolicyApi.store.Put(ctx, ref, all.autoProvPolicyApi.sync.syncWait)
+		_, err = all.autoProvPolicyApi.store.Put(ctx, ref, all.autoProvPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetAddAppAutoProvPolicyTestObj()
@@ -428,7 +428,7 @@ func AddAppAutoProvPolicyAddRefsChecks(t *testing.T, ctx context.Context, all *A
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced AutoProvPolicy
 		ref.DeletePrepare = false
-		_, err = all.autoProvPolicyApi.store.Put(ctx, ref, all.autoProvPolicyApi.sync.syncWait)
+		_, err = all.autoProvPolicyApi.store.Put(ctx, ref, all.autoProvPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 
@@ -462,7 +462,7 @@ func AddAppAlertPolicyAddRefsChecks(t *testing.T, ctx context.Context, all *AllA
 		ref := supportData.getOneAlertPolicy()
 		require.NotNil(t, ref, "support data must include one referenced AlertPolicy")
 		ref.DeletePrepare = true
-		_, err = all.alertPolicyApi.store.Put(ctx, ref, all.alertPolicyApi.sync.syncWait)
+		_, err = all.alertPolicyApi.store.Put(ctx, ref, all.alertPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetAddAppAlertPolicyTestObj()
@@ -471,7 +471,7 @@ func AddAppAlertPolicyAddRefsChecks(t *testing.T, ctx context.Context, all *AllA
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced AlertPolicy
 		ref.DeletePrepare = false
-		_, err = all.alertPolicyApi.store.Put(ctx, ref, all.alertPolicyApi.sync.syncWait)
+		_, err = all.alertPolicyApi.store.Put(ctx, ref, all.alertPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 

--- a/pkg/controller/app_api.go
+++ b/pkg/controller/app_api.go
@@ -29,6 +29,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/deploygen"
 	"github.com/edgexr/edge-cloud-platform/pkg/k8smgmt"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/pkg/util"
 	"go.etcd.io/etcd/client/v3/concurrency"
 	appsv1 "k8s.io/api/apps/v1"
@@ -37,17 +38,17 @@ import (
 // Should only be one of these instantiated in main
 type AppApi struct {
 	all           *AllApis
-	sync          *Sync
+	sync          *regiondata.Sync
 	store         edgeproto.AppStore
 	cache         edgeproto.AppCache
 	globalIdStore edgeproto.AppGlobalIdStore
 }
 
-func NewAppApi(sync *Sync, all *AllApis) *AppApi {
+func NewAppApi(sync *regiondata.Sync, all *AllApis) *AppApi {
 	appApi := AppApi{}
 	appApi.all = all
 	appApi.sync = sync
-	appApi.store = edgeproto.NewAppStore(sync.store)
+	appApi.store = edgeproto.NewAppStore(sync.GetKVStore())
 	edgeproto.InitAppCache(&appApi.cache)
 	sync.RegisterCache(&appApi.cache)
 	return &appApi

--- a/pkg/controller/app_api_test.go
+++ b/pkg/controller/app_api_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/pkg/util"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/stretchr/testify/require"
@@ -39,10 +40,10 @@ func TestAppApi(t *testing.T) {
 	cplookup.Init()
 	nodeMgr.CloudletPoolLookup = cplookup
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/appinst.auto_test.go
+++ b/pkg/controller/appinst.auto_test.go
@@ -74,7 +74,7 @@ func CreateAppInstAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis,
 		ref := supportData.getOneCloudlet()
 		require.NotNil(t, ref, "support data must include one referenced Cloudlet")
 		ref.DeletePrepare = true
-		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateAppInstTestObj()
@@ -83,7 +83,7 @@ func CreateAppInstAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis,
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced Cloudlet
 		ref.DeletePrepare = false
-		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	{
@@ -91,7 +91,7 @@ func CreateAppInstAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis,
 		ref := supportData.getOneApp()
 		require.NotNil(t, ref, "support data must include one referenced App")
 		ref.DeletePrepare = true
-		_, err = all.appApi.store.Put(ctx, ref, all.appApi.sync.syncWait)
+		_, err = all.appApi.store.Put(ctx, ref, all.appApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateAppInstTestObj()
@@ -100,7 +100,7 @@ func CreateAppInstAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis,
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced App
 		ref.DeletePrepare = false
-		_, err = all.appApi.store.Put(ctx, ref, all.appApi.sync.syncWait)
+		_, err = all.appApi.store.Put(ctx, ref, all.appApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	{
@@ -108,7 +108,7 @@ func CreateAppInstAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis,
 		ref := supportData.getOneClusterInst()
 		require.NotNil(t, ref, "support data must include one referenced ClusterInst")
 		ref.DeletePrepare = true
-		_, err = all.clusterInstApi.store.Put(ctx, ref, all.clusterInstApi.sync.syncWait)
+		_, err = all.clusterInstApi.store.Put(ctx, ref, all.clusterInstApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateAppInstTestObj()
@@ -117,7 +117,7 @@ func CreateAppInstAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis,
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced ClusterInst
 		ref.DeletePrepare = false
-		_, err = all.clusterInstApi.store.Put(ctx, ref, all.clusterInstApi.sync.syncWait)
+		_, err = all.clusterInstApi.store.Put(ctx, ref, all.clusterInstApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	{
@@ -125,7 +125,7 @@ func CreateAppInstAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis,
 		ref := supportData.getOneFlavor()
 		require.NotNil(t, ref, "support data must include one referenced Flavor")
 		ref.DeletePrepare = true
-		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.syncWait)
+		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateAppInstTestObj()
@@ -134,7 +134,7 @@ func CreateAppInstAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis,
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced Flavor
 		ref.DeletePrepare = false
-		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.syncWait)
+		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 

--- a/pkg/controller/appinst_api.go
+++ b/pkg/controller/appinst_api.go
@@ -31,6 +31,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/notify"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform"
 	"github.com/edgexr/edge-cloud-platform/pkg/rediscache"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/pkg/util"
 	"github.com/gogo/protobuf/types"
 	"go.etcd.io/etcd/client/v3/concurrency"
@@ -40,7 +41,7 @@ import (
 
 type AppInstApi struct {
 	all                     *AllApis
-	sync                    *Sync
+	sync                    *regiondata.Sync
 	store                   edgeproto.AppInstStore
 	cache                   edgeproto.AppInstCache
 	idStore                 edgeproto.AppInstIdStore
@@ -64,13 +65,13 @@ var DeleteAppInstTransitions = map[edgeproto.TrackedState]struct{}{
 	edgeproto.TrackedState_DELETING: struct{}{},
 }
 
-func NewAppInstApi(sync *Sync, all *AllApis) *AppInstApi {
+func NewAppInstApi(sync *regiondata.Sync, all *AllApis) *AppInstApi {
 	appInstApi := AppInstApi{}
 	appInstApi.all = all
 	appInstApi.sync = sync
-	appInstApi.store = edgeproto.NewAppInstStore(sync.store)
-	appInstApi.idStore.Init(sync.store)
-	appInstApi.fedStore = edgeproto.NewFedAppInstStore(sync.store)
+	appInstApi.store = edgeproto.NewAppInstStore(sync.GetKVStore())
+	appInstApi.idStore.Init(sync.GetKVStore())
+	appInstApi.fedStore = edgeproto.NewFedAppInstStore(sync.GetKVStore())
 	appInstApi.dnsLabelStore = &all.cloudletApi.objectDnsLabelStore
 	appInstApi.fedAppInstEventSendMany = notify.NewFedAppInstEventSendMany()
 	edgeproto.InitAppInstCache(&appInstApi.cache)
@@ -1357,7 +1358,7 @@ func (s *AppInstApi) updateCloudletResourcesMetric(ctx context.Context, in *edge
 }
 
 func (s *AppInstApi) updateAppInstStore(ctx context.Context, in *edgeproto.AppInst) error {
-	_, err := s.store.Update(ctx, in, s.sync.syncWait)
+	_, err := s.store.Update(ctx, in, s.sync.SyncWait)
 	return err
 }
 

--- a/pkg/controller/appinst_api_test.go
+++ b/pkg/controller/appinst_api_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/platform"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform/fake"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform/openstack"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/pkg/util"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/stretchr/testify/require"
@@ -110,11 +111,11 @@ func TestAppInstApi(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 	defer dummy.Stop()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()
@@ -451,10 +452,10 @@ func TestAutoClusterInst(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()
@@ -1049,15 +1050,15 @@ func testAppInstId(t *testing.T, ctx context.Context, apis *AllApis) {
 
 	// func to check if ids are present in database
 	hasIds := func(hasId0, hasId1 bool) {
-		found0 := testHasAppInstId(apis.appInstApi.sync.store, expId0)
+		found0 := testHasAppInstId(apis.appInstApi.sync.GetKVStore(), expId0)
 		require.Equal(t, hasId0, found0, "has id %s", expId0)
-		found1 := testHasAppInstId(apis.appInstApi.sync.store, expId1)
+		found1 := testHasAppInstId(apis.appInstApi.sync.GetKVStore(), expId1)
 		require.Equal(t, hasId1, found1, "has id %s", expId1)
 	}
 	hasDnsLabels := func(hasIds bool, ids ...string) {
 		for _, id := range ids {
 			// note that all objects are on the same cloudlet
-			found := testHasAppInstDnsLabel(apis.appInstApi.sync.store, &appInst0.Key.CloudletKey, id)
+			found := testHasAppInstDnsLabel(apis.appInstApi.sync.GetKVStore(), &appInst0.Key.CloudletKey, id)
 			require.Equal(t, hasIds, found, "has id %s", id)
 		}
 	}

--- a/pkg/controller/appinstclient_api.go
+++ b/pkg/controller/appinstclient_api.go
@@ -23,6 +23,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/notify"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"google.golang.org/grpc"
 )
 
@@ -253,11 +254,11 @@ func (s *AppInstClientApi) Flush(ctx context.Context, notifyId int64) {}
 
 type AppInstClientKeyApi struct {
 	all   *AllApis
-	sync  *Sync
+	sync  *regiondata.Sync
 	cache edgeproto.AppInstClientKeyCache
 }
 
-func NewAppInstClientKeyApi(sync *Sync, all *AllApis) *AppInstClientKeyApi {
+func NewAppInstClientKeyApi(sync *regiondata.Sync, all *AllApis) *AppInstClientKeyApi {
 	appInstClientKeyApi := AppInstClientKeyApi{}
 	appInstClientKeyApi.all = all
 	appInstClientKeyApi.sync = sync

--- a/pkg/controller/appinstclient_api_test.go
+++ b/pkg/controller/appinstclient_api_test.go
@@ -18,10 +18,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/notify"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -60,10 +61,10 @@ func TestAppInstClientApi(t *testing.T) {
 	cplookup.Init()
 	nodeMgr.CloudletPoolLookup = cplookup
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/appinstinfo_api.go
+++ b/pkg/controller/appinstinfo_api.go
@@ -18,14 +18,15 @@ import (
 	"context"
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 )
 
 type AppInstInfoApi struct {
 	all  *AllApis
-	sync *Sync
+	sync *regiondata.Sync
 }
 
-func NewAppInstInfoApi(sync *Sync, all *AllApis) *AppInstInfoApi {
+func NewAppInstInfoApi(sync *regiondata.Sync, all *AllApis) *AppInstInfoApi {
 	appInstInfoApi := AppInstInfoApi{}
 	appInstInfoApi.all = all
 	appInstInfoApi.sync = sync

--- a/pkg/controller/appinstlatency_api.go
+++ b/pkg/controller/appinstlatency_api.go
@@ -18,16 +18,17 @@ import (
 	"context"
 
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 )
 
 type AppInstLatencyApi struct {
 	all  *AllApis
-	sync *Sync
+	sync *regiondata.Sync
 }
 
-func NewAppInstLatencyApi(sync *Sync, all *AllApis) *AppInstLatencyApi {
+func NewAppInstLatencyApi(sync *regiondata.Sync, all *AllApis) *AppInstLatencyApi {
 	appInstLatencyApi := AppInstLatencyApi{}
 	appInstLatencyApi.all = all
 	appInstLatencyApi.sync = sync

--- a/pkg/controller/appinstrefs_api.go
+++ b/pkg/controller/appinstrefs_api.go
@@ -16,21 +16,22 @@ package controller
 
 import (
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
 type AppInstRefsApi struct {
 	all   *AllApis
-	sync  *Sync
+	sync  *regiondata.Sync
 	store edgeproto.AppInstRefsStore
 	cache edgeproto.AppInstRefsCache
 }
 
-func NewAppInstRefsApi(sync *Sync, all *AllApis) *AppInstRefsApi {
+func NewAppInstRefsApi(sync *regiondata.Sync, all *AllApis) *AppInstRefsApi {
 	appInstRefsApi := AppInstRefsApi{}
 	appInstRefsApi.all = all
 	appInstRefsApi.sync = sync
-	appInstRefsApi.store = edgeproto.NewAppInstRefsStore(sync.store)
+	appInstRefsApi.store = edgeproto.NewAppInstRefsStore(sync.GetKVStore())
 	edgeproto.InitAppInstRefsCache(&appInstRefsApi.cache)
 	sync.RegisterCache(&appInstRefsApi.cache)
 	return &appInstRefsApi

--- a/pkg/controller/autoprovinfo_api.go
+++ b/pkg/controller/autoprovinfo_api.go
@@ -22,20 +22,21 @@ import (
 	dme "github.com/edgexr/edge-cloud-platform/api/distributed_match_engine"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 )
 
 type AutoProvInfoApi struct {
 	all   *AllApis
-	sync  *Sync
+	sync  *regiondata.Sync
 	store edgeproto.AutoProvInfoStore
 	cache edgeproto.AutoProvInfoCache
 }
 
-func NewAutoProvInfoApi(sync *Sync, all *AllApis) *AutoProvInfoApi {
+func NewAutoProvInfoApi(sync *regiondata.Sync, all *AllApis) *AutoProvInfoApi {
 	autoProvInfoApi := AutoProvInfoApi{}
 	autoProvInfoApi.all = all
 	autoProvInfoApi.sync = sync
-	autoProvInfoApi.store = edgeproto.NewAutoProvInfoStore(sync.store)
+	autoProvInfoApi.store = edgeproto.NewAutoProvInfoStore(sync.GetKVStore())
 	edgeproto.InitAutoProvInfoCache(&autoProvInfoApi.cache)
 	sync.RegisterCache(&autoProvInfoApi.cache)
 	return &autoProvInfoApi

--- a/pkg/controller/autoprovpolicy.auto_test.go
+++ b/pkg/controller/autoprovpolicy.auto_test.go
@@ -153,7 +153,7 @@ func deleteAutoProvPolicyChecks(t *testing.T, ctx context.Context, all *AllApis,
 	testObj, supportData := dataGen.GetAutoProvPolicyTestObj()
 	supportData.put(t, ctx, all)
 	defer supportData.delete(t, ctx, all)
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	// Positive test, delete should succeed without any references.
 	// The overrided store checks that delete prepare was set on the
@@ -165,7 +165,7 @@ func deleteAutoProvPolicyChecks(t *testing.T, ctx context.Context, all *AllApis,
 	// Negative test, inject testObj with delete prepare already set.
 	testObj, _ = dataGen.GetAutoProvPolicyTestObj()
 	testObj.DeletePrepare = true
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 	// delete should fail with already being deleted
 	testObj, _ = dataGen.GetAutoProvPolicyTestObj()
 	_, err = api.DeleteAutoProvPolicy(ctx, testObj)
@@ -176,7 +176,7 @@ func deleteAutoProvPolicyChecks(t *testing.T, ctx context.Context, all *AllApis,
 
 	// inject testObj for ref tests
 	testObj, _ = dataGen.GetAutoProvPolicyTestObj()
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	{
 		// Negative test, App refers to AutoProvPolicy.
@@ -184,7 +184,7 @@ func deleteAutoProvPolicyChecks(t *testing.T, ctx context.Context, all *AllApis,
 		refBy, supportData := dataGen.GetAppAutoProvPoliciesRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
 		deleteStore.putDeletePrepareCb = func() {
-			all.appApi.store.Put(ctx, refBy, all.appApi.sync.syncWait)
+			all.appApi.store.Put(ctx, refBy, all.appApi.sync.SyncWait)
 		}
 		testObj, _ = dataGen.GetAutoProvPolicyTestObj()
 		_, err = api.DeleteAutoProvPolicy(ctx, testObj)
@@ -193,7 +193,7 @@ func deleteAutoProvPolicyChecks(t *testing.T, ctx context.Context, all *AllApis,
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove App obj
-		_, err = all.appApi.store.Delete(ctx, refBy, all.appApi.sync.syncWait)
+		_, err = all.appApi.store.Delete(ctx, refBy, all.appApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from App must succeed")
 		deleteStore.putDeletePrepareCb = nil
 		supportData.delete(t, ctx, all)
@@ -215,7 +215,7 @@ func CreateAutoProvPolicyAddRefsChecks(t *testing.T, ctx context.Context, all *A
 		ref := supportData.getOneCloudlet()
 		require.NotNil(t, ref, "support data must include one referenced Cloudlet")
 		ref.DeletePrepare = true
-		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateAutoProvPolicyTestObj()
@@ -224,7 +224,7 @@ func CreateAutoProvPolicyAddRefsChecks(t *testing.T, ctx context.Context, all *A
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced Cloudlet
 		ref.DeletePrepare = false
-		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 
@@ -262,7 +262,7 @@ func UpdateAutoProvPolicyAddRefsChecks(t *testing.T, ctx context.Context, all *A
 		ref := supportData.getOneCloudlet()
 		require.NotNil(t, ref, "support data must include one referenced Cloudlet")
 		ref.DeletePrepare = true
-		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetUpdateAutoProvPolicyTestObj()
@@ -271,7 +271,7 @@ func UpdateAutoProvPolicyAddRefsChecks(t *testing.T, ctx context.Context, all *A
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced Cloudlet
 		ref.DeletePrepare = false
-		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 
@@ -305,7 +305,7 @@ func AddAutoProvPolicyCloudletAddRefsChecks(t *testing.T, ctx context.Context, a
 		ref := supportData.getOneCloudlet()
 		require.NotNil(t, ref, "support data must include one referenced Cloudlet")
 		ref.DeletePrepare = true
-		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetAddAutoProvPolicyCloudletTestObj()
@@ -314,7 +314,7 @@ func AddAutoProvPolicyCloudletAddRefsChecks(t *testing.T, ctx context.Context, a
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced Cloudlet
 		ref.DeletePrepare = false
-		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 

--- a/pkg/controller/autoprovpolicy_api_test.go
+++ b/pkg/controller/autoprovpolicy_api_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
@@ -42,11 +43,11 @@ func TestAutoProvPolicyApi(t *testing.T) {
 	testSvcs := testinit(ctx, t, WithLocalRedis())
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 	defer dummy.Stop()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/autoscalepolicy.auto_test.go
+++ b/pkg/controller/autoscalepolicy.auto_test.go
@@ -151,7 +151,7 @@ func deleteAutoScalePolicyChecks(t *testing.T, ctx context.Context, all *AllApis
 	testObj, supportData := dataGen.GetAutoScalePolicyTestObj()
 	supportData.put(t, ctx, all)
 	defer supportData.delete(t, ctx, all)
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	// Positive test, delete should succeed without any references.
 	// The overrided store checks that delete prepare was set on the
@@ -163,7 +163,7 @@ func deleteAutoScalePolicyChecks(t *testing.T, ctx context.Context, all *AllApis
 	// Negative test, inject testObj with delete prepare already set.
 	testObj, _ = dataGen.GetAutoScalePolicyTestObj()
 	testObj.DeletePrepare = true
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 	// delete should fail with already being deleted
 	testObj, _ = dataGen.GetAutoScalePolicyTestObj()
 	_, err = api.DeleteAutoScalePolicy(ctx, testObj)
@@ -174,7 +174,7 @@ func deleteAutoScalePolicyChecks(t *testing.T, ctx context.Context, all *AllApis
 
 	// inject testObj for ref tests
 	testObj, _ = dataGen.GetAutoScalePolicyTestObj()
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	{
 		// Negative test, ClusterInst refers to AutoScalePolicy.
@@ -182,7 +182,7 @@ func deleteAutoScalePolicyChecks(t *testing.T, ctx context.Context, all *AllApis
 		refBy, supportData := dataGen.GetClusterInstAutoScalePolicyRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
 		deleteStore.putDeletePrepareCb = func() {
-			all.clusterInstApi.store.Put(ctx, refBy, all.clusterInstApi.sync.syncWait)
+			all.clusterInstApi.store.Put(ctx, refBy, all.clusterInstApi.sync.SyncWait)
 		}
 		testObj, _ = dataGen.GetAutoScalePolicyTestObj()
 		_, err = api.DeleteAutoScalePolicy(ctx, testObj)
@@ -191,7 +191,7 @@ func deleteAutoScalePolicyChecks(t *testing.T, ctx context.Context, all *AllApis
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove ClusterInst obj
-		_, err = all.clusterInstApi.store.Delete(ctx, refBy, all.clusterInstApi.sync.syncWait)
+		_, err = all.clusterInstApi.store.Delete(ctx, refBy, all.clusterInstApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from ClusterInst must succeed")
 		deleteStore.putDeletePrepareCb = nil
 		supportData.delete(t, ctx, all)

--- a/pkg/controller/autoscalepolicy_api_test.go
+++ b/pkg/controller/autoscalepolicy_api_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -32,10 +33,10 @@ func TestAutoScalePolicyApi(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/checkpoints.go
+++ b/pkg/controller/checkpoints.go
@@ -20,8 +20,8 @@ import (
 	"time"
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
-	influxq "github.com/edgexr/edge-cloud-platform/pkg/influxq_client"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
+	influxq "github.com/edgexr/edge-cloud-platform/pkg/influxq_client"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/util/tasks"
 	client "github.com/influxdata/influxdb/client/v2"

--- a/pkg/controller/cloudlet.auto_test.go
+++ b/pkg/controller/cloudlet.auto_test.go
@@ -153,7 +153,7 @@ func deletePlatformFeaturesChecks(t *testing.T, ctx context.Context, all *AllApi
 	testObj, supportData := dataGen.GetPlatformFeaturesTestObj()
 	supportData.put(t, ctx, all)
 	defer supportData.delete(t, ctx, all)
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	// Positive test, delete should succeed without any references.
 	// The overrided store checks that delete prepare was set on the
@@ -165,7 +165,7 @@ func deletePlatformFeaturesChecks(t *testing.T, ctx context.Context, all *AllApi
 	// Negative test, inject testObj with delete prepare already set.
 	testObj, _ = dataGen.GetPlatformFeaturesTestObj()
 	testObj.DeletePrepare = true
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 	// delete should fail with already being deleted
 	testObj, _ = dataGen.GetPlatformFeaturesTestObj()
 	_, err = api.DeletePlatformFeatures(ctx, testObj)
@@ -176,7 +176,7 @@ func deletePlatformFeaturesChecks(t *testing.T, ctx context.Context, all *AllApi
 
 	// inject testObj for ref tests
 	testObj, _ = dataGen.GetPlatformFeaturesTestObj()
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	{
 		// Negative test, Cloudlet refers to PlatformFeatures.
@@ -184,7 +184,7 @@ func deletePlatformFeaturesChecks(t *testing.T, ctx context.Context, all *AllApi
 		refBy, supportData := dataGen.GetCloudletPlatformTypeRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
 		deleteStore.putDeletePrepareCb = func() {
-			all.cloudletApi.store.Put(ctx, refBy, all.cloudletApi.sync.syncWait)
+			all.cloudletApi.store.Put(ctx, refBy, all.cloudletApi.sync.SyncWait)
 		}
 		testObj, _ = dataGen.GetPlatformFeaturesTestObj()
 		_, err = api.DeletePlatformFeatures(ctx, testObj)
@@ -193,7 +193,7 @@ func deletePlatformFeaturesChecks(t *testing.T, ctx context.Context, all *AllApi
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove Cloudlet obj
-		_, err = all.cloudletApi.store.Delete(ctx, refBy, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Delete(ctx, refBy, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from Cloudlet must succeed")
 		deleteStore.putDeletePrepareCb = nil
 		supportData.delete(t, ctx, all)
@@ -331,7 +331,7 @@ func deleteGPUDriverChecks(t *testing.T, ctx context.Context, all *AllApis, data
 	testObj, supportData := dataGen.GetGPUDriverTestObj()
 	supportData.put(t, ctx, all)
 	defer supportData.delete(t, ctx, all)
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	// Positive test, delete should succeed without any references.
 	// The overrided store checks that delete prepare was set on the
@@ -343,7 +343,7 @@ func deleteGPUDriverChecks(t *testing.T, ctx context.Context, all *AllApis, data
 	// Negative test, inject testObj with delete prepare already set.
 	testObj, _ = dataGen.GetGPUDriverTestObj()
 	testObj.DeletePrepare = true
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 	// delete should fail with already being deleted
 	testObj, _ = dataGen.GetGPUDriverTestObj()
 	err = api.DeleteGPUDriver(testObj, testutil.NewCudStreamoutGPUDriver(ctx))
@@ -354,7 +354,7 @@ func deleteGPUDriverChecks(t *testing.T, ctx context.Context, all *AllApis, data
 
 	// inject testObj for ref tests
 	testObj, _ = dataGen.GetGPUDriverTestObj()
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	{
 		// Negative test, Cloudlet refers to GPUDriver.
@@ -362,7 +362,7 @@ func deleteGPUDriverChecks(t *testing.T, ctx context.Context, all *AllApis, data
 		refBy, supportData := dataGen.GetCloudletGpuConfigDriverRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
 		deleteStore.putDeletePrepareCb = func() {
-			all.cloudletApi.store.Put(ctx, refBy, all.cloudletApi.sync.syncWait)
+			all.cloudletApi.store.Put(ctx, refBy, all.cloudletApi.sync.SyncWait)
 		}
 		testObj, _ = dataGen.GetGPUDriverTestObj()
 		err = api.DeleteGPUDriver(testObj, testutil.NewCudStreamoutGPUDriver(ctx))
@@ -371,7 +371,7 @@ func deleteGPUDriverChecks(t *testing.T, ctx context.Context, all *AllApis, data
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove Cloudlet obj
-		_, err = all.cloudletApi.store.Delete(ctx, refBy, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Delete(ctx, refBy, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from Cloudlet must succeed")
 		deleteStore.putDeletePrepareCb = nil
 		supportData.delete(t, ctx, all)
@@ -515,7 +515,7 @@ func deleteCloudletChecks(t *testing.T, ctx context.Context, all *AllApis, dataG
 	testObj, supportData := dataGen.GetCloudletTestObj()
 	supportData.put(t, ctx, all)
 	defer supportData.delete(t, ctx, all)
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	// Positive test, delete should succeed without any references.
 	// The overrided store checks that delete prepare was set on the
@@ -539,7 +539,7 @@ func deleteCloudletChecks(t *testing.T, ctx context.Context, all *AllApis, dataG
 	// Negative test, inject testObj with delete prepare already set.
 	testObj, _ = dataGen.GetCloudletTestObj()
 	testObj.DeletePrepare = true
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 	// delete should fail with already being deleted
 	testObj, _ = dataGen.GetCloudletTestObj()
 	err = api.DeleteCloudlet(testObj, testutil.NewCudStreamoutCloudlet(ctx))
@@ -550,7 +550,7 @@ func deleteCloudletChecks(t *testing.T, ctx context.Context, all *AllApis, dataG
 
 	// inject testObj for ref tests
 	testObj, _ = dataGen.GetCloudletTestObj()
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	{
 		// Negative test, AutoProvPolicy refers to Cloudlet.
@@ -558,7 +558,7 @@ func deleteCloudletChecks(t *testing.T, ctx context.Context, all *AllApis, dataG
 		refBy, supportData := dataGen.GetAutoProvPolicyCloudletsRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
 		deleteStore.putDeletePrepareCb = func() {
-			all.autoProvPolicyApi.store.Put(ctx, refBy, all.autoProvPolicyApi.sync.syncWait)
+			all.autoProvPolicyApi.store.Put(ctx, refBy, all.autoProvPolicyApi.sync.SyncWait)
 		}
 		testObj, _ = dataGen.GetCloudletTestObj()
 		err = api.DeleteCloudlet(testObj, testutil.NewCudStreamoutCloudlet(ctx))
@@ -567,7 +567,7 @@ func deleteCloudletChecks(t *testing.T, ctx context.Context, all *AllApis, dataG
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove AutoProvPolicy obj
-		_, err = all.autoProvPolicyApi.store.Delete(ctx, refBy, all.autoProvPolicyApi.sync.syncWait)
+		_, err = all.autoProvPolicyApi.store.Delete(ctx, refBy, all.autoProvPolicyApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from AutoProvPolicy must succeed")
 		deleteStore.putDeletePrepareCb = nil
 		supportData.delete(t, ctx, all)
@@ -578,7 +578,7 @@ func deleteCloudletChecks(t *testing.T, ctx context.Context, all *AllApis, dataG
 		refBy, supportData := dataGen.GetCloudletPoolCloudletsRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
 		deleteStore.putDeletePrepareCb = func() {
-			all.cloudletPoolApi.store.Put(ctx, refBy, all.cloudletPoolApi.sync.syncWait)
+			all.cloudletPoolApi.store.Put(ctx, refBy, all.cloudletPoolApi.sync.SyncWait)
 		}
 		testObj, _ = dataGen.GetCloudletTestObj()
 		err = api.DeleteCloudlet(testObj, testutil.NewCudStreamoutCloudlet(ctx))
@@ -587,7 +587,7 @@ func deleteCloudletChecks(t *testing.T, ctx context.Context, all *AllApis, dataG
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove CloudletPool obj
-		_, err = all.cloudletPoolApi.store.Delete(ctx, refBy, all.cloudletPoolApi.sync.syncWait)
+		_, err = all.cloudletPoolApi.store.Delete(ctx, refBy, all.cloudletPoolApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from CloudletPool must succeed")
 		deleteStore.putDeletePrepareCb = nil
 		supportData.delete(t, ctx, all)
@@ -598,7 +598,7 @@ func deleteCloudletChecks(t *testing.T, ctx context.Context, all *AllApis, dataG
 		refBy, supportData := dataGen.GetNetworkKeyCloudletKeyRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
 		deleteStore.putDeletePrepareCb = func() {
-			all.networkApi.store.Put(ctx, refBy, all.networkApi.sync.syncWait)
+			all.networkApi.store.Put(ctx, refBy, all.networkApi.sync.SyncWait)
 		}
 		testObj, _ = dataGen.GetCloudletTestObj()
 		err = api.DeleteCloudlet(testObj, testutil.NewCudStreamoutCloudlet(ctx))
@@ -607,7 +607,7 @@ func deleteCloudletChecks(t *testing.T, ctx context.Context, all *AllApis, dataG
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove Network obj
-		_, err = all.networkApi.store.Delete(ctx, refBy, all.networkApi.sync.syncWait)
+		_, err = all.networkApi.store.Delete(ctx, refBy, all.networkApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from Network must succeed")
 		deleteStore.putDeletePrepareCb = nil
 		supportData.delete(t, ctx, all)
@@ -617,7 +617,7 @@ func deleteCloudletChecks(t *testing.T, ctx context.Context, all *AllApis, dataG
 		// Inject the refs object to trigger an "in use" error.
 		refBy, supportData := dataGen.GetCloudletClusterInstClusterInstsRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
-		_, err = all.cloudletRefsApi.store.Put(ctx, refBy, all.cloudletRefsApi.sync.syncWait)
+		_, err = all.cloudletRefsApi.store.Put(ctx, refBy, all.cloudletRefsApi.sync.SyncWait)
 		require.Nil(t, err)
 		testObj, _ = dataGen.GetCloudletTestObj()
 		err = api.DeleteCloudlet(testObj, testutil.NewCudStreamoutCloudlet(ctx))
@@ -626,7 +626,7 @@ func deleteCloudletChecks(t *testing.T, ctx context.Context, all *AllApis, dataG
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove CloudletRefs obj
-		_, err = all.cloudletRefsApi.store.Delete(ctx, refBy, all.cloudletRefsApi.sync.syncWait)
+		_, err = all.cloudletRefsApi.store.Delete(ctx, refBy, all.cloudletRefsApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from CloudletRefs must succeed")
 		supportData.delete(t, ctx, all)
 	}
@@ -635,7 +635,7 @@ func deleteCloudletChecks(t *testing.T, ctx context.Context, all *AllApis, dataG
 		// Inject the refs object to trigger an "in use" error.
 		refBy, supportData := dataGen.GetCloudletAppInstVmAppInstsRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
-		_, err = all.cloudletRefsApi.store.Put(ctx, refBy, all.cloudletRefsApi.sync.syncWait)
+		_, err = all.cloudletRefsApi.store.Put(ctx, refBy, all.cloudletRefsApi.sync.SyncWait)
 		require.Nil(t, err)
 		testObj, _ = dataGen.GetCloudletTestObj()
 		err = api.DeleteCloudlet(testObj, testutil.NewCudStreamoutCloudlet(ctx))
@@ -644,7 +644,7 @@ func deleteCloudletChecks(t *testing.T, ctx context.Context, all *AllApis, dataG
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove CloudletRefs obj
-		_, err = all.cloudletRefsApi.store.Delete(ctx, refBy, all.cloudletRefsApi.sync.syncWait)
+		_, err = all.cloudletRefsApi.store.Delete(ctx, refBy, all.cloudletRefsApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from CloudletRefs must succeed")
 		supportData.delete(t, ctx, all)
 	}
@@ -665,7 +665,7 @@ func CreateCloudletAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis
 		ref := supportData.getOnePlatformFeatures()
 		require.NotNil(t, ref, "support data must include one referenced PlatformFeatures")
 		ref.DeletePrepare = true
-		_, err = all.platformFeaturesApi.store.Put(ctx, ref, all.platformFeaturesApi.sync.syncWait)
+		_, err = all.platformFeaturesApi.store.Put(ctx, ref, all.platformFeaturesApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateCloudletTestObj()
@@ -674,7 +674,7 @@ func CreateCloudletAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced PlatformFeatures
 		ref.DeletePrepare = false
-		_, err = all.platformFeaturesApi.store.Put(ctx, ref, all.platformFeaturesApi.sync.syncWait)
+		_, err = all.platformFeaturesApi.store.Put(ctx, ref, all.platformFeaturesApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	{
@@ -682,7 +682,7 @@ func CreateCloudletAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis
 		ref := supportData.getOneFlavor()
 		require.NotNil(t, ref, "support data must include one referenced Flavor")
 		ref.DeletePrepare = true
-		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.syncWait)
+		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateCloudletTestObj()
@@ -691,7 +691,7 @@ func CreateCloudletAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced Flavor
 		ref.DeletePrepare = false
-		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.syncWait)
+		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	{
@@ -699,7 +699,7 @@ func CreateCloudletAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis
 		ref := supportData.getOneVMPool()
 		require.NotNil(t, ref, "support data must include one referenced VMPool")
 		ref.DeletePrepare = true
-		_, err = all.vmPoolApi.store.Put(ctx, ref, all.vmPoolApi.sync.syncWait)
+		_, err = all.vmPoolApi.store.Put(ctx, ref, all.vmPoolApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateCloudletTestObj()
@@ -708,7 +708,7 @@ func CreateCloudletAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced VMPool
 		ref.DeletePrepare = false
-		_, err = all.vmPoolApi.store.Put(ctx, ref, all.vmPoolApi.sync.syncWait)
+		_, err = all.vmPoolApi.store.Put(ctx, ref, all.vmPoolApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	{
@@ -716,7 +716,7 @@ func CreateCloudletAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis
 		ref := supportData.getOneTrustPolicy()
 		require.NotNil(t, ref, "support data must include one referenced TrustPolicy")
 		ref.DeletePrepare = true
-		_, err = all.trustPolicyApi.store.Put(ctx, ref, all.trustPolicyApi.sync.syncWait)
+		_, err = all.trustPolicyApi.store.Put(ctx, ref, all.trustPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateCloudletTestObj()
@@ -725,7 +725,7 @@ func CreateCloudletAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced TrustPolicy
 		ref.DeletePrepare = false
-		_, err = all.trustPolicyApi.store.Put(ctx, ref, all.trustPolicyApi.sync.syncWait)
+		_, err = all.trustPolicyApi.store.Put(ctx, ref, all.trustPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	{
@@ -733,7 +733,7 @@ func CreateCloudletAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis
 		ref := supportData.getOneGPUDriver()
 		require.NotNil(t, ref, "support data must include one referenced GPUDriver")
 		ref.DeletePrepare = true
-		_, err = all.gpuDriverApi.store.Put(ctx, ref, all.gpuDriverApi.sync.syncWait)
+		_, err = all.gpuDriverApi.store.Put(ctx, ref, all.gpuDriverApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateCloudletTestObj()
@@ -742,7 +742,7 @@ func CreateCloudletAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced GPUDriver
 		ref.DeletePrepare = false
-		_, err = all.gpuDriverApi.store.Put(ctx, ref, all.gpuDriverApi.sync.syncWait)
+		_, err = all.gpuDriverApi.store.Put(ctx, ref, all.gpuDriverApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 
@@ -796,7 +796,7 @@ func UpdateCloudletAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis
 		ref := supportData.getOneTrustPolicy()
 		require.NotNil(t, ref, "support data must include one referenced TrustPolicy")
 		ref.DeletePrepare = true
-		_, err = all.trustPolicyApi.store.Put(ctx, ref, all.trustPolicyApi.sync.syncWait)
+		_, err = all.trustPolicyApi.store.Put(ctx, ref, all.trustPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetUpdateCloudletTestObj()
@@ -805,7 +805,7 @@ func UpdateCloudletAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced TrustPolicy
 		ref.DeletePrepare = false
-		_, err = all.trustPolicyApi.store.Put(ctx, ref, all.trustPolicyApi.sync.syncWait)
+		_, err = all.trustPolicyApi.store.Put(ctx, ref, all.trustPolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	{
@@ -813,7 +813,7 @@ func UpdateCloudletAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis
 		ref := supportData.getOneGPUDriver()
 		require.NotNil(t, ref, "support data must include one referenced GPUDriver")
 		ref.DeletePrepare = true
-		_, err = all.gpuDriverApi.store.Put(ctx, ref, all.gpuDriverApi.sync.syncWait)
+		_, err = all.gpuDriverApi.store.Put(ctx, ref, all.gpuDriverApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetUpdateCloudletTestObj()
@@ -822,7 +822,7 @@ func UpdateCloudletAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced GPUDriver
 		ref.DeletePrepare = false
-		_, err = all.gpuDriverApi.store.Put(ctx, ref, all.gpuDriverApi.sync.syncWait)
+		_, err = all.gpuDriverApi.store.Put(ctx, ref, all.gpuDriverApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 
@@ -860,7 +860,7 @@ func AddCloudletResMappingAddRefsChecks(t *testing.T, ctx context.Context, all *
 		ref := supportData.getOneResTagTable()
 		require.NotNil(t, ref, "support data must include one referenced ResTagTable")
 		ref.DeletePrepare = true
-		_, err = all.resTagTableApi.store.Put(ctx, ref, all.resTagTableApi.sync.syncWait)
+		_, err = all.resTagTableApi.store.Put(ctx, ref, all.resTagTableApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetAddCloudletResMappingTestObj()
@@ -869,7 +869,7 @@ func AddCloudletResMappingAddRefsChecks(t *testing.T, ctx context.Context, all *
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced ResTagTable
 		ref.DeletePrepare = false
-		_, err = all.resTagTableApi.store.Put(ctx, ref, all.resTagTableApi.sync.syncWait)
+		_, err = all.resTagTableApi.store.Put(ctx, ref, all.resTagTableApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 

--- a/pkg/controller/cloudlet_api.go
+++ b/pkg/controller/cloudlet_api.go
@@ -32,6 +32,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/process"
 	"github.com/edgexr/edge-cloud-platform/pkg/rediscache"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/pkg/util/tasks"
 	"github.com/edgexr/edge-cloud-platform/pkg/vault"
 	"github.com/edgexr/edge-cloud-platform/pkg/vmspec"
@@ -41,7 +42,7 @@ import (
 
 type CloudletApi struct {
 	all                   *AllApis
-	sync                  *Sync
+	sync                  *regiondata.Sync
 	store                 edgeproto.CloudletStore
 	cache                 *edgeproto.CloudletCache
 	accessKeyServer       *node.AccessKeyServer
@@ -100,11 +101,11 @@ func ignoreCRMState(cctx *CallContext) bool {
 	return false
 }
 
-func NewCloudletApi(sync *Sync, all *AllApis) *CloudletApi {
+func NewCloudletApi(sync *regiondata.Sync, all *AllApis) *CloudletApi {
 	cloudletApi := CloudletApi{}
 	cloudletApi.all = all
 	cloudletApi.sync = sync
-	cloudletApi.store = edgeproto.NewCloudletStore(sync.store)
+	cloudletApi.store = edgeproto.NewCloudletStore(sync.GetKVStore())
 	cloudletApi.cache = nodeMgr.CloudletLookup.GetCloudletCache(node.NoRegion)
 	sync.RegisterCache(cloudletApi.cache)
 	cloudletApi.accessKeyServer = node.NewAccessKeyServer(cloudletApi.cache, nodeMgr.VaultAddr)

--- a/pkg/controller/cloudlet_api_test.go
+++ b/pkg/controller/cloudlet_api_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/objstore"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform"
 	"github.com/edgexr/edge-cloud-platform/pkg/process"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/pkg/vault"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/jarcoal/httpmock"
@@ -148,11 +149,11 @@ func TestCloudletApi(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 	defer dummy.Stop()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()
@@ -978,10 +979,10 @@ func TestShowCloudletsAppDeploy(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()
@@ -1097,8 +1098,8 @@ func testCloudletDnsLabel(t *testing.T, ctx context.Context, apis *AllApis) {
 
 	require.NotEqual(t, dnsLabel0, dnsLabel1)
 	// check that ids are present in database
-	require.True(t, testHasCloudletDnsLabel(apis.cloudletApi.sync.store, dnsLabel0))
-	require.True(t, testHasCloudletDnsLabel(apis.cloudletApi.sync.store, dnsLabel1))
+	require.True(t, testHasCloudletDnsLabel(apis.cloudletApi.sync.GetKVStore(), dnsLabel0))
+	require.True(t, testHasCloudletDnsLabel(apis.cloudletApi.sync.GetKVStore(), dnsLabel1))
 
 	// clean up
 	err = apis.cloudletApi.DeleteCloudlet(&cl0, testutil.NewCudStreamoutCloudlet(ctx))
@@ -1106,8 +1107,8 @@ func testCloudletDnsLabel(t *testing.T, ctx context.Context, apis *AllApis) {
 	err = apis.cloudletApi.DeleteCloudlet(&cl1, testutil.NewCudStreamoutCloudlet(ctx))
 	require.Nil(t, err)
 	// check that ids are removed from database
-	require.False(t, testHasCloudletDnsLabel(apis.cloudletApi.sync.store, dnsLabel0))
-	require.False(t, testHasCloudletDnsLabel(apis.cloudletApi.sync.store, dnsLabel1))
+	require.False(t, testHasCloudletDnsLabel(apis.cloudletApi.sync.GetKVStore(), dnsLabel0))
+	require.False(t, testHasCloudletDnsLabel(apis.cloudletApi.sync.GetKVStore(), dnsLabel1))
 }
 
 func testHasCloudletDnsLabel(kvstore objstore.KVStore, id string) bool {

--- a/pkg/controller/cloudletinfo_api_test.go
+++ b/pkg/controller/cloudletinfo_api_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/objstore"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -34,11 +35,11 @@ func TestCloudletInfo(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 	defer dummy.Stop()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()
@@ -77,7 +78,7 @@ func evictCloudletInfo(ctx context.Context, apis *AllApis, data []edgeproto.Clou
 	}
 }
 
-func testCloudletInfoRevs(t *testing.T, ctx context.Context, dummy *dummyEtcd, apis *AllApis, data []edgeproto.CloudletInfo) {
+func testCloudletInfoRevs(t *testing.T, ctx context.Context, dummy *regiondata.InMemoryStore, apis *AllApis, data []edgeproto.CloudletInfo) {
 	testData := &data[0]
 	apis.cloudletInfoApi.Update(ctx, testData, 0)
 	keyStr := objstore.DbKeyString("CloudletInfo", testData.GetKey())

--- a/pkg/controller/cloudletnode_api.go
+++ b/pkg/controller/cloudletnode_api.go
@@ -21,22 +21,23 @@ import (
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/passhash"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/sethvargo/go-password/password"
 	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
 type CloudletNodeApi struct {
 	all   *AllApis
-	sync  *Sync
+	sync  *regiondata.Sync
 	store edgeproto.CloudletNodeStore
 	cache edgeproto.CloudletNodeCache
 }
 
-func NewCloudletNodeApi(sync *Sync, all *AllApis) *CloudletNodeApi {
+func NewCloudletNodeApi(sync *regiondata.Sync, all *AllApis) *CloudletNodeApi {
 	api := CloudletNodeApi{}
 	api.all = all
 	api.sync = sync
-	api.store = edgeproto.NewCloudletNodeStore(sync.store)
+	api.store = edgeproto.NewCloudletNodeStore(sync.GetKVStore())
 	edgeproto.InitCloudletNodeCache(&api.cache)
 	sync.RegisterCache(&api.cache)
 	return &api
@@ -147,6 +148,6 @@ func (s *CloudletNodeApi) cleanupNodes(ctx context.Context, key *edgeproto.Cloud
 	}
 	s.cache.Mux.Unlock()
 	for _, val := range toDelete {
-		s.store.Delete(ctx, val, s.sync.syncWait)
+		s.store.Delete(ctx, val, s.sync.SyncWait)
 	}
 }

--- a/pkg/controller/cloudletnode_api_test.go
+++ b/pkg/controller/cloudletnode_api_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 )
 
@@ -30,11 +31,11 @@ func TestCloudletNodeApi(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 	defer dummy.Stop()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/cloudletpool.auto_test.go
+++ b/pkg/controller/cloudletpool.auto_test.go
@@ -152,7 +152,7 @@ func deleteCloudletPoolChecks(t *testing.T, ctx context.Context, all *AllApis, d
 	testObj, supportData := dataGen.GetCloudletPoolTestObj()
 	supportData.put(t, ctx, all)
 	defer supportData.delete(t, ctx, all)
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	// Positive test, delete should succeed without any references.
 	// The overrided store checks that delete prepare was set on the
@@ -164,7 +164,7 @@ func deleteCloudletPoolChecks(t *testing.T, ctx context.Context, all *AllApis, d
 	// Negative test, inject testObj with delete prepare already set.
 	testObj, _ = dataGen.GetCloudletPoolTestObj()
 	testObj.DeletePrepare = true
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 	// delete should fail with already being deleted
 	testObj, _ = dataGen.GetCloudletPoolTestObj()
 	_, err = api.DeleteCloudletPool(ctx, testObj)
@@ -175,7 +175,7 @@ func deleteCloudletPoolChecks(t *testing.T, ctx context.Context, all *AllApis, d
 
 	// inject testObj for ref tests
 	testObj, _ = dataGen.GetCloudletPoolTestObj()
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	{
 		// Negative test, TrustPolicyException refers to CloudletPool.
@@ -183,7 +183,7 @@ func deleteCloudletPoolChecks(t *testing.T, ctx context.Context, all *AllApis, d
 		refBy, supportData := dataGen.GetTrustPolicyExceptionKeyCloudletPoolKeyRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
 		deleteStore.putDeletePrepareCb = func() {
-			all.trustPolicyExceptionApi.store.Put(ctx, refBy, all.trustPolicyExceptionApi.sync.syncWait)
+			all.trustPolicyExceptionApi.store.Put(ctx, refBy, all.trustPolicyExceptionApi.sync.SyncWait)
 		}
 		testObj, _ = dataGen.GetCloudletPoolTestObj()
 		_, err = api.DeleteCloudletPool(ctx, testObj)
@@ -192,7 +192,7 @@ func deleteCloudletPoolChecks(t *testing.T, ctx context.Context, all *AllApis, d
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove TrustPolicyException obj
-		_, err = all.trustPolicyExceptionApi.store.Delete(ctx, refBy, all.trustPolicyExceptionApi.sync.syncWait)
+		_, err = all.trustPolicyExceptionApi.store.Delete(ctx, refBy, all.trustPolicyExceptionApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from TrustPolicyException must succeed")
 		deleteStore.putDeletePrepareCb = nil
 		supportData.delete(t, ctx, all)
@@ -214,7 +214,7 @@ func CreateCloudletPoolAddRefsChecks(t *testing.T, ctx context.Context, all *All
 		ref := supportData.getOneCloudlet()
 		require.NotNil(t, ref, "support data must include one referenced Cloudlet")
 		ref.DeletePrepare = true
-		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateCloudletPoolTestObj()
@@ -223,7 +223,7 @@ func CreateCloudletPoolAddRefsChecks(t *testing.T, ctx context.Context, all *All
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced Cloudlet
 		ref.DeletePrepare = false
-		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 
@@ -261,7 +261,7 @@ func UpdateCloudletPoolAddRefsChecks(t *testing.T, ctx context.Context, all *All
 		ref := supportData.getOneCloudlet()
 		require.NotNil(t, ref, "support data must include one referenced Cloudlet")
 		ref.DeletePrepare = true
-		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetUpdateCloudletPoolTestObj()
@@ -270,7 +270,7 @@ func UpdateCloudletPoolAddRefsChecks(t *testing.T, ctx context.Context, all *All
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced Cloudlet
 		ref.DeletePrepare = false
-		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 
@@ -304,7 +304,7 @@ func AddCloudletPoolMemberAddRefsChecks(t *testing.T, ctx context.Context, all *
 		ref := supportData.getOneCloudlet()
 		require.NotNil(t, ref, "support data must include one referenced Cloudlet")
 		ref.DeletePrepare = true
-		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetAddCloudletPoolMemberTestObj()
@@ -313,7 +313,7 @@ func AddCloudletPoolMemberAddRefsChecks(t *testing.T, ctx context.Context, all *
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced Cloudlet
 		ref.DeletePrepare = false
-		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 

--- a/pkg/controller/cloudletpool_api.go
+++ b/pkg/controller/cloudletpool_api.go
@@ -20,25 +20,26 @@ import (
 	"strings"
 	"time"
 
-	"go.etcd.io/etcd/client/v3/concurrency"
-	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
 	dme "github.com/edgexr/edge-cloud-platform/api/distributed_match_engine"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
+	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
 type CloudletPoolApi struct {
 	all   *AllApis
-	sync  *Sync
+	sync  *regiondata.Sync
 	store edgeproto.CloudletPoolStore
 	cache *edgeproto.CloudletPoolCache
 }
 
-func NewCloudletPoolApi(sync *Sync, all *AllApis) *CloudletPoolApi {
+func NewCloudletPoolApi(sync *regiondata.Sync, all *AllApis) *CloudletPoolApi {
 	cloudletPoolApi := CloudletPoolApi{}
 	cloudletPoolApi.all = all
 	cloudletPoolApi.sync = sync
-	cloudletPoolApi.store = edgeproto.NewCloudletPoolStore(sync.store)
+	cloudletPoolApi.store = edgeproto.NewCloudletPoolStore(sync.GetKVStore())
 	cloudletPoolApi.cache = nodeMgr.CloudletPoolLookup.GetCloudletPoolCache(node.NoRegion)
 	sync.RegisterCache(cloudletPoolApi.cache)
 	return &cloudletPoolApi

--- a/pkg/controller/cloudletpool_api_test.go
+++ b/pkg/controller/cloudletpool_api_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -34,10 +35,10 @@ func TestCloudletPoolApi(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/cloudletrefs_api.go
+++ b/pkg/controller/cloudletrefs_api.go
@@ -18,20 +18,21 @@ import (
 	"context"
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 )
 
 type CloudletRefsApi struct {
 	all   *AllApis
-	sync  *Sync
+	sync  *regiondata.Sync
 	store edgeproto.CloudletRefsStore
 	cache edgeproto.CloudletRefsCache
 }
 
-func NewCloudletRefsApi(sync *Sync, all *AllApis) *CloudletRefsApi {
+func NewCloudletRefsApi(sync *regiondata.Sync, all *AllApis) *CloudletRefsApi {
 	cloudletRefsApi := CloudletRefsApi{}
 	cloudletRefsApi.all = all
 	cloudletRefsApi.sync = sync
-	cloudletRefsApi.store = edgeproto.NewCloudletRefsStore(sync.store)
+	cloudletRefsApi.store = edgeproto.NewCloudletRefsStore(sync.GetKVStore())
 	edgeproto.InitCloudletRefsCache(&cloudletRefsApi.cache)
 	sync.RegisterCache(&cloudletRefsApi.cache)
 	return &cloudletRefsApi

--- a/pkg/controller/clusterinst.auto_test.go
+++ b/pkg/controller/clusterinst.auto_test.go
@@ -155,7 +155,7 @@ func deleteClusterInstChecks(t *testing.T, ctx context.Context, all *AllApis, da
 	testObj, supportData := dataGen.GetClusterInstTestObj()
 	supportData.put(t, ctx, all)
 	defer supportData.delete(t, ctx, all)
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	// Positive test, delete should succeed without any references.
 	// The overrided store checks that delete prepare was set on the
@@ -177,7 +177,7 @@ func deleteClusterInstChecks(t *testing.T, ctx context.Context, all *AllApis, da
 	// Negative test, inject testObj with delete prepare already set.
 	testObj, _ = dataGen.GetClusterInstTestObj()
 	testObj.DeletePrepare = true
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 	// delete should fail with already being deleted
 	testObj, _ = dataGen.GetClusterInstTestObj()
 	err = api.DeleteClusterInst(testObj, testutil.NewCudStreamoutClusterInst(ctx))
@@ -188,14 +188,14 @@ func deleteClusterInstChecks(t *testing.T, ctx context.Context, all *AllApis, da
 
 	// inject testObj for ref tests
 	testObj, _ = dataGen.GetClusterInstTestObj()
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	{
 		// Negative test, ClusterRefs refers to ClusterInst via refs object.
 		// Inject the refs object to trigger an "in use" error.
 		refBy, supportData := dataGen.GetClusterInstAppInstAppsRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
-		_, err = all.clusterRefsApi.store.Put(ctx, refBy, all.clusterRefsApi.sync.syncWait)
+		_, err = all.clusterRefsApi.store.Put(ctx, refBy, all.clusterRefsApi.sync.SyncWait)
 		require.Nil(t, err)
 		testObj, _ = dataGen.GetClusterInstTestObj()
 		err = api.DeleteClusterInst(testObj, testutil.NewCudStreamoutClusterInst(ctx))
@@ -204,7 +204,7 @@ func deleteClusterInstChecks(t *testing.T, ctx context.Context, all *AllApis, da
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove ClusterRefs obj
-		_, err = all.clusterRefsApi.store.Delete(ctx, refBy, all.clusterRefsApi.sync.syncWait)
+		_, err = all.clusterRefsApi.store.Delete(ctx, refBy, all.clusterRefsApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from ClusterRefs must succeed")
 		supportData.delete(t, ctx, all)
 	}
@@ -225,7 +225,7 @@ func CreateClusterInstAddRefsChecks(t *testing.T, ctx context.Context, all *AllA
 		ref := supportData.getOneCloudlet()
 		require.NotNil(t, ref, "support data must include one referenced Cloudlet")
 		ref.DeletePrepare = true
-		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateClusterInstTestObj()
@@ -234,7 +234,7 @@ func CreateClusterInstAddRefsChecks(t *testing.T, ctx context.Context, all *AllA
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced Cloudlet
 		ref.DeletePrepare = false
-		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	{
@@ -242,7 +242,7 @@ func CreateClusterInstAddRefsChecks(t *testing.T, ctx context.Context, all *AllA
 		ref := supportData.getOneFlavor()
 		require.NotNil(t, ref, "support data must include one referenced Flavor")
 		ref.DeletePrepare = true
-		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.syncWait)
+		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateClusterInstTestObj()
@@ -251,7 +251,7 @@ func CreateClusterInstAddRefsChecks(t *testing.T, ctx context.Context, all *AllA
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced Flavor
 		ref.DeletePrepare = false
-		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.syncWait)
+		_, err = all.flavorApi.store.Put(ctx, ref, all.flavorApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	{
@@ -259,7 +259,7 @@ func CreateClusterInstAddRefsChecks(t *testing.T, ctx context.Context, all *AllA
 		ref := supportData.getOneAutoScalePolicy()
 		require.NotNil(t, ref, "support data must include one referenced AutoScalePolicy")
 		ref.DeletePrepare = true
-		_, err = all.autoScalePolicyApi.store.Put(ctx, ref, all.autoScalePolicyApi.sync.syncWait)
+		_, err = all.autoScalePolicyApi.store.Put(ctx, ref, all.autoScalePolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateClusterInstTestObj()
@@ -268,7 +268,7 @@ func CreateClusterInstAddRefsChecks(t *testing.T, ctx context.Context, all *AllA
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced AutoScalePolicy
 		ref.DeletePrepare = false
-		_, err = all.autoScalePolicyApi.store.Put(ctx, ref, all.autoScalePolicyApi.sync.syncWait)
+		_, err = all.autoScalePolicyApi.store.Put(ctx, ref, all.autoScalePolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	{
@@ -276,7 +276,7 @@ func CreateClusterInstAddRefsChecks(t *testing.T, ctx context.Context, all *AllA
 		ref := supportData.getOneNetwork()
 		require.NotNil(t, ref, "support data must include one referenced Network")
 		ref.DeletePrepare = true
-		_, err = all.networkApi.store.Put(ctx, ref, all.networkApi.sync.syncWait)
+		_, err = all.networkApi.store.Put(ctx, ref, all.networkApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateClusterInstTestObj()
@@ -285,7 +285,7 @@ func CreateClusterInstAddRefsChecks(t *testing.T, ctx context.Context, all *AllA
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced Network
 		ref.DeletePrepare = false
-		_, err = all.networkApi.store.Put(ctx, ref, all.networkApi.sync.syncWait)
+		_, err = all.networkApi.store.Put(ctx, ref, all.networkApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 
@@ -335,7 +335,7 @@ func UpdateClusterInstAddRefsChecks(t *testing.T, ctx context.Context, all *AllA
 		ref := supportData.getOneAutoScalePolicy()
 		require.NotNil(t, ref, "support data must include one referenced AutoScalePolicy")
 		ref.DeletePrepare = true
-		_, err = all.autoScalePolicyApi.store.Put(ctx, ref, all.autoScalePolicyApi.sync.syncWait)
+		_, err = all.autoScalePolicyApi.store.Put(ctx, ref, all.autoScalePolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetUpdateClusterInstTestObj()
@@ -344,7 +344,7 @@ func UpdateClusterInstAddRefsChecks(t *testing.T, ctx context.Context, all *AllA
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced AutoScalePolicy
 		ref.DeletePrepare = false
-		_, err = all.autoScalePolicyApi.store.Put(ctx, ref, all.autoScalePolicyApi.sync.syncWait)
+		_, err = all.autoScalePolicyApi.store.Put(ctx, ref, all.autoScalePolicyApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 

--- a/pkg/controller/clusterinst_api.go
+++ b/pkg/controller/clusterinst_api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/rediscache"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/pkg/util/tasks"
 	"github.com/gogo/protobuf/types"
 	"github.com/opentracing/opentracing-go"
@@ -37,7 +38,7 @@ import (
 
 type ClusterInstApi struct {
 	all            *AllApis
-	sync           *Sync
+	sync           *regiondata.Sync
 	store          edgeproto.ClusterInstStore
 	dnsLabelStore  *edgeproto.CloudletObjectDnsLabelStore
 	cache          edgeproto.ClusterInstCache
@@ -65,11 +66,11 @@ const (
 	GenResourceAlerts   = 1
 )
 
-func NewClusterInstApi(sync *Sync, all *AllApis) *ClusterInstApi {
+func NewClusterInstApi(sync *regiondata.Sync, all *AllApis) *ClusterInstApi {
 	clusterInstApi := ClusterInstApi{}
 	clusterInstApi.all = all
 	clusterInstApi.sync = sync
-	clusterInstApi.store = edgeproto.NewClusterInstStore(sync.store)
+	clusterInstApi.store = edgeproto.NewClusterInstStore(sync.GetKVStore())
 	clusterInstApi.dnsLabelStore = &all.cloudletApi.objectDnsLabelStore
 	edgeproto.InitClusterInstCache(&clusterInstApi.cache)
 	sync.RegisterCache(&clusterInstApi.cache)

--- a/pkg/controller/clusterinst_api_test.go
+++ b/pkg/controller/clusterinst_api_test.go
@@ -23,12 +23,13 @@ import (
 
 	dme "github.com/edgexr/edge-cloud-platform/api/distributed_match_engine"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
-	influxq "github.com/edgexr/edge-cloud-platform/pkg/influxq_client"
-	"github.com/edgexr/edge-cloud-platform/pkg/influxq_client/influxq_testutil"
 	"github.com/edgexr/edge-cloud-platform/pkg/ccrmdummy"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
+	influxq "github.com/edgexr/edge-cloud-platform/pkg/influxq_client"
+	"github.com/edgexr/edge-cloud-platform/pkg/influxq_client/influxq_testutil"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/process"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/client/v3/concurrency"
@@ -42,10 +43,10 @@ func TestClusterInstApi(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()
@@ -928,10 +929,10 @@ func TestDefaultMTCluster(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/clusterinstinfo_api.go
+++ b/pkg/controller/clusterinstinfo_api.go
@@ -18,19 +18,20 @@ import (
 	"context"
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 )
 
 type ClusterInstInfoApi struct {
 	all   *AllApis
-	sync  *Sync
+	sync  *regiondata.Sync
 	store edgeproto.ClusterInstInfoStore
 }
 
-func NewClusterInstInfoApi(sync *Sync, all *AllApis) *ClusterInstInfoApi {
+func NewClusterInstInfoApi(sync *regiondata.Sync, all *AllApis) *ClusterInstInfoApi {
 	clusterInstInfoApi := ClusterInstInfoApi{}
 	clusterInstInfoApi.all = all
 	clusterInstInfoApi.sync = sync
-	clusterInstInfoApi.store = edgeproto.NewClusterInstInfoStore(sync.store)
+	clusterInstInfoApi.store = edgeproto.NewClusterInstInfoStore(sync.GetKVStore())
 	return &clusterInstInfoApi
 }
 

--- a/pkg/controller/clusterrefs_api.go
+++ b/pkg/controller/clusterrefs_api.go
@@ -16,21 +16,22 @@ package controller
 
 import (
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
 type ClusterRefsApi struct {
 	all   *AllApis
-	sync  *Sync
+	sync  *regiondata.Sync
 	store edgeproto.ClusterRefsStore
 	cache edgeproto.ClusterRefsCache
 }
 
-func NewClusterRefsApi(sync *Sync, all *AllApis) *ClusterRefsApi {
+func NewClusterRefsApi(sync *regiondata.Sync, all *AllApis) *ClusterRefsApi {
 	clusterRefsApi := ClusterRefsApi{}
 	clusterRefsApi.all = all
 	clusterRefsApi.sync = sync
-	clusterRefsApi.store = edgeproto.NewClusterRefsStore(sync.store)
+	clusterRefsApi.store = edgeproto.NewClusterRefsStore(sync.GetKVStore())
 	edgeproto.InitClusterRefsCache(&clusterRefsApi.cache)
 	sync.RegisterCache(&clusterRefsApi.cache)
 	return &clusterRefsApi

--- a/pkg/controller/controller_api.go
+++ b/pkg/controller/controller_api.go
@@ -26,6 +26,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/objstore"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/pkg/tls"
 	"github.com/edgexr/edge-cloud-platform/pkg/version"
 	"google.golang.org/grpc"
@@ -33,18 +34,18 @@ import (
 
 type ControllerApi struct {
 	all   *AllApis
-	sync  *Sync
+	sync  *regiondata.Sync
 	store edgeproto.ControllerStore
 	cache edgeproto.ControllerCache
 }
 
 var controllerAliveLease int64
 
-func NewControllerApi(sync *Sync, all *AllApis) *ControllerApi {
+func NewControllerApi(sync *regiondata.Sync, all *AllApis) *ControllerApi {
 	controllerApi := ControllerApi{}
 	controllerApi.all = all
 	controllerApi.sync = sync
-	controllerApi.store = edgeproto.NewControllerStore(sync.store)
+	controllerApi.store = edgeproto.NewControllerStore(sync.GetKVStore())
 	edgeproto.InitControllerCache(&controllerApi.cache)
 	sync.RegisterCache(&controllerApi.cache)
 	return &controllerApi
@@ -64,7 +65,7 @@ func (s *ControllerApi) registerController(ctx context.Context, lease int64) err
 	ctrl.BuildHead = buildInfo.BuildHead
 	ctrl.BuildAuthor = buildInfo.BuildAuthor
 	ctrl.Hostname = cloudcommon.Hostname()
-	_, err := s.store.Put(ctx, &ctrl, s.sync.syncWait, objstore.WithLease(lease))
+	_, err := s.store.Put(ctx, &ctrl, s.sync.SyncWait, objstore.WithLease(lease))
 	return err
 }
 

--- a/pkg/controller/debug_api.go
+++ b/pkg/controller/debug_api.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
 )
 
 type DebugApi struct{}

--- a/pkg/controller/delete_test.go
+++ b/pkg/controller/delete_test.go
@@ -22,6 +22,7 @@ import (
 	dme "github.com/edgexr/edge-cloud-platform/api/distributed_match_engine"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 )
 
@@ -33,10 +34,10 @@ func TestDeleteChecks(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/device_api.go
+++ b/pkg/controller/device_api.go
@@ -18,23 +18,24 @@ import (
 	"context"
 	"fmt"
 
-	"go.etcd.io/etcd/client/v3/concurrency"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
+	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
 type DeviceApi struct {
 	all   *AllApis
-	sync  *Sync
+	sync  *regiondata.Sync
 	store edgeproto.DeviceStore
 	cache edgeproto.DeviceCache
 }
 
-func NewDeviceApi(sync *Sync, all *AllApis) *DeviceApi {
+func NewDeviceApi(sync *regiondata.Sync, all *AllApis) *DeviceApi {
 	deviceApi := DeviceApi{}
 	deviceApi.all = all
 	deviceApi.sync = sync
-	deviceApi.store = edgeproto.NewDeviceStore(sync.store)
+	deviceApi.store = edgeproto.NewDeviceStore(sync.GetKVStore())
 	edgeproto.InitDeviceCache(&deviceApi.cache)
 	sync.RegisterCache(&deviceApi.cache)
 	return &deviceApi
@@ -69,7 +70,7 @@ func (s *DeviceApi) InjectDevice(ctx context.Context, in *edgeproto.Device) (*ed
 
 // This api deletes the device from the controller cache
 func (s *DeviceApi) EvictDevice(ctx context.Context, in *edgeproto.Device) (*edgeproto.Result, error) {
-	return s.store.Delete(ctx, in, s.sync.syncWait)
+	return s.store.Delete(ctx, in, s.sync.SyncWait)
 }
 
 // Show devices that showed up in this timestamp

--- a/pkg/controller/device_api_test.go
+++ b/pkg/controller/device_api_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -35,10 +36,10 @@ func TestDeviceApi(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/flavor.auto_test.go
+++ b/pkg/controller/flavor.auto_test.go
@@ -154,7 +154,7 @@ func deleteFlavorChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen
 	testObj, supportData := dataGen.GetFlavorTestObj()
 	supportData.put(t, ctx, all)
 	defer supportData.delete(t, ctx, all)
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	// Positive test, delete should succeed without any references.
 	// The overrided store checks that delete prepare was set on the
@@ -166,7 +166,7 @@ func deleteFlavorChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen
 	// Negative test, inject testObj with delete prepare already set.
 	testObj, _ = dataGen.GetFlavorTestObj()
 	testObj.DeletePrepare = true
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 	// delete should fail with already being deleted
 	testObj, _ = dataGen.GetFlavorTestObj()
 	_, err = api.DeleteFlavor(ctx, testObj)
@@ -177,7 +177,7 @@ func deleteFlavorChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen
 
 	// inject testObj for ref tests
 	testObj, _ = dataGen.GetFlavorTestObj()
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	{
 		// Negative test, App refers to Flavor.
@@ -185,7 +185,7 @@ func deleteFlavorChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen
 		refBy, supportData := dataGen.GetAppDefaultFlavorRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
 		deleteStore.putDeletePrepareCb = func() {
-			all.appApi.store.Put(ctx, refBy, all.appApi.sync.syncWait)
+			all.appApi.store.Put(ctx, refBy, all.appApi.sync.SyncWait)
 		}
 		testObj, _ = dataGen.GetFlavorTestObj()
 		_, err = api.DeleteFlavor(ctx, testObj)
@@ -194,7 +194,7 @@ func deleteFlavorChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove App obj
-		_, err = all.appApi.store.Delete(ctx, refBy, all.appApi.sync.syncWait)
+		_, err = all.appApi.store.Delete(ctx, refBy, all.appApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from App must succeed")
 		deleteStore.putDeletePrepareCb = nil
 		supportData.delete(t, ctx, all)
@@ -205,7 +205,7 @@ func deleteFlavorChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen
 		refBy, supportData := dataGen.GetAppInstFlavorRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
 		deleteStore.putDeletePrepareCb = func() {
-			all.appInstApi.store.Put(ctx, refBy, all.appInstApi.sync.syncWait)
+			all.appInstApi.store.Put(ctx, refBy, all.appInstApi.sync.SyncWait)
 		}
 		testObj, _ = dataGen.GetFlavorTestObj()
 		_, err = api.DeleteFlavor(ctx, testObj)
@@ -214,7 +214,7 @@ func deleteFlavorChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove AppInst obj
-		_, err = all.appInstApi.store.Delete(ctx, refBy, all.appInstApi.sync.syncWait)
+		_, err = all.appInstApi.store.Delete(ctx, refBy, all.appInstApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from AppInst must succeed")
 		deleteStore.putDeletePrepareCb = nil
 		supportData.delete(t, ctx, all)
@@ -225,7 +225,7 @@ func deleteFlavorChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen
 		refBy, supportData := dataGen.GetCloudletFlavorRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
 		deleteStore.putDeletePrepareCb = func() {
-			all.cloudletApi.store.Put(ctx, refBy, all.cloudletApi.sync.syncWait)
+			all.cloudletApi.store.Put(ctx, refBy, all.cloudletApi.sync.SyncWait)
 		}
 		testObj, _ = dataGen.GetFlavorTestObj()
 		_, err = api.DeleteFlavor(ctx, testObj)
@@ -234,7 +234,7 @@ func deleteFlavorChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove Cloudlet obj
-		_, err = all.cloudletApi.store.Delete(ctx, refBy, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Delete(ctx, refBy, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from Cloudlet must succeed")
 		deleteStore.putDeletePrepareCb = nil
 		supportData.delete(t, ctx, all)
@@ -245,7 +245,7 @@ func deleteFlavorChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen
 		refBy, supportData := dataGen.GetClusterInstFlavorRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
 		deleteStore.putDeletePrepareCb = func() {
-			all.clusterInstApi.store.Put(ctx, refBy, all.clusterInstApi.sync.syncWait)
+			all.clusterInstApi.store.Put(ctx, refBy, all.clusterInstApi.sync.SyncWait)
 		}
 		testObj, _ = dataGen.GetFlavorTestObj()
 		_, err = api.DeleteFlavor(ctx, testObj)
@@ -254,7 +254,7 @@ func deleteFlavorChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove ClusterInst obj
-		_, err = all.clusterInstApi.store.Delete(ctx, refBy, all.clusterInstApi.sync.syncWait)
+		_, err = all.clusterInstApi.store.Delete(ctx, refBy, all.clusterInstApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from ClusterInst must succeed")
 		deleteStore.putDeletePrepareCb = nil
 		supportData.delete(t, ctx, all)

--- a/pkg/controller/flavor_api_test.go
+++ b/pkg/controller/flavor_api_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/client/v3/concurrency"
@@ -35,10 +36,10 @@ func TestFlavorApi(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/gpudriver_api.go
+++ b/pkg/controller/gpudriver_api.go
@@ -26,13 +26,14 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform/pc"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/pkg/util"
 	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
 type GPUDriverApi struct {
 	all   *AllApis
-	sync  *Sync
+	sync  *regiondata.Sync
 	store edgeproto.GPUDriverStore
 	cache edgeproto.GPUDriverCache
 }
@@ -43,11 +44,11 @@ const (
 	AllCloudlets              = ""
 )
 
-func NewGPUDriverApi(sync *Sync, all *AllApis) *GPUDriverApi {
+func NewGPUDriverApi(sync *regiondata.Sync, all *AllApis) *GPUDriverApi {
 	gpuDriverApi := GPUDriverApi{}
 	gpuDriverApi.all = all
 	gpuDriverApi.sync = sync
-	gpuDriverApi.store = edgeproto.NewGPUDriverStore(sync.store)
+	gpuDriverApi.store = edgeproto.NewGPUDriverStore(sync.GetKVStore())
 	edgeproto.InitGPUDriverCache(&gpuDriverApi.cache)
 	sync.RegisterCache(&gpuDriverApi.cache)
 	return &gpuDriverApi
@@ -273,7 +274,7 @@ func (s *GPUDriverApi) CreateGPUDriver(in *edgeproto.GPUDriver, cb edgeproto.GPU
 	}
 
 	in.State = ""
-	_, err = s.store.Put(ctx, in, s.sync.syncWait)
+	_, err = s.store.Put(ctx, in, s.sync.SyncWait)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/network.auto_test.go
+++ b/pkg/controller/network.auto_test.go
@@ -152,7 +152,7 @@ func deleteNetworkChecks(t *testing.T, ctx context.Context, all *AllApis, dataGe
 	testObj, supportData := dataGen.GetNetworkTestObj()
 	supportData.put(t, ctx, all)
 	defer supportData.delete(t, ctx, all)
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	// Positive test, delete should succeed without any references.
 	// The overrided store checks that delete prepare was set on the
@@ -164,7 +164,7 @@ func deleteNetworkChecks(t *testing.T, ctx context.Context, all *AllApis, dataGe
 	// Negative test, inject testObj with delete prepare already set.
 	testObj, _ = dataGen.GetNetworkTestObj()
 	testObj.DeletePrepare = true
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 	// delete should fail with already being deleted
 	testObj, _ = dataGen.GetNetworkTestObj()
 	err = api.DeleteNetwork(testObj, testutil.NewCudStreamoutNetwork(ctx))
@@ -175,7 +175,7 @@ func deleteNetworkChecks(t *testing.T, ctx context.Context, all *AllApis, dataGe
 
 	// inject testObj for ref tests
 	testObj, _ = dataGen.GetNetworkTestObj()
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	{
 		// Negative test, ClusterInst refers to Network.
@@ -183,7 +183,7 @@ func deleteNetworkChecks(t *testing.T, ctx context.Context, all *AllApis, dataGe
 		refBy, supportData := dataGen.GetClusterInstNetworksRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
 		deleteStore.putDeletePrepareCb = func() {
-			all.clusterInstApi.store.Put(ctx, refBy, all.clusterInstApi.sync.syncWait)
+			all.clusterInstApi.store.Put(ctx, refBy, all.clusterInstApi.sync.SyncWait)
 		}
 		testObj, _ = dataGen.GetNetworkTestObj()
 		err = api.DeleteNetwork(testObj, testutil.NewCudStreamoutNetwork(ctx))
@@ -192,7 +192,7 @@ func deleteNetworkChecks(t *testing.T, ctx context.Context, all *AllApis, dataGe
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove ClusterInst obj
-		_, err = all.clusterInstApi.store.Delete(ctx, refBy, all.clusterInstApi.sync.syncWait)
+		_, err = all.clusterInstApi.store.Delete(ctx, refBy, all.clusterInstApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from ClusterInst must succeed")
 		deleteStore.putDeletePrepareCb = nil
 		supportData.delete(t, ctx, all)
@@ -214,7 +214,7 @@ func CreateNetworkAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis,
 		ref := supportData.getOneCloudlet()
 		require.NotNil(t, ref, "support data must include one referenced Cloudlet")
 		ref.DeletePrepare = true
-		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateNetworkTestObj()
@@ -223,7 +223,7 @@ func CreateNetworkAddRefsChecks(t *testing.T, ctx context.Context, all *AllApis,
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced Cloudlet
 		ref.DeletePrepare = false
-		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Put(ctx, ref, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 

--- a/pkg/controller/network_api.go
+++ b/pkg/controller/network_api.go
@@ -18,23 +18,24 @@ import (
 	"errors"
 	"fmt"
 
-	"go.etcd.io/etcd/client/v3/concurrency"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
+	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
 type NetworkApi struct {
 	all   *AllApis
-	sync  *Sync
+	sync  *regiondata.Sync
 	store edgeproto.NetworkStore
 	cache edgeproto.NetworkCache
 }
 
-func NewNetworkApi(sync *Sync, all *AllApis) *NetworkApi {
+func NewNetworkApi(sync *regiondata.Sync, all *AllApis) *NetworkApi {
 	networkApi := NetworkApi{}
 	networkApi.all = all
 	networkApi.sync = sync
-	networkApi.store = edgeproto.NewNetworkStore(sync.store)
+	networkApi.store = edgeproto.NewNetworkStore(sync.GetKVStore())
 	edgeproto.InitNetworkCache(&networkApi.cache)
 	sync.RegisterCache(&networkApi.cache)
 	return &networkApi
@@ -132,7 +133,7 @@ func (s *NetworkApi) DeleteNetwork(in *edgeproto.Network, cb edgeproto.NetworkAp
 	if k := s.all.clusterInstApi.UsesNetwork(&in.Key); k != nil {
 		return fmt.Errorf("Network in use by ClusterInst %s", k.GetKeyString())
 	}
-	_, err = s.store.Delete(ctx, in, s.sync.syncWait)
+	_, err = s.store.Delete(ctx, in, s.sync.SyncWait)
 	return err
 }
 

--- a/pkg/controller/network_api_test.go
+++ b/pkg/controller/network_api_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -31,10 +32,10 @@ func TestNetworkApi(t *testing.T) {
 	ctx := log.StartTestSpan(context.Background())
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 	defer dummy.Stop()
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/operatorcode_api.go
+++ b/pkg/controller/operatorcode_api.go
@@ -18,20 +18,21 @@ import (
 	"context"
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 )
 
 type OperatorCodeApi struct {
 	all   *AllApis
-	sync  *Sync
+	sync  *regiondata.Sync
 	store edgeproto.OperatorCodeStore
 	cache edgeproto.OperatorCodeCache
 }
 
-func NewOperatorCodeApi(sync *Sync, all *AllApis) *OperatorCodeApi {
+func NewOperatorCodeApi(sync *regiondata.Sync, all *AllApis) *OperatorCodeApi {
 	operatorCodeApi := OperatorCodeApi{}
 	operatorCodeApi.all = all
 	operatorCodeApi.sync = sync
-	operatorCodeApi.store = edgeproto.NewOperatorCodeStore(sync.store)
+	operatorCodeApi.store = edgeproto.NewOperatorCodeStore(sync.GetKVStore())
 	edgeproto.InitOperatorCodeCache(&operatorCodeApi.cache)
 	sync.RegisterCache(&operatorCodeApi.cache)
 	return &operatorCodeApi
@@ -41,14 +42,14 @@ func (s *OperatorCodeApi) CreateOperatorCode(ctx context.Context, in *edgeproto.
 	if err := in.Validate(nil); err != nil {
 		return &edgeproto.Result{}, err
 	}
-	return s.store.Create(ctx, in, s.sync.syncWait)
+	return s.store.Create(ctx, in, s.sync.SyncWait)
 }
 
 func (s *OperatorCodeApi) DeleteOperatorCode(ctx context.Context, in *edgeproto.OperatorCode) (*edgeproto.Result, error) {
 	if !s.cache.HasKey(in.GetKey()) {
 		return &edgeproto.Result{}, in.GetKey().NotFoundError()
 	}
-	return s.store.Delete(ctx, in, s.sync.syncWait)
+	return s.store.Delete(ctx, in, s.sync.SyncWait)
 }
 
 func (s *OperatorCodeApi) ShowOperatorCode(in *edgeproto.OperatorCode, cb edgeproto.OperatorCodeApi_ShowOperatorCodeServer) error {

--- a/pkg/controller/operatorcode_api_test.go
+++ b/pkg/controller/operatorcode_api_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -32,11 +33,11 @@ func TestOperatorCodeApi(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 	defer dummy.Stop()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/organization_api.go
+++ b/pkg/controller/organization_api.go
@@ -19,14 +19,15 @@ import (
 	"strings"
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 )
 
 type OrganizationApi struct {
 	all  *AllApis
-	sync *Sync
+	sync *regiondata.Sync
 }
 
-func NewOrganizationApi(sync *Sync, all *AllApis) *OrganizationApi {
+func NewOrganizationApi(sync *regiondata.Sync, all *AllApis) *OrganizationApi {
 	organizationApi := OrganizationApi{}
 	organizationApi.all = all
 	organizationApi.sync = sync
@@ -34,7 +35,7 @@ func NewOrganizationApi(sync *Sync, all *AllApis) *OrganizationApi {
 }
 
 func (s *OrganizationApi) OrganizationInUse(ctx context.Context, in *edgeproto.Organization) (*edgeproto.Result, error) {
-	usedBy := s.sync.usesOrg(in.Name)
+	usedBy := s.sync.UsesOrg(in.Name)
 	res := &edgeproto.Result{}
 	if len(usedBy) > 0 {
 		res.Message = "in use by some " + strings.Join(usedBy, ", ")

--- a/pkg/controller/platformfeatures_api.go
+++ b/pkg/controller/platformfeatures_api.go
@@ -21,21 +21,22 @@ import (
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
 type PlatformFeaturesApi struct {
 	all   *AllApis
-	sync  *Sync
+	sync  *regiondata.Sync
 	store edgeproto.PlatformFeaturesStore
 	cache edgeproto.PlatformFeaturesCache
 }
 
-func NewPlatformFeaturesApi(sync *Sync, all *AllApis) *PlatformFeaturesApi {
+func NewPlatformFeaturesApi(sync *regiondata.Sync, all *AllApis) *PlatformFeaturesApi {
 	platformFeaturesApi := PlatformFeaturesApi{}
 	platformFeaturesApi.all = all
 	platformFeaturesApi.sync = sync
-	platformFeaturesApi.store = edgeproto.NewPlatformFeaturesStore(sync.store)
+	platformFeaturesApi.store = edgeproto.NewPlatformFeaturesStore(sync.GetKVStore())
 	edgeproto.InitPlatformFeaturesCache(&platformFeaturesApi.cache)
 	sync.RegisterCache(&platformFeaturesApi.cache)
 	return &platformFeaturesApi
@@ -97,7 +98,7 @@ func (s *PlatformFeaturesApi) DeletePlatformFeatures(ctx context.Context, in *ed
 	if inuse, keys := s.all.cloudletApi.UsesPlatformFeatures(in.GetKey()); inuse {
 		return &edgeproto.Result{}, fmt.Errorf("PlatformType in use by Cloudlets %s", strings.Join(keys, ", "))
 	}
-	return s.store.Delete(ctx, in, s.sync.syncWait)
+	return s.store.Delete(ctx, in, s.sync.SyncWait)
 }
 
 func (s *PlatformFeaturesApi) GetCloudletFeatures(ctx context.Context, platformType string) (*edgeproto.PlatformFeatures, error) {
@@ -114,7 +115,7 @@ func (s *PlatformFeaturesApi) Update(ctx context.Context, in *edgeproto.Platform
 	// Write to Etcd the features sent by the CCRM so it will persist
 	// even it the CCRM goes offline in case there are cloudlets still
 	// using it.
-	res, err := s.store.Put(ctx, in, s.sync.syncWait)
+	res, err := s.store.Put(ctx, in, s.sync.SyncWait)
 	log.SpanLog(ctx, log.DebugLevelApi, "put platform features", "platformType", in.PlatformType, "nodeType", in.NodeType, "res", res, "err", err)
 }
 

--- a/pkg/controller/redis_server.go
+++ b/pkg/controller/redis_server.go
@@ -17,8 +17,8 @@
 package controller
 
 import (
-	"github.com/edgexr/edge-cloud-platform/pkg/process"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/process"
 )
 
 func StartLocalRedisServer(opts ...process.StartOp) (*process.RedisCache, error) {

--- a/pkg/controller/restagtable.auto_test.go
+++ b/pkg/controller/restagtable.auto_test.go
@@ -151,7 +151,7 @@ func deleteResTagTableChecks(t *testing.T, ctx context.Context, all *AllApis, da
 	testObj, supportData := dataGen.GetResTagTableTestObj()
 	supportData.put(t, ctx, all)
 	defer supportData.delete(t, ctx, all)
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	// Positive test, delete should succeed without any references.
 	// The overrided store checks that delete prepare was set on the
@@ -163,7 +163,7 @@ func deleteResTagTableChecks(t *testing.T, ctx context.Context, all *AllApis, da
 	// Negative test, inject testObj with delete prepare already set.
 	testObj, _ = dataGen.GetResTagTableTestObj()
 	testObj.DeletePrepare = true
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 	// delete should fail with already being deleted
 	testObj, _ = dataGen.GetResTagTableTestObj()
 	_, err = api.DeleteResTagTable(ctx, testObj)
@@ -174,7 +174,7 @@ func deleteResTagTableChecks(t *testing.T, ctx context.Context, all *AllApis, da
 
 	// inject testObj for ref tests
 	testObj, _ = dataGen.GetResTagTableTestObj()
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	{
 		// Negative test, Cloudlet refers to ResTagTable.
@@ -182,7 +182,7 @@ func deleteResTagTableChecks(t *testing.T, ctx context.Context, all *AllApis, da
 		refBy, supportData := dataGen.GetCloudletResTagMapRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
 		deleteStore.putDeletePrepareCb = func() {
-			all.cloudletApi.store.Put(ctx, refBy, all.cloudletApi.sync.syncWait)
+			all.cloudletApi.store.Put(ctx, refBy, all.cloudletApi.sync.SyncWait)
 		}
 		testObj, _ = dataGen.GetResTagTableTestObj()
 		_, err = api.DeleteResTagTable(ctx, testObj)
@@ -191,7 +191,7 @@ func deleteResTagTableChecks(t *testing.T, ctx context.Context, all *AllApis, da
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove Cloudlet obj
-		_, err = all.cloudletApi.store.Delete(ctx, refBy, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Delete(ctx, refBy, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from Cloudlet must succeed")
 		deleteStore.putDeletePrepareCb = nil
 		supportData.delete(t, ctx, all)

--- a/pkg/controller/restagtable_api_test.go
+++ b/pkg/controller/restagtable_api_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/objstore"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -37,10 +38,10 @@ func TestResTagTableApi(t *testing.T) {
 	tMode := true
 	testMode = &tMode
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/settings_api.go
+++ b/pkg/controller/settings_api.go
@@ -24,21 +24,22 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	influxq "github.com/edgexr/edge-cloud-platform/pkg/influxq_client"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
 type SettingsApi struct {
 	all   *AllApis
-	sync  *Sync
+	sync  *regiondata.Sync
 	store edgeproto.SettingsStore
 	cache edgeproto.SettingsCache
 }
 
-func NewSettingsApi(sync *Sync, all *AllApis) *SettingsApi {
+func NewSettingsApi(sync *regiondata.Sync, all *AllApis) *SettingsApi {
 	settingsApi := SettingsApi{}
 	settingsApi.all = all
 	settingsApi.sync = sync
-	settingsApi.store = edgeproto.NewSettingsStore(sync.store)
+	settingsApi.store = edgeproto.NewSettingsStore(sync.GetKVStore())
 	edgeproto.InitSettingsCache(&settingsApi.cache)
 	sync.RegisterCache(&settingsApi.cache)
 	return &settingsApi

--- a/pkg/controller/settings_api_test.go
+++ b/pkg/controller/settings_api_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,10 +33,10 @@ func TestSettingsApi(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/stream_api.go
+++ b/pkg/controller/stream_api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/rediscache"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/go-redis/redis/v8"
 	grpc "google.golang.org/grpc"
 )
@@ -119,7 +120,7 @@ type CbWrapper struct {
 	streamBuf    []edgeproto.Result
 }
 
-func NewStreamObjApi(sync *Sync, all *AllApis) *StreamObjApi {
+func NewStreamObjApi(sync *regiondata.Sync, all *AllApis) *StreamObjApi {
 	streamObjApi := StreamObjApi{}
 	streamObjApi.all = all
 	return &streamObjApi

--- a/pkg/controller/trustpolicy.auto_test.go
+++ b/pkg/controller/trustpolicy.auto_test.go
@@ -152,7 +152,7 @@ func deleteTrustPolicyChecks(t *testing.T, ctx context.Context, all *AllApis, da
 	testObj, supportData := dataGen.GetTrustPolicyTestObj()
 	supportData.put(t, ctx, all)
 	defer supportData.delete(t, ctx, all)
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	// Positive test, delete should succeed without any references.
 	// The overrided store checks that delete prepare was set on the
@@ -164,7 +164,7 @@ func deleteTrustPolicyChecks(t *testing.T, ctx context.Context, all *AllApis, da
 	// Negative test, inject testObj with delete prepare already set.
 	testObj, _ = dataGen.GetTrustPolicyTestObj()
 	testObj.DeletePrepare = true
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 	// delete should fail with already being deleted
 	testObj, _ = dataGen.GetTrustPolicyTestObj()
 	err = api.DeleteTrustPolicy(testObj, testutil.NewCudStreamoutTrustPolicy(ctx))
@@ -175,7 +175,7 @@ func deleteTrustPolicyChecks(t *testing.T, ctx context.Context, all *AllApis, da
 
 	// inject testObj for ref tests
 	testObj, _ = dataGen.GetTrustPolicyTestObj()
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	{
 		// Negative test, Cloudlet refers to TrustPolicy.
@@ -183,7 +183,7 @@ func deleteTrustPolicyChecks(t *testing.T, ctx context.Context, all *AllApis, da
 		refBy, supportData := dataGen.GetCloudletTrustPolicyRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
 		deleteStore.putDeletePrepareCb = func() {
-			all.cloudletApi.store.Put(ctx, refBy, all.cloudletApi.sync.syncWait)
+			all.cloudletApi.store.Put(ctx, refBy, all.cloudletApi.sync.SyncWait)
 		}
 		testObj, _ = dataGen.GetTrustPolicyTestObj()
 		err = api.DeleteTrustPolicy(testObj, testutil.NewCudStreamoutTrustPolicy(ctx))
@@ -192,7 +192,7 @@ func deleteTrustPolicyChecks(t *testing.T, ctx context.Context, all *AllApis, da
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove Cloudlet obj
-		_, err = all.cloudletApi.store.Delete(ctx, refBy, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Delete(ctx, refBy, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from Cloudlet must succeed")
 		deleteStore.putDeletePrepareCb = nil
 		supportData.delete(t, ctx, all)

--- a/pkg/controller/trustpolicy_api_test.go
+++ b/pkg/controller/trustpolicy_api_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -32,10 +33,10 @@ func TestTrustPolicyApi(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/trustpolicyexception.auto_test.go
+++ b/pkg/controller/trustpolicyexception.auto_test.go
@@ -72,7 +72,7 @@ func CreateTrustPolicyExceptionAddRefsChecks(t *testing.T, ctx context.Context, 
 		ref := supportData.getOneApp()
 		require.NotNil(t, ref, "support data must include one referenced App")
 		ref.DeletePrepare = true
-		_, err = all.appApi.store.Put(ctx, ref, all.appApi.sync.syncWait)
+		_, err = all.appApi.store.Put(ctx, ref, all.appApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateTrustPolicyExceptionTestObj()
@@ -81,7 +81,7 @@ func CreateTrustPolicyExceptionAddRefsChecks(t *testing.T, ctx context.Context, 
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced App
 		ref.DeletePrepare = false
-		_, err = all.appApi.store.Put(ctx, ref, all.appApi.sync.syncWait)
+		_, err = all.appApi.store.Put(ctx, ref, all.appApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 	{
@@ -89,7 +89,7 @@ func CreateTrustPolicyExceptionAddRefsChecks(t *testing.T, ctx context.Context, 
 		ref := supportData.getOneCloudletPool()
 		require.NotNil(t, ref, "support data must include one referenced CloudletPool")
 		ref.DeletePrepare = true
-		_, err = all.cloudletPoolApi.store.Put(ctx, ref, all.cloudletPoolApi.sync.syncWait)
+		_, err = all.cloudletPoolApi.store.Put(ctx, ref, all.cloudletPoolApi.sync.SyncWait)
 		require.Nil(t, err)
 		// api call must fail with object being deleted
 		testObj, _ = dataGen.GetCreateTrustPolicyExceptionTestObj()
@@ -98,7 +98,7 @@ func CreateTrustPolicyExceptionAddRefsChecks(t *testing.T, ctx context.Context, 
 		require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 		// reset delete_prepare on referenced CloudletPool
 		ref.DeletePrepare = false
-		_, err = all.cloudletPoolApi.store.Put(ctx, ref, all.cloudletPoolApi.sync.syncWait)
+		_, err = all.cloudletPoolApi.store.Put(ctx, ref, all.cloudletPoolApi.sync.SyncWait)
 		require.Nil(t, err)
 	}
 

--- a/pkg/controller/trustpolicyexception_api.go
+++ b/pkg/controller/trustpolicyexception_api.go
@@ -19,23 +19,24 @@ import (
 	"fmt"
 	"strings"
 
-	"go.etcd.io/etcd/client/v3/concurrency"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
+	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
 type TrustPolicyExceptionApi struct {
 	all   *AllApis
-	sync  *Sync
+	sync  *regiondata.Sync
 	store edgeproto.TrustPolicyExceptionStore
 	cache edgeproto.TrustPolicyExceptionCache
 }
 
-func NewTrustPolicyExceptionApi(sync *Sync, all *AllApis) *TrustPolicyExceptionApi {
+func NewTrustPolicyExceptionApi(sync *regiondata.Sync, all *AllApis) *TrustPolicyExceptionApi {
 	trustPolicyExceptionApi := TrustPolicyExceptionApi{}
 	trustPolicyExceptionApi.all = all
 	trustPolicyExceptionApi.sync = sync
-	trustPolicyExceptionApi.store = edgeproto.NewTrustPolicyExceptionStore(sync.store)
+	trustPolicyExceptionApi.store = edgeproto.NewTrustPolicyExceptionStore(sync.GetKVStore())
 	edgeproto.InitTrustPolicyExceptionCache(&trustPolicyExceptionApi.cache)
 	sync.RegisterCache(&trustPolicyExceptionApi.cache)
 	return &trustPolicyExceptionApi
@@ -154,7 +155,7 @@ func (s *TrustPolicyExceptionApi) DeleteTrustPolicyException(ctx context.Context
 	if !s.cache.HasKey(&in.Key) {
 		return nil, in.Key.NotFoundError()
 	}
-	_, err := s.store.Delete(ctx, in, s.sync.syncWait)
+	_, err := s.store.Delete(ctx, in, s.sync.SyncWait)
 	return &edgeproto.Result{}, err
 }
 

--- a/pkg/controller/trustpolicyexception_api_test.go
+++ b/pkg/controller/trustpolicyexception_api_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/ccrmdummy"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -33,10 +34,10 @@ func TestTrustPolicyExceptionApi(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/upgrade_test.go
+++ b/pkg/controller/upgrade_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/objstore"
 	"github.com/edgexr/edge-cloud-platform/pkg/process"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/pkg/vault"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/google/go-cmp/cmp"
@@ -276,7 +277,7 @@ func getTestFileName(funcName, suffix string) string {
 // Verify that the resulting content in etcd matches expected
 func TestAllUpgradeFuncs(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelUpgrade | log.DebugLevelApi)
-	objStore := dummyEtcd{}
+	objStore := regiondata.InMemoryStore{}
 	objstore.InitRegion(1)
 	log.InitTracer(nil)
 	defer log.FinishTracer()
@@ -297,7 +298,7 @@ func TestAllUpgradeFuncs(t *testing.T) {
 	// because the appinst_api_test sets it to something else.
 	*appDNSRoot = "appdnsroot.net"
 
-	sync := InitSync(&objStore)
+	sync := regiondata.InitSync(&objStore)
 	apis := NewAllApis(sync)
 
 	// Start in-memory Vault for upgrade funcs that upgrade Vault data

--- a/pkg/controller/vmpool.auto_test.go
+++ b/pkg/controller/vmpool.auto_test.go
@@ -152,7 +152,7 @@ func deleteVMPoolChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen
 	testObj, supportData := dataGen.GetVMPoolTestObj()
 	supportData.put(t, ctx, all)
 	defer supportData.delete(t, ctx, all)
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	// Positive test, delete should succeed without any references.
 	// The overrided store checks that delete prepare was set on the
@@ -164,7 +164,7 @@ func deleteVMPoolChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen
 	// Negative test, inject testObj with delete prepare already set.
 	testObj, _ = dataGen.GetVMPoolTestObj()
 	testObj.DeletePrepare = true
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 	// delete should fail with already being deleted
 	testObj, _ = dataGen.GetVMPoolTestObj()
 	_, err = api.DeleteVMPool(ctx, testObj)
@@ -175,7 +175,7 @@ func deleteVMPoolChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen
 
 	// inject testObj for ref tests
 	testObj, _ = dataGen.GetVMPoolTestObj()
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	{
 		// Negative test, Cloudlet refers to VMPool.
@@ -183,7 +183,7 @@ func deleteVMPoolChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen
 		refBy, supportData := dataGen.GetCloudletVmPoolRef(testObj.GetKey())
 		supportData.put(t, ctx, all)
 		deleteStore.putDeletePrepareCb = func() {
-			all.cloudletApi.store.Put(ctx, refBy, all.cloudletApi.sync.syncWait)
+			all.cloudletApi.store.Put(ctx, refBy, all.cloudletApi.sync.SyncWait)
 		}
 		testObj, _ = dataGen.GetVMPoolTestObj()
 		_, err = api.DeleteVMPool(ctx, testObj)
@@ -192,7 +192,7 @@ func deleteVMPoolChecks(t *testing.T, ctx context.Context, all *AllApis, dataGen
 		// check that delete prepare was reset
 		deleteStore.requireUndoDeletePrepare(ctx, testObj)
 		// remove Cloudlet obj
-		_, err = all.cloudletApi.store.Delete(ctx, refBy, all.cloudletApi.sync.syncWait)
+		_, err = all.cloudletApi.store.Delete(ctx, refBy, all.cloudletApi.sync.SyncWait)
 		require.Nil(t, err, "cleanup ref from Cloudlet must succeed")
 		deleteStore.putDeletePrepareCb = nil
 		supportData.delete(t, ctx, all)

--- a/pkg/controller/vmpool_api.go
+++ b/pkg/controller/vmpool_api.go
@@ -20,21 +20,22 @@ import (
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
 type VMPoolApi struct {
 	all   *AllApis
-	sync  *Sync
+	sync  *regiondata.Sync
 	store edgeproto.VMPoolStore
 	cache edgeproto.VMPoolCache
 }
 
-func NewVMPoolApi(sync *Sync, all *AllApis) *VMPoolApi {
+func NewVMPoolApi(sync *regiondata.Sync, all *AllApis) *VMPoolApi {
 	vmPoolApi := VMPoolApi{}
 	vmPoolApi.all = all
 	vmPoolApi.sync = sync
-	vmPoolApi.store = edgeproto.NewVMPoolStore(sync.store)
+	vmPoolApi.store = edgeproto.NewVMPoolStore(sync.GetKVStore())
 	edgeproto.InitVMPoolCache(&vmPoolApi.cache)
 	sync.RegisterCache(&vmPoolApi.cache)
 	return &vmPoolApi

--- a/pkg/controller/vmpool_api_test.go
+++ b/pkg/controller/vmpool_api_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 	"github.com/edgexr/edge-cloud-platform/test/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -33,10 +34,10 @@ func TestVMPoolApi(t *testing.T) {
 	testSvcs := testinit(ctx, t)
 	defer testfinish(testSvcs)
 
-	dummy := dummyEtcd{}
+	dummy := regiondata.InMemoryStore{}
 	dummy.Start()
 
-	sync := InitSync(&dummy)
+	sync := regiondata.InitSync(&dummy)
 	apis := NewAllApis(sync)
 	sync.Start()
 	defer sync.Done()

--- a/pkg/controller/vmpoolinfo_api.go
+++ b/pkg/controller/vmpoolinfo_api.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/regiondata"
 )
 
 type VMPoolInfoApi struct {
@@ -25,7 +26,7 @@ type VMPoolInfoApi struct {
 	cache edgeproto.VMPoolInfoCache
 }
 
-func NewVMPoolInfoApi(sync *Sync, all *AllApis) *VMPoolInfoApi {
+func NewVMPoolInfoApi(sync *regiondata.Sync, all *AllApis) *VMPoolInfoApi {
 	vmPoolInfoApi := VMPoolInfoApi{}
 	vmPoolInfoApi.all = all
 	edgeproto.InitVMPoolInfoCache(&vmPoolInfoApi.cache)

--- a/pkg/regiondata/etcd.go
+++ b/pkg/regiondata/etcd.go
@@ -14,7 +14,7 @@
 
 // Start etcd
 
-package controller
+package regiondata
 
 import (
 	"context"
@@ -322,7 +322,6 @@ func (e *EtcdClient) Sync(ctx context.Context, key string, cb objstore.SyncCb) e
 				} else {
 					data.MoreEvents = true
 				}
-				log.SpanLog(spctx, log.DebugLevelEtcd, "watch data", "key", string(data.Key), "val", string(data.Value), "more-events", data.MoreEvents)
 				cb(spctx, &data)
 			}
 			span.Finish()

--- a/pkg/regiondata/etcd_lease_test.go
+++ b/pkg/regiondata/etcd_lease_test.go
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build slow
 // +build slow
+
 // To run this unit test, run:
 // go test -tags=slow
 // or:
 // go test -run TestEtcdLease -v -tags=slow
 
-package controller
+package regiondata
 
 import (
 	"context"

--- a/pkg/regiondata/etcd_server.go
+++ b/pkg/regiondata/etcd_server.go
@@ -15,7 +15,7 @@
 // Run Etcd as a child process.
 // May be useful for testing and initial development.
 
-package controller
+package regiondata
 
 import (
 	"fmt"

--- a/pkg/regiondata/etcd_test.go
+++ b/pkg/regiondata/etcd_test.go
@@ -14,7 +14,7 @@
 
 // test etcd process
 
-package controller
+package regiondata
 
 import (
 	"context"
@@ -24,10 +24,10 @@ import (
 	"testing"
 	"time"
 
-	"go.etcd.io/etcd/client/v3/concurrency"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/objstore"
 	"github.com/stretchr/testify/assert"
+	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
 func expectNewRev(t *testing.T, expRev *int64, checkRev int64) {
@@ -322,7 +322,7 @@ func testCalls(t *testing.T, objStore objstore.KVStore) {
 
 func TestEtcdDummy(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelEtcd)
-	dummy := dummyEtcd{}
+	dummy := InMemoryStore{}
 	dummy.Start()
 	testCalls(t, &dummy)
 	dummy.Stop()

--- a/pkg/regiondata/sync_test.go
+++ b/pkg/regiondata/sync_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controller
+package regiondata
 
 import (
 	"testing"

--- a/tools/protoc-gen-controller-test/addrefs-test.go
+++ b/tools/protoc-gen-controller-test/addrefs-test.go
@@ -63,7 +63,7 @@ func {{.Api}}AddRefsChecks(t *testing.T, ctx context.Context, all *AllApis, data
 	ref := supportData.getOne{{.Type}}()
 	require.NotNil(t, ref, "support data must include one referenced {{.Type}}")
 	ref.{{.DeletePrepareField}} = true
-	_, err = all.{{.ApiObj}}.store.Put(ctx, ref, all.{{.ApiObj}}.sync.syncWait)
+	_, err = all.{{.ApiObj}}.store.Put(ctx, ref, all.{{.ApiObj}}.sync.SyncWait)
 	require.Nil(t, err)
 	// api call must fail with object being deleted
 {{- template "runApi" $}}
@@ -71,7 +71,7 @@ func {{.Api}}AddRefsChecks(t *testing.T, ctx context.Context, all *AllApis, data
 	require.Equal(t, ref.GetKey().BeingDeletedError().Error(), err.Error())
 	// reset delete_prepare on referenced {{.Type}}
 	ref.{{.DeletePrepareField}} = false
-	_, err = all.{{.ApiObj}}.store.Put(ctx, ref, all.{{.ApiObj}}.sync.syncWait)
+	_, err = all.{{.ApiObj}}.store.Put(ctx, ref, all.{{.ApiObj}}.sync.SyncWait)
 	require.Nil(t, err)
 	}
 {{- end}}

--- a/tools/protoc-gen-controller-test/alldata-test.go
+++ b/tools/protoc-gen-controller-test/alldata-test.go
@@ -43,12 +43,12 @@ func (s *testSupportData) put(t *testing.T, ctx context.Context, all *AllApis) {
 {{- range .Fields}}
 {{- if .Repeated}}
 	for _, obj := range s.{{.Name}} {
-		_, err := all.{{.ApiObj}}.store.Put(ctx, &obj, all.{{.ApiObj}}.sync.syncWait)
+		_, err := all.{{.ApiObj}}.store.Put(ctx, &obj, all.{{.ApiObj}}.sync.SyncWait)
 		require.Nil(t, err)
 	}
 {{- else}}
 	if s.{{.Name}} != nil {
-		_, err := all.{{.ApiObj}}.store.Put(ctx, s.{{.Name}}, all.{{.ApiObj}}.sync.syncWait)
+		_, err := all.{{.ApiObj}}.store.Put(ctx, s.{{.Name}}, all.{{.ApiObj}}.sync.SyncWait)
 		require.Nil(t, err)
 	}
 {{- end}}
@@ -59,12 +59,12 @@ func (s *testSupportData) delete(t *testing.T, ctx context.Context, all *AllApis
 {{- range .FieldsReverse}}
 {{- if .Repeated}}
 	for _, obj := range s.{{.Name}} {
-		_, err := all.{{.ApiObj}}.store.Delete(ctx, &obj, all.{{.ApiObj}}.sync.syncWait)
+		_, err := all.{{.ApiObj}}.store.Delete(ctx, &obj, all.{{.ApiObj}}.sync.SyncWait)
 		require.Nil(t, err)
 	}
 {{- else}}
 	if s.{{.Name}} != nil {
-		_, err := all.{{.ApiObj}}.store.Delete(ctx, s.{{.Name}}, all.{{.ApiObj}}.sync.syncWait)
+		_, err := all.{{.ApiObj}}.store.Delete(ctx, s.{{.Name}}, all.{{.ApiObj}}.sync.SyncWait)
 		require.Nil(t, err)
 	}
 {{- end}}

--- a/tools/protoc-gen-controller-test/delete-test.go
+++ b/tools/protoc-gen-controller-test/delete-test.go
@@ -170,7 +170,7 @@ func delete{{.Type}}Checks(t *testing.T, ctx context.Context, all *AllApis, data
 	testObj, supportData := dataGen.Get{{.Type}}TestObj()
 	supportData.put(t, ctx, all)
 	defer supportData.delete(t, ctx, all)
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 
 	// Positive test, delete should succeed without any references.
 	// The overrided store checks that delete prepare was set on the
@@ -197,7 +197,7 @@ func delete{{.Type}}Checks(t *testing.T, ctx context.Context, all *AllApis, data
 	// Negative test, inject testObj with delete prepare already set.
 	testObj, _ = dataGen.Get{{.Type}}TestObj()
 	testObj.{{.DeletePrepareField}} = true
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 	// delete should fail with already being deleted
 {{- template "runDelete" .}}
 	require.NotNil(t, err, "delete must fail if already being deleted")
@@ -207,7 +207,7 @@ func delete{{.Type}}Checks(t *testing.T, ctx context.Context, all *AllApis, data
 
 	// inject testObj for ref tests
 	testObj, _ = dataGen.Get{{.Type}}TestObj()
-	origStore.Put(ctx, testObj, api.sync.syncWait)
+	origStore.Put(ctx, testObj, api.sync.SyncWait)
 {{range .RefBys}}
 	{
 	// Negative test, {{.Type}} refers to {{$.Type}}.
@@ -215,7 +215,7 @@ func delete{{.Type}}Checks(t *testing.T, ctx context.Context, all *AllApis, data
 	refBy, supportData := dataGen.Get{{.ObjField}}Ref(testObj.GetKey())
 	supportData.put(t, ctx, all)
 	deleteStore.putDeletePrepareCb = func() {
-		all.{{.ApiObj}}.store.Put(ctx, refBy, all.{{.ApiObj}}.sync.syncWait)
+		all.{{.ApiObj}}.store.Put(ctx, refBy, all.{{.ApiObj}}.sync.SyncWait)
 	}
 {{- template "runDelete" $}}
 	require.NotNil(t, err, "must fail delete with ref from {{.Type}}")
@@ -223,7 +223,7 @@ func delete{{.Type}}Checks(t *testing.T, ctx context.Context, all *AllApis, data
 	// check that delete prepare was reset
 	deleteStore.requireUndoDeletePrepare(ctx, testObj)
 	// remove {{.Type}} obj
-	_, err = all.{{.ApiObj}}.store.Delete(ctx, refBy, all.{{.ApiObj}}.sync.syncWait)
+	_, err = all.{{.ApiObj}}.store.Delete(ctx, refBy, all.{{.ApiObj}}.sync.SyncWait)
 	require.Nil(t, err, "cleanup ref from {{.Type}} must succeed")
 	deleteStore.putDeletePrepareCb = nil
 	supportData.delete(t, ctx, all)
@@ -236,7 +236,7 @@ func delete{{.Type}}Checks(t *testing.T, ctx context.Context, all *AllApis, data
 	// Inject the refs object to trigger an "in use" error.
 	refBy, supportData := dataGen.Get{{.RefName}}Ref(testObj.GetKey())
 	supportData.put(t, ctx, all)
-	_, err = all.{{.ApiObj}}.store.Put(ctx, refBy, all.{{.ApiObj}}.sync.syncWait)
+	_, err = all.{{.ApiObj}}.store.Put(ctx, refBy, all.{{.ApiObj}}.sync.SyncWait)
 	require.Nil(t, err)
 {{- template "runDelete" $}}
 	require.NotNil(t, err, "delete with ref from {{.Type}} must fail")
@@ -244,7 +244,7 @@ func delete{{.Type}}Checks(t *testing.T, ctx context.Context, all *AllApis, data
 	// check that delete prepare was reset
 	deleteStore.requireUndoDeletePrepare(ctx, testObj)
 	// remove {{.Type}} obj
-	_, err = all.{{.ApiObj}}.store.Delete(ctx, refBy, all.{{.ApiObj}}.sync.syncWait)
+	_, err = all.{{.ApiObj}}.store.Delete(ctx, refBy, all.{{.ApiObj}}.sync.SyncWait)
 	require.Nil(t, err, "cleanup ref from {{.Type}} must succeed")
 	supportData.delete(t, ctx, all)
 	}


### PR DESCRIPTION
This change moves etcd-related code out of pkg/controller and into its own common package, "regiondata". This will allow the etcd code to be leveraged by the CCRM service as well as the Controller. There are no functional changes here (except to allow multiple watchers in the dummy etcd server). Everything else is just moving code around and dealing with renames.