### PR TITLE
clusterrefs upgrade fix

### DIFF
--- a/api/edgeproto/unmarshal_bc.go
+++ b/api/edgeproto/unmarshal_bc.go
@@ -81,28 +81,25 @@ func BindJSONClusterRefsV2(refs *ClusterRefs, jsonData []byte) (*CloudletKey, er
 // the parent object, and the jsonData corresponds to the parent.
 // Examples of this are ClusterInstInfo, ClusterRefs.
 func bindJSONObjectWithClusterInstKeyV2(objKey *ClusterKey, jsonData []byte) (*CloudletKey, error) {
-	if objKey.IsEmpty() {
-		// read the cluster key from the old location
-		out, _, _, err := jsonparser.Get(jsonData, "key", "cluster_key")
-		if err == nil {
-			// data was found, unmarshal it
-			err = json.Unmarshal(out, objKey)
-			if err != nil {
-				return nil, err
-			}
+	// read the cluster key from the old location
+	out, _, _, err := jsonparser.Get(jsonData, "key", "cluster_key")
+	if err == nil {
+		// data was found, unmarshal it
+		err = json.Unmarshal(out, objKey)
+		if err != nil {
+			return nil, err
 		}
-		cloudletKey := CloudletKey{}
-		out, _, _, err = jsonparser.Get(jsonData, "key", "cloudlet_key")
-		if err == nil {
-			// data was found, unmarshal it
-			err = json.Unmarshal(out, &cloudletKey)
-			if err != nil {
-				return nil, err
-			}
-		}
-		return &cloudletKey, nil
 	}
-	return nil, nil
+	cloudletKey := CloudletKey{}
+	out, _, _, err = jsonparser.Get(jsonData, "key", "cloudlet_key")
+	if err == nil {
+		// data was found, unmarshal it
+		err = json.Unmarshal(out, &cloudletKey)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &cloudletKey, nil
 }
 
 // BindJSONAppInstKeyV2 reads jsonData corresponding to either

--- a/pkg/controller/upgrade_funcs.go
+++ b/pkg/controller/upgrade_funcs.go
@@ -184,6 +184,10 @@ func AppInstKeyName(ctx context.Context, objStore objstore.KVStore, allApis *All
 				updated = true
 			}
 			if updated {
+				// sort refs for determinism
+				sort.Slice(refs.Apps, func(i, j int) bool {
+					return refs.Apps[i].GetKeyString() < refs.Apps[j].GetKeyString()
+				})
 				allApis.clusterRefsApi.store.STMPut(stm, &refs)
 			}
 			return nil

--- a/pkg/controller/upgrade_funcs.go
+++ b/pkg/controller/upgrade_funcs.go
@@ -353,6 +353,7 @@ func UpgradeCrmOnEdge(ctx context.Context, objStore objstore.KVStore, allApis *A
 			data := map[string]any{}
 			err := json.Unmarshal([]byte(appInstStr), &data)
 			if err != nil {
+				log.SpanLog(ctx, log.DebugLevelUpgrade, "Upgrade unmarshal object failed", "objType", "appInst", "key", appInstKey, "val", appInstStr, "err", err)
 				return err
 			}
 			if _, ok := data["obj_id"]; ok {
@@ -388,6 +389,7 @@ func UpgradeCrmOnEdge(ctx context.Context, objStore objstore.KVStore, allApis *A
 			data := map[string]any{}
 			err := json.Unmarshal([]byte(clusterInstStr), &data)
 			if err != nil {
+				log.SpanLog(ctx, log.DebugLevelUpgrade, "Upgrade unmarshal object failed", "objType", "clusterInst", "key", key, "val", clusterInstStr, "err", err)
 				return err
 			}
 			if _, ok := data["obj_id"]; ok {
@@ -620,7 +622,7 @@ func InstanceKeysRegionScopedName(ctx context.Context, objStore objstore.KVStore
 					ClusterKey:  cikey,
 					CloudletKey: refs.Key,
 				}
-				if newKey, ok := ciUpdatedNames[v2]; ok && !newKey.Matches(&cikey) {
+				if newKey, ok := ciUpdatedNames[v2]; ok {
 					refs.ClusterInsts[ii] = newKey
 					updated = true
 				}
@@ -632,7 +634,7 @@ func InstanceKeysRegionScopedName(ctx context.Context, objStore objstore.KVStore
 					Organization: aikey.Organization,
 					CloudletKey:  refs.Key,
 				}
-				if newKey, ok := aiUpdatedNames[v2]; ok && !newKey.Matches(&aikey) {
+				if newKey, ok := aiUpdatedNames[v2]; ok {
 					refs.VmAppInsts[ii] = newKey
 					updated = true
 				}
@@ -644,7 +646,7 @@ func InstanceKeysRegionScopedName(ctx context.Context, objStore objstore.KVStore
 					Organization: aikey.Organization,
 					CloudletKey:  refs.Key,
 				}
-				if newKey, ok := aiUpdatedNames[v2]; ok && !newKey.Matches(&aikey) {
+				if newKey, ok := aiUpdatedNames[v2]; ok {
 					refs.K8SAppInsts[ii] = newKey
 					updated = true
 				}
@@ -706,7 +708,7 @@ func InstanceKeysRegionScopedName(ctx context.Context, objStore objstore.KVStore
 					// invalid ref, skip it, we'll rebuild clusterRefs
 					// at the end anyway.
 				}
-				if newKey, ok := aiUpdatedNames[v2]; ok && !newKey.Matches(&aikey) {
+				if newKey, ok := aiUpdatedNames[v2]; ok {
 					refs.Apps[ii] = newKey
 				}
 			}
@@ -736,7 +738,7 @@ func InstanceKeysRegionScopedName(ctx context.Context, objStore objstore.KVStore
 			// update insts refs from AppInstKeyV2 to AppInstKey
 			updated := false
 			for str, val := range refs.Insts {
-				key, v2, err := edgeproto.BindJSONAppInstKeyV2([]byte(str))
+				_, v2, err := edgeproto.BindJSONAppInstKeyV2([]byte(str))
 				if err != nil {
 					return err
 				}
@@ -744,7 +746,7 @@ func InstanceKeysRegionScopedName(ctx context.Context, objStore objstore.KVStore
 					// already upgraded
 					continue
 				}
-				if newKey, ok := aiUpdatedNames[*v2]; ok && !newKey.Matches(key) {
+				if newKey, ok := aiUpdatedNames[*v2]; ok {
 					newStr, err := json.Marshal(newKey)
 					if err != nil {
 						return err

--- a/pkg/controller/upgrade_testfiles/InstanceKeysRegionScopedName_post.etcd
+++ b/pkg/controller/upgrade_testfiles/InstanceKeysRegionScopedName_post.etcd
@@ -16,6 +16,10 @@
 {"key":{"name":"noconflict","organization":"edgecloudorg"},"app_key":{},"cluster_key":{},"cloudlet_key":{"organization":"oper1","name":"cloudlet1"},"cloudlet_loc":{},"mapped_ports":null,"flavor":{},"runtime_info":{},"created_at":"","updated_at":"","fed_key":{},"virtual_cluster_key":{},"obj_id":"1"}
 1/AppInst/{"name":"noconflict2","organization":"edgecloudorg"}
 {"key":{"name":"noconflict2","organization":"edgecloudorg"},"app_key":{},"cluster_key":{},"cloudlet_key":{"organization":"oper1","name":"cloudlet1"},"cloudlet_loc":{},"mapped_ports":null,"flavor":{},"runtime_info":{},"created_at":"","updated_at":"","fed_key":{},"virtual_cluster_key":{},"obj_id":"2"}
+1/AppInst/{"name":"ref2","organization":"edgecloudorg"}
+{"key":{"name":"ref2","organization":"edgecloudorg"},"app_key":{},"cluster_key":{"name":"reservable0","organization":"edgecloudorg"},"cloudlet_key":{"organization":"oper1","name":"cloudletx"},"cloudlet_loc":{},"mapped_ports":null,"flavor":{},"runtime_info":{},"created_at":"","updated_at":"","fed_key":{},"virtual_cluster_key":{},"obj_id":"10"}
+1/AppInst/{"name":"ref2a","organization":"edgecloudorg"}
+{"key":{"name":"ref2a","organization":"edgecloudorg"},"app_key":{},"cluster_key":{"name":"reservable0","organization":"edgecloudorg"},"cloudlet_key":{"organization":"oper1","name":"cloudletx"},"cloudlet_loc":{},"mapped_ports":null,"flavor":{},"runtime_info":{},"created_at":"","updated_at":"","fed_key":{},"virtual_cluster_key":{},"obj_id":"11"}
 1/AppInstRefs/{"organization":"edgecloudorg","name":"app1","version":"1.0"}
 {"key":{"organization":"edgecloudorg","name":"app1","version":"1.0"},"insts":{"{\"name\":\"conflict-132bad5b\",\"organization\":\"edgecloudorg\"}":1},"delete_requested_insts":null}
 1/CloudletRefs/{"organization":"oper1","name":"cloudlet1"}
@@ -54,3 +58,5 @@
 {"key":{"name":"conflict-132bad5b","organization":"dev1"},"apps":[{"name":"conflict-132bad5b","organization":"edgecloudorg"}]}
 1/ClusterRefs/{"name":"noconflict","organization":"dev1"}
 {"key":{"name":"noconflict","organization":"dev1"},"apps":[{"name":"noconflict","organization":"edgecloudorg"},{"name":"noconflict2","organization":"edgecloudorg"},{"name":"conflict","organization":"edgecloudorg"}]}
+1/ClusterRefs/{"name":"reservable0","organization":"edgecloudorg"}
+{"key":{"name":"reservable0","organization":"edgecloudorg"},"apps":[{"name":"ref2","organization":"edgecloudorg"},{"name":"ref2a","organization":"edgecloudorg"}]}

--- a/pkg/controller/upgrade_testfiles/InstanceKeysRegionScopedName_pre.etcd
+++ b/pkg/controller/upgrade_testfiles/InstanceKeysRegionScopedName_pre.etcd
@@ -79,5 +79,17 @@
 1/ClusterRefs/{"cluster_key":{"name":"conflict","organization":"dev1},"cloudlet_key":{"organization":"oper1","name":"cloudlet7"}}
 {"key":{"cluster_key":{"name":"conflict","organization":"dev1"},"cloudlet_key":{"organization":"oper1","name":"cloudlet7"}},"apps":[{"name":"conflict","organization":"edgecloudorg"}]}
 
+1/AppInst/{"name":"ref2","organization":"edgecloudorg","cloudlet_key":{"organization":"oper1","name":"cloudletx"}}
+{"key":{"name":"ref2","organization":"edgecloudorg","cloudlet_key":{"organization":"oper1","name":"cloudletx"}},"cluster_key":{"name":"reservable0","organization":"edgecloudorg"},"obj_id":"10"}
+
+1/AppInst/{"name":"ref2a","organization":"edgecloudorg","cloudlet_key":{"organization":"oper1","name":"cloudletx"}}
+{"key":{"name":"ref2a","organization":"edgecloudorg","cloudlet_key":{"organization":"oper1","name":"cloudletx"}},"cluster_key":{"name":"reservable0","organization":"edgecloudorg"},"obj_id":"11"}
+
+1/ClusterRefs/{"cluster_key":{"name":"reservable0"},"cloudlet_key":{"organization":"oper1","name":"cloudletx"},"organization":"edgecloudorg"}
+{"key":{"cluster_key":{"name":"reservable0"},"cloudlet_key":{"organization":"oper1","name":"cloudletx"},"organization":"edgecloudorg"},"apps":[{"app_key":{"organization":"EdgeXR-Dev","name":"ComputerVision","version":"2.2"},"v_cluster_name":"autoclustercomputervision"},{"app_key":{"organization":"edgecloudorg","name":"MEXPrometheusAppName","version":"1.0"},"v_cluster_name":"reservable0"}]}
+
+1/ClusterRefs/{"cluster_key":{"name":"reservable0"},"cloudlet_key":{"organization":"oper1","name":"nosuchcloudlet"},"organization":"edgecloudorg"}
+{"key":{"cluster_key":{"name":"reservable0"},"cloudlet_key":{"organization":"oper1","name":"nosuchcloudlet"},"organization":"edgecloudorg"},"apps":[{"app_key":{"organization":"EdgeXR-Dev","name":"ComputerVision","version":"2.2"},"v_cluster_name":"autoclustercomputervision"},{"app_key":{"organization":"edgecloudorg","name":"MEXPrometheusAppName","version":"1.0"},"v_cluster_name":"reservable0"}]}
+
 1/AppInstRefs/{"organization":"edgecloudorg","name":"app1","version":"1.0"}
 {"key":{"organization":"edgecloudorg","name":"app1","version":"1.0"},"insts":{"{\"name\":\"conflict\",\"organization\":\"edgecloudorg\",\"cloudlet_key\":{\"organization\":\"oper1\",\"name\":\"cloudlet7\"}}":1}}


### PR DESCRIPTION
The AppInstKeyName upgrade function failed to upgrade ClusterRefs properly. As a result the database is now in a state of old and new clusterRefs, the old ones which still refer to AppInsts by AppKey+CloudletKey.

This change fixes an issue with the InstanceKeysRegionScopedName function hitting errors on these old formats, and also adds another upgrade function to fix the old clusterRefs.

The additional upgrade function fixes clusterRefs by rebuilding them from existing AppInsts.