### PR TITLE
track etcd database version ID

### DIFF
--- a/api/edgeproto/version.pb.go
+++ b/api/edgeproto/version.pb.go
@@ -250,8 +250,15 @@ var VersionHashCommonPrefix = "Hash"
 // TrustPolicyExceptionKey
 // VMPoolKey
 // VirtualClusterInstKeyV1
-var versionHashString = "eac56710c013d954db31eeb306b514a4"
 
-func GetDataModelVersion() string {
-	return versionHashString
+type DataModelVersion struct {
+	Hash string
+	ID   int32
+}
+
+func GetDataModelVersion() *DataModelVersion {
+	return &DataModelVersion{
+		Hash: "eac56710c013d954db31eeb306b514a4",
+		ID:   55,
+	}
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -668,10 +668,8 @@ func stopServices() {
 	services = Services{}
 }
 
-// Helper function to verify the compatibility of etcd version and
-// current data model version
+// get the etcd data model version
 func getDataVersion(ctx context.Context, objStore objstore.KVStore) (*edgeproto.DataModelVersion, error) {
-	// Version has value which is the hash value
 	// Version2 has value which is JSON string of edgeproto.DataModelVersion.
 	keyV2 := objstore.DbKeyPrefixString(DataModelVersion2Prefix)
 	val, _, _, err := objStore.Get(keyV2)
@@ -686,7 +684,7 @@ func getDataVersion(ctx context.Context, objStore objstore.KVStore) (*edgeproto.
 		return nil, err
 	}
 
-	// keyV2 not found, look for old key
+	// keyV2 not found, look for old key whose value is the hash value
 	key := objstore.DbKeyPrefixString(DataModelVersion0Prefix)
 	val, _, _, err = objStore.Get(key)
 	if err == nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -265,8 +266,11 @@ func startServices() error {
 	// We might need to upgrade the stored objects
 	if !*skipVersionCheck {
 		// First off - check version of the objectStore we are running
-		version, err := checkVersion(ctx, objStore)
-		if err != nil && strings.Contains(err.Error(), ErrCtrlUpgradeRequired.Error()) && *autoUpgrade {
+		version, err := getDataVersion(ctx, objStore)
+		if err != nil {
+			return fmt.Errorf("database version check failed, %s", err)
+		}
+		if *autoUpgrade && dataNeedsUpgrade(ctx, version) {
 			upgradeSupport := &UpgradeSupport{
 				region:      *region,
 				vaultConfig: vaultConfig,
@@ -666,29 +670,47 @@ func stopServices() {
 
 // Helper function to verify the compatibility of etcd version and
 // current data model version
-func checkVersion(ctx context.Context, objStore objstore.KVStore) (string, error) {
-	key := objstore.DbKeyPrefixString("Version")
-	val, _, _, err := objStore.Get(key)
-	if err != nil {
-		if !strings.Contains(err.Error(), objstore.NotFoundError(key).Error()) {
-			return "", err
-		}
-	}
-	verHash := string(val)
-	// If this is the first upgrade, just write the latest hash into etcd
-	if verHash == "" {
-		log.InfoLog("Could not find a previous version", "curr hash", edgeproto.GetDataModelVersion())
-		key := objstore.DbKeyPrefixString("Version")
-		_, err = objStore.Put(ctx, key, edgeproto.GetDataModelVersion())
+func getDataVersion(ctx context.Context, objStore objstore.KVStore) (*edgeproto.DataModelVersion, error) {
+	// Version has value which is the hash value
+	// Version2 has value which is JSON string of edgeproto.DataModelVersion.
+	keyV2 := objstore.DbKeyPrefixString(DataModelVersion2Prefix)
+	val, _, _, err := objStore.Get(keyV2)
+	if err == nil {
+		vers := edgeproto.DataModelVersion{}
+		err = json.Unmarshal(val, &vers)
 		if err != nil {
-			return "", err
+			return nil, fmt.Errorf("failed to unmarshal data model version string %s, %s", string(val), err)
 		}
-		return edgeproto.GetDataModelVersion(), nil
+		return &vers, nil
+	} else if !strings.Contains(err.Error(), objstore.NotFoundError(keyV2).Error()) {
+		return nil, err
 	}
-	if edgeproto.GetDataModelVersion() != verHash {
-		return verHash, ErrCtrlUpgradeRequired
+
+	// keyV2 not found, look for old key
+	key := objstore.DbKeyPrefixString(DataModelVersion0Prefix)
+	val, _, _, err = objStore.Get(key)
+	if err == nil {
+		vers := edgeproto.DataModelVersion{
+			Hash: string(val),
+			ID:   0,
+		}
+		return &vers, nil
+	} else if !strings.Contains(err.Error(), objstore.NotFoundError(key).Error()) {
+		return nil, err
 	}
-	return verHash, nil
+
+	// neither key found, this is the first upgrade,
+	// write the latest hash into etcd
+	log.InfoLog("Could not find a previous version", "curr version", edgeproto.GetDataModelVersion())
+	vers := edgeproto.GetDataModelVersion()
+	if err := writeDataModelVersionV2(ctx, objStore, vers); err != nil {
+		return nil, fmt.Errorf("failed to write data model version %v, %s", vers, err)
+	}
+	return vers, nil
+}
+
+func dataNeedsUpgrade(ctx context.Context, vers *edgeproto.DataModelVersion) bool {
+	return edgeproto.GetDataModelVersion().Hash != vers.Hash
 }
 
 type AllApis struct {

--- a/pkg/controller/upgrade_funcs.go
+++ b/pkg/controller/upgrade_funcs.go
@@ -93,7 +93,7 @@ type ClusterRefsV1 struct {
 	Apps []AppInstRefKeyV1 `json:"apps"`
 }
 
-func AddStaticFqdn(ctx context.Context, objStore objstore.KVStore, allApis *AllApis, sup *UpgradeSupport) error {
+func AddStaticFqdn(ctx context.Context, objStore objstore.KVStore, allApis *AllApis, sup *UpgradeSupport, dbModelID int32) error {
 	// 1. Update cloudlets - set StaticRootLbFqdn
 	cloudletKeys, err := getDbObjectKeys(objStore, "Cloudlet")
 	if err != nil {
@@ -198,7 +198,7 @@ func AddStaticFqdn(ctx context.Context, objStore objstore.KVStore, allApis *AllA
 	return nil
 }
 
-func UpgradeCrmOnEdge(ctx context.Context, objStore objstore.KVStore, allApis *AllApis, sup *UpgradeSupport) error {
+func UpgradeCrmOnEdge(ctx context.Context, objStore objstore.KVStore, allApis *AllApis, sup *UpgradeSupport, dbModelID int32) error {
 	log.SpanLog(ctx, log.DebugLevelUpgrade, "CrmOnEdge")
 
 	cloudletKeys, err := getDbObjectKeys(objStore, "Cloudlet")
@@ -309,11 +309,11 @@ func UpgradeCrmOnEdge(ctx context.Context, objStore objstore.KVStore, allApis *A
 // of the AppInst/ClusterInst Key and onto the object body, changing
 // the unique key. Also, this requires the instance name to be unique
 // within the entire region instead of within a cloudlet scope.
-func InstanceKeysRegionScopedName(ctx context.Context, objStore objstore.KVStore, allApis *AllApis, sup *UpgradeSupport) error {
+func InstanceKeysRegionScopedName(ctx context.Context, objStore objstore.KVStore, allApis *AllApis, sup *UpgradeSupport, dbModelID int32) error {
 	// Unfortunately the last upgrade func had a bug which failed to
 	// asign object IDs to AppInsts and ClusterInsts. We run the fixed
 	// version here again. Note that all upgrade functions must be idempotent.
-	err := UpgradeCrmOnEdge(ctx, objStore, allApis, sup)
+	err := UpgradeCrmOnEdge(ctx, objStore, allApis, sup, dbModelID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This tracks the data model version ID in addition to the hash value in the etcd database. The model version ID is a monotonically increasing integer, and can be used to determine if an upgrade has been upgrade or not, regardless of whether the current software is still tracking the upgrade associated with it.

The intent here is to be able to tag objects with a db model version ID to guarantee that upgrade functions are idempotent. So far upgrade functions guarantee idempotency by looking at the current data in the object. This does not work for new non-nil fields that need to be set on upgrade, but may be cleared by the user later on. Consider the "CrmOnEdge" bool. On upgrade we need to set it "true" because all existing cloudlets use Crms on Edge. However, new cloudlets may not use crm on edge, so may set it to false. Therefore there is no way to tell from a false CrmOnEdge value if the cloudlet needs to be upgraded or not. As an aside, the CrmOnEdge upgrade function guarantees idempotency by looking at the "ObjId" field which does not have the same issue, and is part of the same upgrade.

The intent here then is to add a "dbModelVersion int32" field to an object, like Cloudlet, and compare that to the ID for the running upgrade function to tell if the object needs to be upgraded or not. This will be used for the Zone upgrade feature which adds a string field to the Cloudlet.