### PR TITLE
upgrade fixes again

### DIFF
--- a/api/edgeproto/objs.go
+++ b/api/edgeproto/objs.go
@@ -1485,3 +1485,25 @@ func (s *AppInst) AddTags(tags map[string]string) {
 	s.ClusterKey.AddTags(tags)
 	s.CloudletKey.AddTags(tags)
 }
+
+func (s *AppInst) AddAnnotationNoClobber(key, val string) bool {
+	if s.Annotations == nil {
+		s.Annotations = map[string]string{}
+	}
+	if _, ok := s.Annotations[key]; ok {
+		return false
+	}
+	s.Annotations[key] = val
+	return true
+}
+
+func (s *ClusterInst) AddAnnotationNoClobber(key, val string) bool {
+	if s.Annotations == nil {
+		s.Annotations = map[string]string{}
+	}
+	if _, ok := s.Annotations[key]; ok {
+		return false
+	}
+	s.Annotations[key] = val
+	return true
+}

--- a/pkg/cloudcommon/names.go
+++ b/pkg/cloudcommon/names.go
@@ -256,6 +256,7 @@ const (
 
 const (
 	AnnotationCloudletScopedName = "cloudlet-scoped-name"
+	AnnotationBadUpgrade55Name   = "bad-upgrade55-name"
 )
 
 var InstanceUp = "UP"
@@ -624,7 +625,13 @@ func ParseReservableClusterName(name string) (int, string, error) {
 	if err != nil {
 		return 0, "", fmt.Errorf("parse reservable cluster name failed to extract numeric id %s from %s, %s", parts[0], name, err)
 	}
-	return id, parts[1], nil
+	// Note: parser MUST be able to handle old name format, which was
+	// reservable<ID>, where ID is a positive integer.
+	hash := ""
+	if len(parts) > 1 {
+		hash = parts[1]
+	}
+	return id, hash, nil
 }
 
 func GetDefaultMTClustKey(cloudletKey edgeproto.CloudletKey) *edgeproto.ClusterKey {

--- a/pkg/controller/upgrade_test.go
+++ b/pkg/controller/upgrade_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 	"testing"
 	"time"
 
@@ -83,9 +82,6 @@ func scanEtcdFile(ctx context.Context, file *os.File, cb func(ctx context.Contex
 			key = scanner.Text()
 			lineno++
 			if key != "" {
-				if !strings.HasPrefix(key, "1/") {
-					return fmt.Errorf("invalid key %s on line %d", key, lineno)
-				}
 				break
 			}
 		}

--- a/pkg/controller/upgrade_testfiles/InstanceKeysRegionScopedName_post.etcd
+++ b/pkg/controller/upgrade_testfiles/InstanceKeysRegionScopedName_post.etcd
@@ -58,5 +58,3 @@
 {"key":{"name":"conflict-132bad5b","organization":"dev1"},"apps":[{"name":"conflict-132bad5b","organization":"edgecloudorg"}]}
 1/ClusterRefs/{"name":"noconflict","organization":"dev1"}
 {"key":{"name":"noconflict","organization":"dev1"},"apps":[{"name":"noconflict","organization":"edgecloudorg"},{"name":"noconflict2","organization":"edgecloudorg"},{"name":"conflict","organization":"edgecloudorg"}]}
-1/ClusterRefs/{"name":"reservable0","organization":"edgecloudorg"}
-{"key":{"name":"reservable0","organization":"edgecloudorg"},"apps":[{"name":"ref2","organization":"edgecloudorg"},{"name":"ref2a","organization":"edgecloudorg"}]}


### PR DESCRIPTION
The previous upgrade function had two problems:
- For AppInsts, we did not update the ClusterInst key with the new name if the ClusterInst name was changed.
- For reservable ClusterInsts, the name format generated by the upgrade function was incorrect. It was just appending a number to avoid conflicts, however for reservable ClusterInsts the system wants to append the cloudlet hash. This supports the previous method of using IDs to generate unique names.

This upgrade function must be able to upgrade old data, broken data from the previous upgrade, and new data (no-op).

Unfortunately because I needed to swap the order of the ClusterInsts and AppInsts processing in the upgrade function, the diff is a bit ugly. There's really not that many changes.