### PR TITLE
Delete consistency check after upgrade test

### DIFF
--- a/api/edgeproto/alert.pb.go
+++ b/api/edgeproto/alert.pb.go
@@ -701,6 +701,21 @@ func (s *AlertStoreImpl) STMDel(stm concurrency.STM, key *AlertKey) {
 	stm.Del(keystr)
 }
 
+func StoreListAlert(ctx context.Context, kvstore objstore.KVStore) ([]Alert, error) {
+	keyPrefix := objstore.DbKeyPrefixString("Alert") + "/"
+	objs := []Alert{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := Alert{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal Alert json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type AlertKeyWatcher struct {
 	cb func(ctx context.Context)
 }

--- a/api/edgeproto/alertpolicy.pb.go
+++ b/api/edgeproto/alertpolicy.pb.go
@@ -1347,6 +1347,21 @@ func (s *AlertPolicyStoreImpl) STMDel(stm concurrency.STM, key *AlertPolicyKey) 
 	stm.Del(keystr)
 }
 
+func StoreListAlertPolicy(ctx context.Context, kvstore objstore.KVStore) ([]AlertPolicy, error) {
+	keyPrefix := objstore.DbKeyPrefixString("AlertPolicy") + "/"
+	objs := []AlertPolicy{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := AlertPolicy{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal AlertPolicy json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type AlertPolicyKeyWatcher struct {
 	cb func(ctx context.Context)
 }

--- a/api/edgeproto/alldata.pb.go
+++ b/api/edgeproto/alldata.pb.go
@@ -4,7 +4,9 @@
 package edgeproto
 
 import (
+	context "context"
 	fmt "fmt"
+	"github.com/edgexr/edge-cloud-platform/pkg/objstore"
 	_ "github.com/edgexr/edge-cloud-platform/tools/protogen"
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
@@ -1990,6 +1992,127 @@ func (m *AllData) IsEmpty() bool {
 		return false
 	}
 	return true
+}
+
+func (m *AllData) StoreRead(ctx context.Context, kvstore objstore.KVStore) error {
+	settings, err := StoreListSettings(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	if len(settings) > 0 {
+		m.Settings = &settings[0]
+	}
+	flavors, err := StoreListFlavor(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.Flavors = flavors
+	operator_codes, err := StoreListOperatorCode(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.OperatorCodes = operator_codes
+	res_tag_tables, err := StoreListResTagTable(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.ResTagTables = res_tag_tables
+	cloudlets, err := StoreListCloudlet(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.Cloudlets = cloudlets
+	cloudlet_infos, err := StoreListCloudletInfo(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.CloudletInfos = cloudlet_infos
+	cloudlet_pools, err := StoreListCloudletPool(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.CloudletPools = cloudlet_pools
+	auto_prov_policies, err := StoreListAutoProvPolicy(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.AutoProvPolicies = auto_prov_policies
+	auto_scale_policies, err := StoreListAutoScalePolicy(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.AutoScalePolicies = auto_scale_policies
+	trust_policies, err := StoreListTrustPolicy(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.TrustPolicies = trust_policies
+	cluster_insts, err := StoreListClusterInst(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.ClusterInsts = cluster_insts
+	apps, err := StoreListApp(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.Apps = apps
+	app_instances, err := StoreListAppInst(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.AppInstances = app_instances
+	app_inst_refs, err := StoreListAppInstRefs(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.AppInstRefs = app_inst_refs
+	vm_pools, err := StoreListVMPool(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.VmPools = vm_pools
+	gpu_drivers, err := StoreListGPUDriver(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.GpuDrivers = gpu_drivers
+	alert_policies, err := StoreListAlertPolicy(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.AlertPolicies = alert_policies
+	flow_rate_limit_settings, err := StoreListFlowRateLimitSettings(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.FlowRateLimitSettings = flow_rate_limit_settings
+	max_reqs_rate_limit_settings, err := StoreListMaxReqsRateLimitSettings(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.MaxReqsRateLimitSettings = max_reqs_rate_limit_settings
+	networks, err := StoreListNetwork(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.Networks = networks
+	trust_policy_exceptions, err := StoreListTrustPolicyException(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.TrustPolicyExceptions = trust_policy_exceptions
+	cluster_refs, err := StoreListClusterRefs(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.ClusterRefs = cluster_refs
+	platform_features, err := StoreListPlatformFeatures(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.PlatformFeatures = platform_features
+	return nil
 }
 
 func (m *AllData) Size() (n int) {

--- a/api/edgeproto/app.pb.go
+++ b/api/edgeproto/app.pb.go
@@ -4032,6 +4032,21 @@ func (s *AppStoreImpl) STMDel(stm concurrency.STM, key *AppKey) {
 	stm.Del(keystr)
 }
 
+func StoreListApp(ctx context.Context, kvstore objstore.KVStore) ([]App, error) {
+	keyPrefix := objstore.DbKeyPrefixString("App") + "/"
+	objs := []App{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := App{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal App json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type AppKeyWatcher struct {
 	cb func(ctx context.Context)
 }

--- a/api/edgeproto/appinst.pb.go
+++ b/api/edgeproto/appinst.pb.go
@@ -5086,6 +5086,21 @@ func (s *AppInstStoreImpl) STMDel(stm concurrency.STM, key *AppInstKey) {
 	stm.Del(keystr)
 }
 
+func StoreListAppInst(ctx context.Context, kvstore objstore.KVStore) ([]AppInst, error) {
+	keyPrefix := objstore.DbKeyPrefixString("AppInst") + "/"
+	objs := []AppInst{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := AppInst{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal AppInst json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type AppInstKeyWatcher struct {
 	cb func(ctx context.Context)
 }
@@ -6551,6 +6566,21 @@ func (s *AppInstInfoStoreImpl) STMDel(stm concurrency.STM, key *AppInstKey) {
 	stm.Del(keystr)
 }
 
+func StoreListAppInstInfo(ctx context.Context, kvstore objstore.KVStore) ([]AppInstInfo, error) {
+	keyPrefix := objstore.DbKeyPrefixString("AppInstInfo") + "/"
+	objs := []AppInstInfo{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := AppInstInfo{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal AppInstInfo json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type AppInstInfoKeyWatcher struct {
 	cb func(ctx context.Context)
 }
@@ -7987,6 +8017,21 @@ func (s *FedAppInstStoreImpl) STMPut(stm concurrency.STM, obj *FedAppInst, ops .
 func (s *FedAppInstStoreImpl) STMDel(stm concurrency.STM, key *FedAppInstKey) {
 	keystr := objstore.DbKeyString("FedAppInst", key)
 	stm.Del(keystr)
+}
+
+func StoreListFedAppInst(ctx context.Context, kvstore objstore.KVStore) ([]FedAppInst, error) {
+	keyPrefix := objstore.DbKeyPrefixString("FedAppInst") + "/"
+	objs := []FedAppInst{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := FedAppInst{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal FedAppInst json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 type FedAppInstKeyWatcher struct {

--- a/api/edgeproto/appinstclient.pb.go
+++ b/api/edgeproto/appinstclient.pb.go
@@ -750,6 +750,21 @@ func (s *AppInstClientKeyStoreImpl) STMDel(stm concurrency.STM, key *AppInstClie
 	stm.Del(keystr)
 }
 
+func StoreListAppInstClientKey(ctx context.Context, kvstore objstore.KVStore) ([]AppInstClientKey, error) {
+	keyPrefix := objstore.DbKeyPrefixString("AppInstClientKey") + "/"
+	objs := []AppInstClientKey{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := AppInstClientKey{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal AppInstClientKey json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type AppInstClientKeyKeyWatcher struct {
 	cb func(ctx context.Context)
 }

--- a/api/edgeproto/autoprovpolicy.pb.go
+++ b/api/edgeproto/autoprovpolicy.pb.go
@@ -1734,6 +1734,21 @@ func (s *AutoProvPolicyStoreImpl) STMDel(stm concurrency.STM, key *PolicyKey) {
 	stm.Del(keystr)
 }
 
+func StoreListAutoProvPolicy(ctx context.Context, kvstore objstore.KVStore) ([]AutoProvPolicy, error) {
+	keyPrefix := objstore.DbKeyPrefixString("AutoProvPolicy") + "/"
+	objs := []AutoProvPolicy{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := AutoProvPolicy{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal AutoProvPolicy json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type AutoProvPolicyKeyWatcher struct {
 	cb func(ctx context.Context)
 }
@@ -3154,6 +3169,21 @@ func (s *AutoProvInfoStoreImpl) STMPut(stm concurrency.STM, obj *AutoProvInfo, o
 func (s *AutoProvInfoStoreImpl) STMDel(stm concurrency.STM, key *CloudletKey) {
 	keystr := objstore.DbKeyString("AutoProvInfo", key)
 	stm.Del(keystr)
+}
+
+func StoreListAutoProvInfo(ctx context.Context, kvstore objstore.KVStore) ([]AutoProvInfo, error) {
+	keyPrefix := objstore.DbKeyPrefixString("AutoProvInfo") + "/"
+	objs := []AutoProvInfo{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := AutoProvInfo{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal AutoProvInfo json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 type AutoProvInfoKeyWatcher struct {

--- a/api/edgeproto/autoscalepolicy.pb.go
+++ b/api/edgeproto/autoscalepolicy.pb.go
@@ -1182,6 +1182,21 @@ func (s *AutoScalePolicyStoreImpl) STMDel(stm concurrency.STM, key *PolicyKey) {
 	stm.Del(keystr)
 }
 
+func StoreListAutoScalePolicy(ctx context.Context, kvstore objstore.KVStore) ([]AutoScalePolicy, error) {
+	keyPrefix := objstore.DbKeyPrefixString("AutoScalePolicy") + "/"
+	objs := []AutoScalePolicy{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := AutoScalePolicy{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal AutoScalePolicy json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type AutoScalePolicyKeyWatcher struct {
 	cb func(ctx context.Context)
 }

--- a/api/edgeproto/cloudlet.pb.go
+++ b/api/edgeproto/cloudlet.pb.go
@@ -7059,6 +7059,21 @@ func (s *CloudletInternalStoreImpl) STMDel(stm concurrency.STM, key *CloudletKey
 	stm.Del(keystr)
 }
 
+func StoreListCloudletInternal(ctx context.Context, kvstore objstore.KVStore) ([]CloudletInternal, error) {
+	keyPrefix := objstore.DbKeyPrefixString("CloudletInternal") + "/"
+	objs := []CloudletInternal{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := CloudletInternal{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal CloudletInternal json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type CloudletInternalKeyWatcher struct {
 	cb func(ctx context.Context)
 }
@@ -8410,6 +8425,21 @@ func (s *PlatformFeaturesStoreImpl) STMPut(stm concurrency.STM, obj *PlatformFea
 func (s *PlatformFeaturesStoreImpl) STMDel(stm concurrency.STM, key *PlatformFeaturesKey) {
 	keystr := objstore.DbKeyString("PlatformFeatures", key)
 	stm.Del(keystr)
+}
+
+func StoreListPlatformFeatures(ctx context.Context, kvstore objstore.KVStore) ([]PlatformFeatures, error) {
+	keyPrefix := objstore.DbKeyPrefixString("PlatformFeatures") + "/"
+	objs := []PlatformFeatures{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := PlatformFeatures{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal PlatformFeatures json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 type PlatformFeaturesKeyWatcher struct {
@@ -10010,6 +10040,21 @@ func (s *GPUDriverStoreImpl) STMPut(stm concurrency.STM, obj *GPUDriver, ops ...
 func (s *GPUDriverStoreImpl) STMDel(stm concurrency.STM, key *GPUDriverKey) {
 	keystr := objstore.DbKeyString("GPUDriver", key)
 	stm.Del(keystr)
+}
+
+func StoreListGPUDriver(ctx context.Context, kvstore objstore.KVStore) ([]GPUDriver, error) {
+	keyPrefix := objstore.DbKeyPrefixString("GPUDriver") + "/"
+	objs := []GPUDriver{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := GPUDriver{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal GPUDriver json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 type GPUDriverKeyWatcher struct {
@@ -13306,6 +13351,21 @@ func (s *CloudletStoreImpl) STMDel(stm concurrency.STM, key *CloudletKey) {
 	stm.Del(keystr)
 }
 
+func StoreListCloudlet(ctx context.Context, kvstore objstore.KVStore) ([]Cloudlet, error) {
+	keyPrefix := objstore.DbKeyPrefixString("Cloudlet") + "/"
+	objs := []Cloudlet{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := Cloudlet{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal Cloudlet json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type CloudletKeyWatcher struct {
 	cb func(ctx context.Context)
 }
@@ -16490,6 +16550,21 @@ func (s *CloudletInfoStoreImpl) STMPut(stm concurrency.STM, obj *CloudletInfo, o
 func (s *CloudletInfoStoreImpl) STMDel(stm concurrency.STM, key *CloudletKey) {
 	keystr := objstore.DbKeyString("CloudletInfo", key)
 	stm.Del(keystr)
+}
+
+func StoreListCloudletInfo(ctx context.Context, kvstore objstore.KVStore) ([]CloudletInfo, error) {
+	keyPrefix := objstore.DbKeyPrefixString("CloudletInfo") + "/"
+	objs := []CloudletInfo{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := CloudletInfo{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal CloudletInfo json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 type CloudletInfoKeyWatcher struct {

--- a/api/edgeproto/cloudletnode.pb.go
+++ b/api/edgeproto/cloudletnode.pb.go
@@ -1310,6 +1310,21 @@ func (s *CloudletNodeStoreImpl) STMDel(stm concurrency.STM, key *CloudletNodeKey
 	stm.Del(keystr)
 }
 
+func StoreListCloudletNode(ctx context.Context, kvstore objstore.KVStore) ([]CloudletNode, error) {
+	keyPrefix := objstore.DbKeyPrefixString("CloudletNode") + "/"
+	objs := []CloudletNode{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := CloudletNode{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal CloudletNode json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type CloudletNodeKeyWatcher struct {
 	cb func(ctx context.Context)
 }

--- a/api/edgeproto/cloudletpool.pb.go
+++ b/api/edgeproto/cloudletpool.pb.go
@@ -1340,6 +1340,21 @@ func (s *CloudletPoolStoreImpl) STMDel(stm concurrency.STM, key *CloudletPoolKey
 	stm.Del(keystr)
 }
 
+func StoreListCloudletPool(ctx context.Context, kvstore objstore.KVStore) ([]CloudletPool, error) {
+	keyPrefix := objstore.DbKeyPrefixString("CloudletPool") + "/"
+	objs := []CloudletPool{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := CloudletPool{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal CloudletPool json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type CloudletPoolKeyWatcher struct {
 	cb func(ctx context.Context)
 }

--- a/api/edgeproto/clusterinst.pb.go
+++ b/api/edgeproto/clusterinst.pb.go
@@ -3293,6 +3293,21 @@ func (s *ClusterInstStoreImpl) STMDel(stm concurrency.STM, key *ClusterKey) {
 	stm.Del(keystr)
 }
 
+func StoreListClusterInst(ctx context.Context, kvstore objstore.KVStore) ([]ClusterInst, error) {
+	keyPrefix := objstore.DbKeyPrefixString("ClusterInst") + "/"
+	objs := []ClusterInst{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := ClusterInst{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal ClusterInst json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type ClusterInstKeyWatcher struct {
 	cb func(ctx context.Context)
 }
@@ -4568,6 +4583,21 @@ func (s *ClusterInstInfoStoreImpl) STMPut(stm concurrency.STM, obj *ClusterInstI
 func (s *ClusterInstInfoStoreImpl) STMDel(stm concurrency.STM, key *ClusterKey) {
 	keystr := objstore.DbKeyString("ClusterInstInfo", key)
 	stm.Del(keystr)
+}
+
+func StoreListClusterInstInfo(ctx context.Context, kvstore objstore.KVStore) ([]ClusterInstInfo, error) {
+	keyPrefix := objstore.DbKeyPrefixString("ClusterInstInfo") + "/"
+	objs := []ClusterInstInfo{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := ClusterInstInfo{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal ClusterInstInfo json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 type ClusterInstInfoKeyWatcher struct {

--- a/api/edgeproto/controller.pb.go
+++ b/api/edgeproto/controller.pb.go
@@ -828,6 +828,21 @@ func (s *ControllerStoreImpl) STMDel(stm concurrency.STM, key *ControllerKey) {
 	stm.Del(keystr)
 }
 
+func StoreListController(ctx context.Context, kvstore objstore.KVStore) ([]Controller, error) {
+	keyPrefix := objstore.DbKeyPrefixString("Controller") + "/"
+	objs := []Controller{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := Controller{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal Controller json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type ControllerKeyWatcher struct {
 	cb func(ctx context.Context)
 }

--- a/api/edgeproto/flavor.pb.go
+++ b/api/edgeproto/flavor.pb.go
@@ -1163,6 +1163,21 @@ func (s *FlavorStoreImpl) STMDel(stm concurrency.STM, key *FlavorKey) {
 	stm.Del(keystr)
 }
 
+func StoreListFlavor(ctx context.Context, kvstore objstore.KVStore) ([]Flavor, error) {
+	keyPrefix := objstore.DbKeyPrefixString("Flavor") + "/"
+	objs := []Flavor{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := Flavor{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal Flavor json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type FlavorKeyWatcher struct {
 	cb func(ctx context.Context)
 }

--- a/api/edgeproto/network.pb.go
+++ b/api/edgeproto/network.pb.go
@@ -1359,6 +1359,21 @@ func (s *NetworkStoreImpl) STMDel(stm concurrency.STM, key *NetworkKey) {
 	stm.Del(keystr)
 }
 
+func StoreListNetwork(ctx context.Context, kvstore objstore.KVStore) ([]Network, error) {
+	keyPrefix := objstore.DbKeyPrefixString("Network") + "/"
+	objs := []Network{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := Network{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal Network json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type NetworkKeyWatcher struct {
 	cb func(ctx context.Context)
 }

--- a/api/edgeproto/operatorcode.pb.go
+++ b/api/edgeproto/operatorcode.pb.go
@@ -560,6 +560,21 @@ func (s *OperatorCodeStoreImpl) STMDel(stm concurrency.STM, key *OperatorCodeKey
 	stm.Del(keystr)
 }
 
+func StoreListOperatorCode(ctx context.Context, kvstore objstore.KVStore) ([]OperatorCode, error) {
+	keyPrefix := objstore.DbKeyPrefixString("OperatorCode") + "/"
+	objs := []OperatorCode{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := OperatorCode{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal OperatorCode json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type OperatorCodeKeyWatcher struct {
 	cb func(ctx context.Context)
 }

--- a/api/edgeproto/ratelimit.pb.go
+++ b/api/edgeproto/ratelimit.pb.go
@@ -2110,6 +2110,21 @@ func (s *FlowRateLimitSettingsStoreImpl) STMDel(stm concurrency.STM, key *FlowRa
 	stm.Del(keystr)
 }
 
+func StoreListFlowRateLimitSettings(ctx context.Context, kvstore objstore.KVStore) ([]FlowRateLimitSettings, error) {
+	keyPrefix := objstore.DbKeyPrefixString("FlowRateLimitSettings") + "/"
+	objs := []FlowRateLimitSettings{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := FlowRateLimitSettings{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal FlowRateLimitSettings json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type FlowRateLimitSettingsKeyWatcher struct {
 	cb func(ctx context.Context)
 }
@@ -3090,6 +3105,21 @@ func (s *MaxReqsRateLimitSettingsStoreImpl) STMDel(stm concurrency.STM, key *Max
 	stm.Del(keystr)
 }
 
+func StoreListMaxReqsRateLimitSettings(ctx context.Context, kvstore objstore.KVStore) ([]MaxReqsRateLimitSettings, error) {
+	keyPrefix := objstore.DbKeyPrefixString("MaxReqsRateLimitSettings") + "/"
+	objs := []MaxReqsRateLimitSettings{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := MaxReqsRateLimitSettings{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal MaxReqsRateLimitSettings json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type MaxReqsRateLimitSettingsKeyWatcher struct {
 	cb func(ctx context.Context)
 }
@@ -3977,6 +4007,21 @@ func (s *RateLimitSettingsStoreImpl) STMDel(stm concurrency.STM, key *RateLimitS
 	stm.Del(keystr)
 }
 
+func StoreListRateLimitSettings(ctx context.Context, kvstore objstore.KVStore) ([]RateLimitSettings, error) {
+	keyPrefix := objstore.DbKeyPrefixString("RateLimitSettings") + "/"
+	objs := []RateLimitSettings{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := RateLimitSettings{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal RateLimitSettings json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 func (m *RateLimitSettings) GetObjKey() objstore.ObjKey {
 	return m.GetKey()
 }
@@ -4080,6 +4125,15 @@ func (m *RateLimitSettingsData) IsEmpty() bool {
 		return false
 	}
 	return true
+}
+
+func (m *RateLimitSettingsData) StoreRead(ctx context.Context, kvstore objstore.KVStore) error {
+	settings, err := StoreListRateLimitSettings(ctx, kvstore)
+	if err != nil {
+		return err
+	}
+	m.Settings = settings
+	return nil
 }
 
 var ApiEndpointTypeStrings = []string{

--- a/api/edgeproto/refs.pb.go
+++ b/api/edgeproto/refs.pb.go
@@ -1641,6 +1641,21 @@ func (s *CloudletRefsStoreImpl) STMDel(stm concurrency.STM, key *CloudletKey) {
 	stm.Del(keystr)
 }
 
+func StoreListCloudletRefs(ctx context.Context, kvstore objstore.KVStore) ([]CloudletRefs, error) {
+	keyPrefix := objstore.DbKeyPrefixString("CloudletRefs") + "/"
+	objs := []CloudletRefs{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := CloudletRefs{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal CloudletRefs json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type CloudletRefsKeyWatcher struct {
 	cb func(ctx context.Context)
 }
@@ -2409,6 +2424,21 @@ func (s *ClusterRefsStoreImpl) STMDel(stm concurrency.STM, key *ClusterKey) {
 	stm.Del(keystr)
 }
 
+func StoreListClusterRefs(ctx context.Context, kvstore objstore.KVStore) ([]ClusterRefs, error) {
+	keyPrefix := objstore.DbKeyPrefixString("ClusterRefs") + "/"
+	objs := []ClusterRefs{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := ClusterRefs{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal ClusterRefs json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type ClusterRefsKeyWatcher struct {
 	cb func(ctx context.Context)
 }
@@ -3175,6 +3205,21 @@ func (s *AppInstRefsStoreImpl) STMPut(stm concurrency.STM, obj *AppInstRefs, ops
 func (s *AppInstRefsStoreImpl) STMDel(stm concurrency.STM, key *AppKey) {
 	keystr := objstore.DbKeyString("AppInstRefs", key)
 	stm.Del(keystr)
+}
+
+func StoreListAppInstRefs(ctx context.Context, kvstore objstore.KVStore) ([]AppInstRefs, error) {
+	keyPrefix := objstore.DbKeyPrefixString("AppInstRefs") + "/"
+	objs := []AppInstRefs{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := AppInstRefs{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal AppInstRefs json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 type AppInstRefsKeyWatcher struct {

--- a/api/edgeproto/restagtable.pb.go
+++ b/api/edgeproto/restagtable.pb.go
@@ -1247,6 +1247,21 @@ func (s *ResTagTableStoreImpl) STMDel(stm concurrency.STM, key *ResTagTableKey) 
 	stm.Del(keystr)
 }
 
+func StoreListResTagTable(ctx context.Context, kvstore objstore.KVStore) ([]ResTagTable, error) {
+	keyPrefix := objstore.DbKeyPrefixString("ResTagTable") + "/"
+	objs := []ResTagTable{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := ResTagTable{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal ResTagTable json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type ResTagTableKeyWatcher struct {
 	cb func(ctx context.Context)
 }

--- a/api/edgeproto/settings.pb.go
+++ b/api/edgeproto/settings.pb.go
@@ -1946,6 +1946,21 @@ func (s *SettingsStoreImpl) STMDel(stm concurrency.STM, key *SettingsKey) {
 	stm.Del(keystr)
 }
 
+func StoreListSettings(ctx context.Context, kvstore objstore.KVStore) ([]Settings, error) {
+	keyPrefix := objstore.DbKeyPrefixString("Settings") + "/"
+	objs := []Settings{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := Settings{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal Settings json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type SettingsKeyWatcher struct {
 	cb func(ctx context.Context)
 }

--- a/api/edgeproto/trustpolicy.pb.go
+++ b/api/edgeproto/trustpolicy.pb.go
@@ -1072,6 +1072,21 @@ func (s *TrustPolicyStoreImpl) STMDel(stm concurrency.STM, key *PolicyKey) {
 	stm.Del(keystr)
 }
 
+func StoreListTrustPolicy(ctx context.Context, kvstore objstore.KVStore) ([]TrustPolicy, error) {
+	keyPrefix := objstore.DbKeyPrefixString("TrustPolicy") + "/"
+	objs := []TrustPolicy{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := TrustPolicy{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal TrustPolicy json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type TrustPolicyKeyWatcher struct {
 	cb func(ctx context.Context)
 }

--- a/api/edgeproto/trustpolicyexception.pb.go
+++ b/api/edgeproto/trustpolicyexception.pb.go
@@ -1490,6 +1490,21 @@ func (s *TrustPolicyExceptionStoreImpl) STMDel(stm concurrency.STM, key *TrustPo
 	stm.Del(keystr)
 }
 
+func StoreListTrustPolicyException(ctx context.Context, kvstore objstore.KVStore) ([]TrustPolicyException, error) {
+	keyPrefix := objstore.DbKeyPrefixString("TrustPolicyException") + "/"
+	objs := []TrustPolicyException{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := TrustPolicyException{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal TrustPolicyException json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type TrustPolicyExceptionKeyWatcher struct {
 	cb func(ctx context.Context)
 }
@@ -2459,6 +2474,21 @@ func (s *TPEInstanceStateStoreImpl) STMPut(stm concurrency.STM, obj *TPEInstance
 func (s *TPEInstanceStateStoreImpl) STMDel(stm concurrency.STM, key *TPEInstanceKey) {
 	keystr := objstore.DbKeyString("TPEInstanceState", key)
 	stm.Del(keystr)
+}
+
+func StoreListTPEInstanceState(ctx context.Context, kvstore objstore.KVStore) ([]TPEInstanceState, error) {
+	keyPrefix := objstore.DbKeyPrefixString("TPEInstanceState") + "/"
+	objs := []TPEInstanceState{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := TPEInstanceState{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal TPEInstanceState json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 type TPEInstanceStateKeyWatcher struct {

--- a/api/edgeproto/vmpool.pb.go
+++ b/api/edgeproto/vmpool.pb.go
@@ -2303,6 +2303,21 @@ func (s *VMPoolStoreImpl) STMDel(stm concurrency.STM, key *VMPoolKey) {
 	stm.Del(keystr)
 }
 
+func StoreListVMPool(ctx context.Context, kvstore objstore.KVStore) ([]VMPool, error) {
+	keyPrefix := objstore.DbKeyPrefixString("VMPool") + "/"
+	objs := []VMPool{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := VMPool{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal VMPool json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
 type VMPoolKeyWatcher struct {
 	cb func(ctx context.Context)
 }
@@ -3801,6 +3816,21 @@ func (s *VMPoolInfoStoreImpl) STMPut(stm concurrency.STM, obj *VMPoolInfo, ops .
 func (s *VMPoolInfoStoreImpl) STMDel(stm concurrency.STM, key *VMPoolKey) {
 	keystr := objstore.DbKeyString("VMPoolInfo", key)
 	stm.Del(keystr)
+}
+
+func StoreListVMPoolInfo(ctx context.Context, kvstore objstore.KVStore) ([]VMPoolInfo, error) {
+	keyPrefix := objstore.DbKeyPrefixString("VMPoolInfo") + "/"
+	objs := []VMPoolInfo{}
+	err := kvstore.List(keyPrefix, func(key, val []byte, rev, modRev int64) error {
+		obj := VMPoolInfo{}
+		err := json.Unmarshal(val, &obj)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal VMPoolInfo json %s, %s", string(val), err)
+		}
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
 }
 
 type VMPoolInfoKeyWatcher struct {

--- a/pkg/controller/appinst_api.go
+++ b/pkg/controller/appinst_api.go
@@ -1723,8 +1723,10 @@ func (s *AppInstApi) deleteAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 	streamCb, cb := s.all.streamObjApi.newStream(ctx, cctx, appInstKey.StreamKey(), inCb)
 
 	// get appinst info for flavor
+	log.SpanLog(ctx, log.DebugLevelInfo, "debug deleteAppInst", "key", in.Key)
 	appInstInfo := edgeproto.AppInst{}
 	if !s.cache.Get(&in.Key, &appInstInfo) {
+		log.SpanLog(ctx, log.DebugLevelInfo, "debug deleteAppInst not found", "key", in.Key)
 		return in.Key.NotFoundError()
 	}
 	defer func() {
@@ -1747,6 +1749,7 @@ func (s *AppInstApi) deleteAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 
 		if !s.store.STMGet(stm, &in.Key, in) {
 			// already deleted
+			log.SpanLog(ctx, log.DebugLevelInfo, "debug deleteAppInst not found", "key", in.Key)
 			return in.Key.NotFoundError()
 		}
 		if err := validateDeleteState(cctx, "AppInst", in.State, in.Errors, cb.Send); err != nil {

--- a/pkg/controller/appinst_api.go
+++ b/pkg/controller/appinst_api.go
@@ -1723,10 +1723,8 @@ func (s *AppInstApi) deleteAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 	streamCb, cb := s.all.streamObjApi.newStream(ctx, cctx, appInstKey.StreamKey(), inCb)
 
 	// get appinst info for flavor
-	log.SpanLog(ctx, log.DebugLevelInfo, "debug deleteAppInst", "key", in.Key)
 	appInstInfo := edgeproto.AppInst{}
 	if !s.cache.Get(&in.Key, &appInstInfo) {
-		log.SpanLog(ctx, log.DebugLevelInfo, "debug deleteAppInst not found", "key", in.Key)
 		return in.Key.NotFoundError()
 	}
 	defer func() {
@@ -1749,7 +1747,6 @@ func (s *AppInstApi) deleteAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 
 		if !s.store.STMGet(stm, &in.Key, in) {
 			// already deleted
-			log.SpanLog(ctx, log.DebugLevelInfo, "debug deleteAppInst not found", "key", in.Key)
 			return in.Key.NotFoundError()
 		}
 		if err := validateDeleteState(cctx, "AppInst", in.State, in.Errors, cb.Send); err != nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -931,3 +931,27 @@ func initContinuousQueries(allApis *AllApis) {
 	}
 	services.waitGroup.Done()
 }
+
+func (s *AllApis) GetAlertPolicyApi() edgeproto.AlertPolicyApiServer   { return s.alertPolicyApi }
+func (s *AllApis) GetFlavorApi() edgeproto.FlavorApiServer             { return s.flavorApi }
+func (s *AllApis) GetOperatorCodeApi() edgeproto.OperatorCodeApiServer { return s.operatorCodeApi }
+func (s *AllApis) GetResTagTableApi() edgeproto.ResTagTableApiServer   { return s.resTagTableApi }
+func (s *AllApis) GetAutoScalePolicyApi() edgeproto.AutoScalePolicyApiServer {
+	return s.autoScalePolicyApi
+}
+func (s *AllApis) GetTrustPolicyApi() edgeproto.TrustPolicyApiServer   { return s.trustPolicyApi }
+func (s *AllApis) GetAppApi() edgeproto.AppApiServer                   { return s.appApi }
+func (s *AllApis) GetAppInstApi() edgeproto.AppInstApiServer           { return s.appInstApi }
+func (s *AllApis) GetGPUDriverApi() edgeproto.GPUDriverApiServer       { return s.gpuDriverApi }
+func (s *AllApis) GetCloudletApi() edgeproto.CloudletApiServer         { return s.cloudletApi }
+func (s *AllApis) GetCloudletPoolApi() edgeproto.CloudletPoolApiServer { return s.cloudletPoolApi }
+func (s *AllApis) GetVMPoolApi() edgeproto.VMPoolApiServer             { return s.vmPoolApi }
+func (s *AllApis) GetClusterInstApi() edgeproto.ClusterInstApiServer   { return s.clusterInstApi }
+func (s *AllApis) GetAutoProvPolicyApi() edgeproto.AutoProvPolicyApiServer {
+	return s.autoProvPolicyApi
+}
+func (s *AllApis) GetTrustPolicyExceptionApi() edgeproto.TrustPolicyExceptionApiServer {
+	return s.trustPolicyExceptionApi
+}
+func (s *AllApis) GetNetworkApi() edgeproto.NetworkApiServer           { return s.networkApi }
+func (s *AllApis) GetCloudletNodeApi() edgeproto.CloudletNodeApiServer { return s.cloudletNodeApi }

--- a/pkg/regiondata/sync.go
+++ b/pkg/regiondata/sync.go
@@ -95,6 +95,7 @@ func (s *Sync) Start() {
 func (s *Sync) Done() {
 	s.syncCancel()
 	s.mux.Lock()
+	defer s.mux.Unlock()
 	for !s.syncDone {
 		s.cond.Wait()
 	}

--- a/test/testgen/testutil/sample_testutil.go
+++ b/test/testgen/testutil/sample_testutil.go
@@ -93,3 +93,6 @@ type CliClient struct {
 type Client interface {
 	TestApiClient
 }
+
+type InternalCUDAPIs interface {
+}

--- a/test/testutil/alert_testutil.go
+++ b/test/testutil/alert_testutil.go
@@ -48,14 +48,6 @@ func (x *ShowAlert) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowAlert) ListData() []edgeproto.Alert {
-	data := []edgeproto.Alert{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var AlertShowExtraCount = 0
 
 func (x *ShowAlert) ReadStream(stream edgeproto.AlertApi_ShowAlertClient, err error) {

--- a/test/testutil/alert_testutil.go
+++ b/test/testutil/alert_testutil.go
@@ -48,6 +48,14 @@ func (x *ShowAlert) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowAlert) ListData() []edgeproto.Alert {
+	data := []edgeproto.Alert{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var AlertShowExtraCount = 0
 
 func (x *ShowAlert) ReadStream(stream edgeproto.AlertApi_ShowAlertClient, err error) {
@@ -493,4 +501,24 @@ type Client interface {
 	DebugApiClient
 	DeviceApiClient
 	StreamObjApiClient
+}
+
+type InternalCUDAPIs interface {
+	GetAlertPolicyApi() edgeproto.AlertPolicyApiServer
+	GetFlavorApi() edgeproto.FlavorApiServer
+	GetOperatorCodeApi() edgeproto.OperatorCodeApiServer
+	GetResTagTableApi() edgeproto.ResTagTableApiServer
+	GetAutoScalePolicyApi() edgeproto.AutoScalePolicyApiServer
+	GetTrustPolicyApi() edgeproto.TrustPolicyApiServer
+	GetAppApi() edgeproto.AppApiServer
+	GetAppInstApi() edgeproto.AppInstApiServer
+	GetGPUDriverApi() edgeproto.GPUDriverApiServer
+	GetCloudletApi() edgeproto.CloudletApiServer
+	GetCloudletPoolApi() edgeproto.CloudletPoolApiServer
+	GetVMPoolApi() edgeproto.VMPoolApiServer
+	GetClusterInstApi() edgeproto.ClusterInstApiServer
+	GetAutoProvPolicyApi() edgeproto.AutoProvPolicyApiServer
+	GetTrustPolicyExceptionApi() edgeproto.TrustPolicyExceptionApiServer
+	GetNetworkApi() edgeproto.NetworkApiServer
+	GetCloudletNodeApi() edgeproto.CloudletNodeApiServer
 }

--- a/test/testutil/alertpolicy_testutil.go
+++ b/test/testutil/alertpolicy_testutil.go
@@ -48,6 +48,14 @@ func (x *ShowAlertPolicy) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowAlertPolicy) ListData() []edgeproto.AlertPolicy {
+	data := []edgeproto.AlertPolicy{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var AlertPolicyShowExtraCount = 0
 
 func (x *ShowAlertPolicy) ReadStream(stream edgeproto.AlertPolicyApi_ShowAlertPolicyClient, err error) {
@@ -331,6 +339,12 @@ func InternalAlertPolicyDelete(t *testing.T, api edgeproto.AlertPolicyApiServer,
 	ctx := log.ContextWithSpan(context.Background(), span)
 
 	DeleteAlertPolicyData(t, ctx, NewInternalAlertPolicyApi(api), testData)
+}
+
+func InternalAlertPolicyDeleteAll(t *testing.T, ctx context.Context, api edgeproto.AlertPolicyApiServer, data []edgeproto.AlertPolicy) {
+	intapi := NewInternalAlertPolicyApi(api)
+	log.SpanLog(ctx, log.DebugLevelInfo, "deleting all AlertPolicys", "count", len(data))
+	DeleteAlertPolicyData(t, ctx, intapi, data)
 }
 
 func ClientAlertPolicyDelete(t *testing.T, api edgeproto.AlertPolicyApiClient, testData []edgeproto.AlertPolicy) {

--- a/test/testutil/alertpolicy_testutil.go
+++ b/test/testutil/alertpolicy_testutil.go
@@ -48,14 +48,6 @@ func (x *ShowAlertPolicy) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowAlertPolicy) ListData() []edgeproto.AlertPolicy {
-	data := []edgeproto.AlertPolicy{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var AlertPolicyShowExtraCount = 0
 
 func (x *ShowAlertPolicy) ReadStream(stream edgeproto.AlertPolicyApi_ShowAlertPolicyClient, err error) {

--- a/test/testutil/alldata_testutil.go
+++ b/test/testutil/alldata_testutil.go
@@ -4,12 +4,14 @@
 package testutil
 
 import (
+	"context"
 	fmt "fmt"
 	edgeproto "github.com/edgexr/edge-cloud-platform/api/edgeproto"
 	_ "github.com/edgexr/edge-cloud-platform/tools/protogen"
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	math "math"
+	"testing"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -222,4 +224,23 @@ func RunAllDataShowApis(run *Run, in *edgeproto.AllData, selector edgeproto.AllS
 	if selector.Has("trustpolicyexceptions") {
 		run.TrustPolicyExceptionApi(&in.TrustPolicyExceptions, nil, &out.TrustPolicyExceptions)
 	}
+}
+
+func DeleteAllAllDataInternal(t *testing.T, ctx context.Context, apis InternalCUDAPIs, in *edgeproto.AllData) {
+	InternalTrustPolicyExceptionDeleteAll(t, ctx, apis.GetTrustPolicyExceptionApi(), in.TrustPolicyExceptions)
+	InternalAlertPolicyDeleteAll(t, ctx, apis.GetAlertPolicyApi(), in.AlertPolicies)
+	InternalVMPoolDeleteAll(t, ctx, apis.GetVMPoolApi(), in.VmPools)
+	InternalAppInstDeleteAll(t, ctx, apis.GetAppInstApi(), in.AppInstances)
+	InternalAppDeleteAll(t, ctx, apis.GetAppApi(), in.Apps)
+	InternalClusterInstDeleteAll(t, ctx, apis.GetClusterInstApi(), in.ClusterInsts)
+	InternalAutoScalePolicyDeleteAll(t, ctx, apis.GetAutoScalePolicyApi(), in.AutoScalePolicies)
+	InternalAutoProvPolicyDeleteAll(t, ctx, apis.GetAutoProvPolicyApi(), in.AutoProvPolicies)
+	InternalNetworkDeleteAll(t, ctx, apis.GetNetworkApi(), in.Networks)
+	InternalCloudletPoolDeleteAll(t, ctx, apis.GetCloudletPoolApi(), in.CloudletPools)
+	InternalCloudletDeleteAll(t, ctx, apis.GetCloudletApi(), in.Cloudlets)
+	InternalGPUDriverDeleteAll(t, ctx, apis.GetGPUDriverApi(), in.GpuDrivers)
+	InternalTrustPolicyDeleteAll(t, ctx, apis.GetTrustPolicyApi(), in.TrustPolicies)
+	InternalResTagTableDeleteAll(t, ctx, apis.GetResTagTableApi(), in.ResTagTables)
+	InternalOperatorCodeDeleteAll(t, ctx, apis.GetOperatorCodeApi(), in.OperatorCodes)
+	InternalFlavorDeleteAll(t, ctx, apis.GetFlavorApi(), in.Flavors)
 }

--- a/test/testutil/app_testutil.go
+++ b/test/testutil/app_testutil.go
@@ -49,6 +49,14 @@ func (x *ShowApp) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowApp) ListData() []edgeproto.App {
+	data := []edgeproto.App{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var AppShowExtraCount = 0
 
 func (x *ShowApp) ReadStream(stream edgeproto.AppApi_ShowAppClient, err error) {
@@ -332,6 +340,12 @@ func InternalAppDelete(t *testing.T, api edgeproto.AppApiServer, testData []edge
 	ctx := log.ContextWithSpan(context.Background(), span)
 
 	DeleteAppData(t, ctx, NewInternalAppApi(api), testData)
+}
+
+func InternalAppDeleteAll(t *testing.T, ctx context.Context, api edgeproto.AppApiServer, data []edgeproto.App) {
+	intapi := NewInternalAppApi(api)
+	log.SpanLog(ctx, log.DebugLevelInfo, "deleting all Apps", "count", len(data))
+	DeleteAppData(t, ctx, intapi, data)
 }
 
 func ClientAppDelete(t *testing.T, api edgeproto.AppApiClient, testData []edgeproto.App) {

--- a/test/testutil/app_testutil.go
+++ b/test/testutil/app_testutil.go
@@ -49,14 +49,6 @@ func (x *ShowApp) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowApp) ListData() []edgeproto.App {
-	data := []edgeproto.App{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var AppShowExtraCount = 0
 
 func (x *ShowApp) ReadStream(stream edgeproto.AppApi_ShowAppClient, err error) {

--- a/test/testutil/appinst_testutil.go
+++ b/test/testutil/appinst_testutil.go
@@ -49,6 +49,14 @@ func (x *ShowAppInst) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowAppInst) ListData() []edgeproto.AppInst {
+	data := []edgeproto.AppInst{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var AppInstShowExtraCount = 0
 
 type CudStreamoutAppInst struct {
@@ -376,6 +384,12 @@ func InternalAppInstDelete(t *testing.T, api edgeproto.AppInstApiServer, testDat
 	DeleteAppInstData(t, ctx, NewInternalAppInstApi(api), testData)
 }
 
+func InternalAppInstDeleteAll(t *testing.T, ctx context.Context, api edgeproto.AppInstApiServer, data []edgeproto.AppInst) {
+	intapi := NewInternalAppInstApi(api)
+	log.SpanLog(ctx, log.DebugLevelInfo, "deleting all AppInsts", "count", len(data))
+	DeleteAppInstData(t, ctx, intapi, data)
+}
+
 func ClientAppInstDelete(t *testing.T, api edgeproto.AppInstApiClient, testData []edgeproto.AppInst) {
 	span := log.StartSpan(log.DebugLevelApi, "ClientAppInstDelete")
 	defer span.Finish()
@@ -420,6 +434,14 @@ func (x *ShowAppInstInfo) Send(m *edgeproto.AppInstInfo) error {
 
 func (x *ShowAppInstInfo) Context() context.Context {
 	return x.Ctx
+}
+
+func (x *ShowAppInstInfo) ListData() []edgeproto.AppInstInfo {
+	data := []edgeproto.AppInstInfo{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
 }
 
 var AppInstInfoShowExtraCount = 0

--- a/test/testutil/appinst_testutil.go
+++ b/test/testutil/appinst_testutil.go
@@ -49,14 +49,6 @@ func (x *ShowAppInst) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowAppInst) ListData() []edgeproto.AppInst {
-	data := []edgeproto.AppInst{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var AppInstShowExtraCount = 0
 
 type CudStreamoutAppInst struct {
@@ -434,14 +426,6 @@ func (x *ShowAppInstInfo) Send(m *edgeproto.AppInstInfo) error {
 
 func (x *ShowAppInstInfo) Context() context.Context {
 	return x.Ctx
-}
-
-func (x *ShowAppInstInfo) ListData() []edgeproto.AppInstInfo {
-	data := []edgeproto.AppInstInfo{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
 }
 
 var AppInstInfoShowExtraCount = 0

--- a/test/testutil/autoprovpolicy_testutil.go
+++ b/test/testutil/autoprovpolicy_testutil.go
@@ -50,6 +50,14 @@ func (x *ShowAutoProvPolicy) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowAutoProvPolicy) ListData() []edgeproto.AutoProvPolicy {
+	data := []edgeproto.AutoProvPolicy{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var AutoProvPolicyShowExtraCount = 0
 
 func (x *ShowAutoProvPolicy) ReadStream(stream edgeproto.AutoProvPolicyApi_ShowAutoProvPolicyClient, err error) {
@@ -353,6 +361,12 @@ func InternalAutoProvPolicyDelete(t *testing.T, api edgeproto.AutoProvPolicyApiS
 	ctx := log.ContextWithSpan(context.Background(), span)
 
 	DeleteAutoProvPolicyData(t, ctx, NewInternalAutoProvPolicyApi(api), testData)
+}
+
+func InternalAutoProvPolicyDeleteAll(t *testing.T, ctx context.Context, api edgeproto.AutoProvPolicyApiServer, data []edgeproto.AutoProvPolicy) {
+	intapi := NewInternalAutoProvPolicyApi(api)
+	log.SpanLog(ctx, log.DebugLevelInfo, "deleting all AutoProvPolicys", "count", len(data))
+	DeleteAutoProvPolicyData(t, ctx, intapi, data)
 }
 
 func ClientAutoProvPolicyDelete(t *testing.T, api edgeproto.AutoProvPolicyApiClient, testData []edgeproto.AutoProvPolicy) {

--- a/test/testutil/autoprovpolicy_testutil.go
+++ b/test/testutil/autoprovpolicy_testutil.go
@@ -50,14 +50,6 @@ func (x *ShowAutoProvPolicy) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowAutoProvPolicy) ListData() []edgeproto.AutoProvPolicy {
-	data := []edgeproto.AutoProvPolicy{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var AutoProvPolicyShowExtraCount = 0
 
 func (x *ShowAutoProvPolicy) ReadStream(stream edgeproto.AutoProvPolicyApi_ShowAutoProvPolicyClient, err error) {

--- a/test/testutil/autoscalepolicy_testutil.go
+++ b/test/testutil/autoscalepolicy_testutil.go
@@ -48,14 +48,6 @@ func (x *ShowAutoScalePolicy) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowAutoScalePolicy) ListData() []edgeproto.AutoScalePolicy {
-	data := []edgeproto.AutoScalePolicy{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var AutoScalePolicyShowExtraCount = 0
 
 func (x *ShowAutoScalePolicy) ReadStream(stream edgeproto.AutoScalePolicyApi_ShowAutoScalePolicyClient, err error) {

--- a/test/testutil/autoscalepolicy_testutil.go
+++ b/test/testutil/autoscalepolicy_testutil.go
@@ -48,6 +48,14 @@ func (x *ShowAutoScalePolicy) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowAutoScalePolicy) ListData() []edgeproto.AutoScalePolicy {
+	data := []edgeproto.AutoScalePolicy{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var AutoScalePolicyShowExtraCount = 0
 
 func (x *ShowAutoScalePolicy) ReadStream(stream edgeproto.AutoScalePolicyApi_ShowAutoScalePolicyClient, err error) {
@@ -351,6 +359,12 @@ func InternalAutoScalePolicyDelete(t *testing.T, api edgeproto.AutoScalePolicyAp
 	ctx := log.ContextWithSpan(context.Background(), span)
 
 	DeleteAutoScalePolicyData(t, ctx, NewInternalAutoScalePolicyApi(api), testData)
+}
+
+func InternalAutoScalePolicyDeleteAll(t *testing.T, ctx context.Context, api edgeproto.AutoScalePolicyApiServer, data []edgeproto.AutoScalePolicy) {
+	intapi := NewInternalAutoScalePolicyApi(api)
+	log.SpanLog(ctx, log.DebugLevelInfo, "deleting all AutoScalePolicys", "count", len(data))
+	DeleteAutoScalePolicyData(t, ctx, intapi, data)
 }
 
 func ClientAutoScalePolicyDelete(t *testing.T, api edgeproto.AutoScalePolicyApiClient, testData []edgeproto.AutoScalePolicy) {

--- a/test/testutil/cloudlet_testutil.go
+++ b/test/testutil/cloudlet_testutil.go
@@ -49,6 +49,14 @@ func (x *ShowGPUDriver) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowGPUDriver) ListData() []edgeproto.GPUDriver {
+	data := []edgeproto.GPUDriver{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var GPUDriverShowExtraCount = 0
 
 type CudStreamoutGPUDriver struct {
@@ -376,6 +384,12 @@ func InternalGPUDriverDelete(t *testing.T, api edgeproto.GPUDriverApiServer, tes
 	DeleteGPUDriverData(t, ctx, NewInternalGPUDriverApi(api), testData)
 }
 
+func InternalGPUDriverDeleteAll(t *testing.T, ctx context.Context, api edgeproto.GPUDriverApiServer, data []edgeproto.GPUDriver) {
+	intapi := NewInternalGPUDriverApi(api)
+	log.SpanLog(ctx, log.DebugLevelInfo, "deleting all GPUDrivers", "count", len(data))
+	DeleteGPUDriverData(t, ctx, intapi, data)
+}
+
 func ClientGPUDriverDelete(t *testing.T, api edgeproto.GPUDriverApiClient, testData []edgeproto.GPUDriver) {
 	span := log.StartSpan(log.DebugLevelApi, "ClientGPUDriverDelete")
 	defer span.Finish()
@@ -420,6 +434,14 @@ func (x *ShowCloudlet) Send(m *edgeproto.Cloudlet) error {
 
 func (x *ShowCloudlet) Context() context.Context {
 	return x.Ctx
+}
+
+func (x *ShowCloudlet) ListData() []edgeproto.Cloudlet {
+	data := []edgeproto.Cloudlet{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
 }
 
 var CloudletShowExtraCount = 0
@@ -749,6 +771,12 @@ func InternalCloudletDelete(t *testing.T, api edgeproto.CloudletApiServer, testD
 	DeleteCloudletData(t, ctx, NewInternalCloudletApi(api), testData)
 }
 
+func InternalCloudletDeleteAll(t *testing.T, ctx context.Context, api edgeproto.CloudletApiServer, data []edgeproto.Cloudlet) {
+	intapi := NewInternalCloudletApi(api)
+	log.SpanLog(ctx, log.DebugLevelInfo, "deleting all Cloudlets", "count", len(data))
+	DeleteCloudletData(t, ctx, intapi, data)
+}
+
 func ClientCloudletDelete(t *testing.T, api edgeproto.CloudletApiClient, testData []edgeproto.Cloudlet) {
 	span := log.StartSpan(log.DebugLevelApi, "ClientCloudletDelete")
 	defer span.Finish()
@@ -793,6 +821,14 @@ func (x *ShowCloudletInfo) Send(m *edgeproto.CloudletInfo) error {
 
 func (x *ShowCloudletInfo) Context() context.Context {
 	return x.Ctx
+}
+
+func (x *ShowCloudletInfo) ListData() []edgeproto.CloudletInfo {
+	data := []edgeproto.CloudletInfo{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
 }
 
 var CloudletInfoShowExtraCount = 0

--- a/test/testutil/cloudlet_testutil.go
+++ b/test/testutil/cloudlet_testutil.go
@@ -49,14 +49,6 @@ func (x *ShowGPUDriver) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowGPUDriver) ListData() []edgeproto.GPUDriver {
-	data := []edgeproto.GPUDriver{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var GPUDriverShowExtraCount = 0
 
 type CudStreamoutGPUDriver struct {
@@ -436,14 +428,6 @@ func (x *ShowCloudlet) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowCloudlet) ListData() []edgeproto.Cloudlet {
-	data := []edgeproto.Cloudlet{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var CloudletShowExtraCount = 0
 
 type CudStreamoutCloudlet struct {
@@ -821,14 +805,6 @@ func (x *ShowCloudletInfo) Send(m *edgeproto.CloudletInfo) error {
 
 func (x *ShowCloudletInfo) Context() context.Context {
 	return x.Ctx
-}
-
-func (x *ShowCloudletInfo) ListData() []edgeproto.CloudletInfo {
-	data := []edgeproto.CloudletInfo{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
 }
 
 var CloudletInfoShowExtraCount = 0

--- a/test/testutil/cloudletnode_testutil.go
+++ b/test/testutil/cloudletnode_testutil.go
@@ -48,14 +48,6 @@ func (x *ShowCloudletNode) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowCloudletNode) ListData() []edgeproto.CloudletNode {
-	data := []edgeproto.CloudletNode{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var CloudletNodeShowExtraCount = 0
 
 func (x *ShowCloudletNode) ReadStream(stream edgeproto.CloudletNodeApi_ShowCloudletNodeClient, err error) {

--- a/test/testutil/cloudletnode_testutil.go
+++ b/test/testutil/cloudletnode_testutil.go
@@ -48,6 +48,14 @@ func (x *ShowCloudletNode) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowCloudletNode) ListData() []edgeproto.CloudletNode {
+	data := []edgeproto.CloudletNode{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var CloudletNodeShowExtraCount = 0
 
 func (x *ShowCloudletNode) ReadStream(stream edgeproto.CloudletNodeApi_ShowCloudletNodeClient, err error) {
@@ -331,6 +339,12 @@ func InternalCloudletNodeDelete(t *testing.T, api edgeproto.CloudletNodeApiServe
 	ctx := log.ContextWithSpan(context.Background(), span)
 
 	DeleteCloudletNodeData(t, ctx, NewInternalCloudletNodeApi(api), testData)
+}
+
+func InternalCloudletNodeDeleteAll(t *testing.T, ctx context.Context, api edgeproto.CloudletNodeApiServer, data []edgeproto.CloudletNode) {
+	intapi := NewInternalCloudletNodeApi(api)
+	log.SpanLog(ctx, log.DebugLevelInfo, "deleting all CloudletNodes", "count", len(data))
+	DeleteCloudletNodeData(t, ctx, intapi, data)
 }
 
 func ClientCloudletNodeDelete(t *testing.T, api edgeproto.CloudletNodeApiClient, testData []edgeproto.CloudletNode) {

--- a/test/testutil/cloudletpool_testutil.go
+++ b/test/testutil/cloudletpool_testutil.go
@@ -49,14 +49,6 @@ func (x *ShowCloudletPool) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowCloudletPool) ListData() []edgeproto.CloudletPool {
-	data := []edgeproto.CloudletPool{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var CloudletPoolShowExtraCount = 0
 
 func (x *ShowCloudletPool) ReadStream(stream edgeproto.CloudletPoolApi_ShowCloudletPoolClient, err error) {

--- a/test/testutil/cloudletpool_testutil.go
+++ b/test/testutil/cloudletpool_testutil.go
@@ -49,6 +49,14 @@ func (x *ShowCloudletPool) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowCloudletPool) ListData() []edgeproto.CloudletPool {
+	data := []edgeproto.CloudletPool{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var CloudletPoolShowExtraCount = 0
 
 func (x *ShowCloudletPool) ReadStream(stream edgeproto.CloudletPoolApi_ShowCloudletPoolClient, err error) {
@@ -318,6 +326,12 @@ func InternalCloudletPoolDelete(t *testing.T, api edgeproto.CloudletPoolApiServe
 	ctx := log.ContextWithSpan(context.Background(), span)
 
 	DeleteCloudletPoolData(t, ctx, NewInternalCloudletPoolApi(api), testData)
+}
+
+func InternalCloudletPoolDeleteAll(t *testing.T, ctx context.Context, api edgeproto.CloudletPoolApiServer, data []edgeproto.CloudletPool) {
+	intapi := NewInternalCloudletPoolApi(api)
+	log.SpanLog(ctx, log.DebugLevelInfo, "deleting all CloudletPools", "count", len(data))
+	DeleteCloudletPoolData(t, ctx, intapi, data)
 }
 
 func ClientCloudletPoolDelete(t *testing.T, api edgeproto.CloudletPoolApiClient, testData []edgeproto.CloudletPool) {

--- a/test/testutil/clusterinst_testutil.go
+++ b/test/testutil/clusterinst_testutil.go
@@ -49,14 +49,6 @@ func (x *ShowClusterInst) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowClusterInst) ListData() []edgeproto.ClusterInst {
-	data := []edgeproto.ClusterInst{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var ClusterInstShowExtraCount = 0
 
 type CudStreamoutClusterInst struct {
@@ -434,14 +426,6 @@ func (x *ShowClusterInstInfo) Send(m *edgeproto.ClusterInstInfo) error {
 
 func (x *ShowClusterInstInfo) Context() context.Context {
 	return x.Ctx
-}
-
-func (x *ShowClusterInstInfo) ListData() []edgeproto.ClusterInstInfo {
-	data := []edgeproto.ClusterInstInfo{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
 }
 
 var ClusterInstInfoShowExtraCount = 0

--- a/test/testutil/clusterinst_testutil.go
+++ b/test/testutil/clusterinst_testutil.go
@@ -49,6 +49,14 @@ func (x *ShowClusterInst) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowClusterInst) ListData() []edgeproto.ClusterInst {
+	data := []edgeproto.ClusterInst{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var ClusterInstShowExtraCount = 0
 
 type CudStreamoutClusterInst struct {
@@ -376,6 +384,12 @@ func InternalClusterInstDelete(t *testing.T, api edgeproto.ClusterInstApiServer,
 	DeleteClusterInstData(t, ctx, NewInternalClusterInstApi(api), testData)
 }
 
+func InternalClusterInstDeleteAll(t *testing.T, ctx context.Context, api edgeproto.ClusterInstApiServer, data []edgeproto.ClusterInst) {
+	intapi := NewInternalClusterInstApi(api)
+	log.SpanLog(ctx, log.DebugLevelInfo, "deleting all ClusterInsts", "count", len(data))
+	DeleteClusterInstData(t, ctx, intapi, data)
+}
+
 func ClientClusterInstDelete(t *testing.T, api edgeproto.ClusterInstApiClient, testData []edgeproto.ClusterInst) {
 	span := log.StartSpan(log.DebugLevelApi, "ClientClusterInstDelete")
 	defer span.Finish()
@@ -420,6 +434,14 @@ func (x *ShowClusterInstInfo) Send(m *edgeproto.ClusterInstInfo) error {
 
 func (x *ShowClusterInstInfo) Context() context.Context {
 	return x.Ctx
+}
+
+func (x *ShowClusterInstInfo) ListData() []edgeproto.ClusterInstInfo {
+	data := []edgeproto.ClusterInstInfo{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
 }
 
 var ClusterInstInfoShowExtraCount = 0

--- a/test/testutil/debug_testutil.go
+++ b/test/testutil/debug_testutil.go
@@ -15,6 +15,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	"io"
 	math "math"
+	"testing"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -48,6 +49,9 @@ func RunDebugDataReverseApis(run *Run, in *edgeproto.DebugData, inMap map[string
 }
 
 func RunDebugDataShowApis(run *Run, in *edgeproto.DebugData, selector edgeproto.AllSelector, out *edgeproto.DebugData) {
+}
+
+func DeleteAllDebugDataInternal(t *testing.T, ctx context.Context, apis InternalCUDAPIs, in *edgeproto.DebugData) {
 }
 
 func (r *Run) DebugApi_DebugRequest(data *[]edgeproto.DebugRequest, dataMap interface{}, dataOut interface{}) {

--- a/test/testutil/device_testutil.go
+++ b/test/testutil/device_testutil.go
@@ -48,6 +48,14 @@ func (x *ShowDevice) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowDevice) ListData() []edgeproto.Device {
+	data := []edgeproto.Device{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var DeviceShowExtraCount = 0
 
 func (x *ShowDevice) ReadStream(stream edgeproto.DeviceApi_ShowDeviceClient, err error) {
@@ -249,6 +257,9 @@ func RunDeviceDataShowApis(run *Run, in *edgeproto.DeviceData, selector edgeprot
 	if selector.Has("devices") {
 		run.DeviceApi(&in.Devices, nil, &out.Devices)
 	}
+}
+
+func DeleteAllDeviceDataInternal(t *testing.T, ctx context.Context, apis InternalCUDAPIs, in *edgeproto.DeviceData) {
 }
 
 func (r *Run) DeviceApi(data *[]edgeproto.Device, dataMap interface{}, dataOut interface{}) {

--- a/test/testutil/device_testutil.go
+++ b/test/testutil/device_testutil.go
@@ -48,14 +48,6 @@ func (x *ShowDevice) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowDevice) ListData() []edgeproto.Device {
-	data := []edgeproto.Device{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var DeviceShowExtraCount = 0
 
 func (x *ShowDevice) ReadStream(stream edgeproto.DeviceApi_ShowDeviceClient, err error) {

--- a/test/testutil/flavor_testutil.go
+++ b/test/testutil/flavor_testutil.go
@@ -48,6 +48,14 @@ func (x *ShowFlavor) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowFlavor) ListData() []edgeproto.Flavor {
+	data := []edgeproto.Flavor{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var FlavorShowExtraCount = 0
 
 func (x *ShowFlavor) ReadStream(stream edgeproto.FlavorApi_ShowFlavorClient, err error) {
@@ -331,6 +339,12 @@ func InternalFlavorDelete(t *testing.T, api edgeproto.FlavorApiServer, testData 
 	ctx := log.ContextWithSpan(context.Background(), span)
 
 	DeleteFlavorData(t, ctx, NewInternalFlavorApi(api), testData)
+}
+
+func InternalFlavorDeleteAll(t *testing.T, ctx context.Context, api edgeproto.FlavorApiServer, data []edgeproto.Flavor) {
+	intapi := NewInternalFlavorApi(api)
+	log.SpanLog(ctx, log.DebugLevelInfo, "deleting all Flavors", "count", len(data))
+	DeleteFlavorData(t, ctx, intapi, data)
 }
 
 func ClientFlavorDelete(t *testing.T, api edgeproto.FlavorApiClient, testData []edgeproto.Flavor) {

--- a/test/testutil/flavor_testutil.go
+++ b/test/testutil/flavor_testutil.go
@@ -48,14 +48,6 @@ func (x *ShowFlavor) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowFlavor) ListData() []edgeproto.Flavor {
-	data := []edgeproto.Flavor{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var FlavorShowExtraCount = 0
 
 func (x *ShowFlavor) ReadStream(stream edgeproto.FlavorApi_ShowFlavorClient, err error) {

--- a/test/testutil/network_testutil.go
+++ b/test/testutil/network_testutil.go
@@ -48,6 +48,14 @@ func (x *ShowNetwork) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowNetwork) ListData() []edgeproto.Network {
+	data := []edgeproto.Network{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var NetworkShowExtraCount = 0
 
 type CudStreamoutNetwork struct {
@@ -373,6 +381,12 @@ func InternalNetworkDelete(t *testing.T, api edgeproto.NetworkApiServer, testDat
 	ctx := log.ContextWithSpan(context.Background(), span)
 
 	DeleteNetworkData(t, ctx, NewInternalNetworkApi(api), testData)
+}
+
+func InternalNetworkDeleteAll(t *testing.T, ctx context.Context, api edgeproto.NetworkApiServer, data []edgeproto.Network) {
+	intapi := NewInternalNetworkApi(api)
+	log.SpanLog(ctx, log.DebugLevelInfo, "deleting all Networks", "count", len(data))
+	DeleteNetworkData(t, ctx, intapi, data)
 }
 
 func ClientNetworkDelete(t *testing.T, api edgeproto.NetworkApiClient, testData []edgeproto.Network) {

--- a/test/testutil/network_testutil.go
+++ b/test/testutil/network_testutil.go
@@ -48,14 +48,6 @@ func (x *ShowNetwork) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowNetwork) ListData() []edgeproto.Network {
-	data := []edgeproto.Network{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var NetworkShowExtraCount = 0
 
 type CudStreamoutNetwork struct {

--- a/test/testutil/node_testutil.go
+++ b/test/testutil/node_testutil.go
@@ -47,6 +47,14 @@ func (x *ShowNode) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowNode) ListData() []edgeproto.Node {
+	data := []edgeproto.Node{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var NodeShowExtraCount = 0
 
 func (x *ShowNode) ReadStream(stream edgeproto.NodeApi_ShowNodeClient, err error) {
@@ -243,6 +251,9 @@ func RunNodeDataShowApis(run *Run, in *edgeproto.NodeData, selector edgeproto.Al
 	if selector.Has("nodes") {
 		run.NodeApi(&in.Nodes, nil, &out.Nodes)
 	}
+}
+
+func DeleteAllNodeDataInternal(t *testing.T, ctx context.Context, apis InternalCUDAPIs, in *edgeproto.NodeData) {
 }
 
 func (r *Run) NodeApi(data *[]edgeproto.Node, dataMap interface{}, dataOut interface{}) {

--- a/test/testutil/node_testutil.go
+++ b/test/testutil/node_testutil.go
@@ -47,14 +47,6 @@ func (x *ShowNode) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowNode) ListData() []edgeproto.Node {
-	data := []edgeproto.Node{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var NodeShowExtraCount = 0
 
 func (x *ShowNode) ReadStream(stream edgeproto.NodeApi_ShowNodeClient, err error) {

--- a/test/testutil/operatorcode_testutil.go
+++ b/test/testutil/operatorcode_testutil.go
@@ -47,6 +47,14 @@ func (x *ShowOperatorCode) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowOperatorCode) ListData() []edgeproto.OperatorCode {
+	data := []edgeproto.OperatorCode{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var OperatorCodeShowExtraCount = 0
 
 func (x *ShowOperatorCode) ReadStream(stream edgeproto.OperatorCodeApi_ShowOperatorCodeClient, err error) {
@@ -316,6 +324,12 @@ func InternalOperatorCodeDelete(t *testing.T, api edgeproto.OperatorCodeApiServe
 	ctx := log.ContextWithSpan(context.Background(), span)
 
 	DeleteOperatorCodeData(t, ctx, NewInternalOperatorCodeApi(api), testData)
+}
+
+func InternalOperatorCodeDeleteAll(t *testing.T, ctx context.Context, api edgeproto.OperatorCodeApiServer, data []edgeproto.OperatorCode) {
+	intapi := NewInternalOperatorCodeApi(api)
+	log.SpanLog(ctx, log.DebugLevelInfo, "deleting all OperatorCodes", "count", len(data))
+	DeleteOperatorCodeData(t, ctx, intapi, data)
 }
 
 func ClientOperatorCodeDelete(t *testing.T, api edgeproto.OperatorCodeApiClient, testData []edgeproto.OperatorCode) {

--- a/test/testutil/operatorcode_testutil.go
+++ b/test/testutil/operatorcode_testutil.go
@@ -47,14 +47,6 @@ func (x *ShowOperatorCode) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowOperatorCode) ListData() []edgeproto.OperatorCode {
-	data := []edgeproto.OperatorCode{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var OperatorCodeShowExtraCount = 0
 
 func (x *ShowOperatorCode) ReadStream(stream edgeproto.OperatorCodeApi_ShowOperatorCodeClient, err error) {

--- a/test/testutil/org_testutil.go
+++ b/test/testutil/org_testutil.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	math "math"
+	"testing"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -47,6 +48,9 @@ func RunOrganizationDataReverseApis(run *Run, in *edgeproto.OrganizationData, in
 }
 
 func RunOrganizationDataShowApis(run *Run, in *edgeproto.OrganizationData, selector edgeproto.AllSelector, out *edgeproto.OrganizationData) {
+}
+
+func DeleteAllOrganizationDataInternal(t *testing.T, ctx context.Context, apis InternalCUDAPIs, in *edgeproto.OrganizationData) {
 }
 
 func (r *Run) OrganizationApi(data *[]edgeproto.Organization, dataMap interface{}, dataOut interface{}) {

--- a/test/testutil/ratelimit_testutil.go
+++ b/test/testutil/ratelimit_testutil.go
@@ -16,6 +16,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	"io"
 	math "math"
+	"testing"
 	"time"
 )
 
@@ -48,6 +49,9 @@ func RunRateLimitSettingsDataShowApis(run *Run, in *edgeproto.RateLimitSettingsD
 	if selector.Has("settings") {
 		run.RateLimitSettingsApi(&in.Settings, nil, &out.Settings)
 	}
+}
+
+func DeleteAllRateLimitSettingsDataInternal(t *testing.T, ctx context.Context, apis InternalCUDAPIs, in *edgeproto.RateLimitSettingsData) {
 }
 
 func (r *Run) RateLimitSettingsApi_FlowRateLimitSettings(data *[]edgeproto.FlowRateLimitSettings, dataMap interface{}, dataOut interface{}) {

--- a/test/testutil/refs_testutil.go
+++ b/test/testutil/refs_testutil.go
@@ -46,6 +46,14 @@ func (x *ShowCloudletRefs) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowCloudletRefs) ListData() []edgeproto.CloudletRefs {
+	data := []edgeproto.CloudletRefs{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var CloudletRefsShowExtraCount = 0
 
 func (x *ShowCloudletRefs) ReadStream(stream edgeproto.CloudletRefsApi_ShowCloudletRefsClient, err error) {
@@ -238,6 +246,14 @@ func (x *ShowClusterRefs) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowClusterRefs) ListData() []edgeproto.ClusterRefs {
+	data := []edgeproto.ClusterRefs{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var ClusterRefsShowExtraCount = 0
 
 func (x *ShowClusterRefs) ReadStream(stream edgeproto.ClusterRefsApi_ShowClusterRefsClient, err error) {
@@ -428,6 +444,14 @@ func (x *ShowAppInstRefs) Send(m *edgeproto.AppInstRefs) error {
 
 func (x *ShowAppInstRefs) Context() context.Context {
 	return x.Ctx
+}
+
+func (x *ShowAppInstRefs) ListData() []edgeproto.AppInstRefs {
+	data := []edgeproto.AppInstRefs{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
 }
 
 var AppInstRefsShowExtraCount = 0

--- a/test/testutil/refs_testutil.go
+++ b/test/testutil/refs_testutil.go
@@ -46,14 +46,6 @@ func (x *ShowCloudletRefs) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowCloudletRefs) ListData() []edgeproto.CloudletRefs {
-	data := []edgeproto.CloudletRefs{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var CloudletRefsShowExtraCount = 0
 
 func (x *ShowCloudletRefs) ReadStream(stream edgeproto.CloudletRefsApi_ShowCloudletRefsClient, err error) {
@@ -246,14 +238,6 @@ func (x *ShowClusterRefs) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowClusterRefs) ListData() []edgeproto.ClusterRefs {
-	data := []edgeproto.ClusterRefs{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var ClusterRefsShowExtraCount = 0
 
 func (x *ShowClusterRefs) ReadStream(stream edgeproto.ClusterRefsApi_ShowClusterRefsClient, err error) {
@@ -444,14 +428,6 @@ func (x *ShowAppInstRefs) Send(m *edgeproto.AppInstRefs) error {
 
 func (x *ShowAppInstRefs) Context() context.Context {
 	return x.Ctx
-}
-
-func (x *ShowAppInstRefs) ListData() []edgeproto.AppInstRefs {
-	data := []edgeproto.AppInstRefs{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
 }
 
 var AppInstRefsShowExtraCount = 0

--- a/test/testutil/restagtable_testutil.go
+++ b/test/testutil/restagtable_testutil.go
@@ -48,6 +48,14 @@ func (x *ShowResTagTable) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowResTagTable) ListData() []edgeproto.ResTagTable {
+	data := []edgeproto.ResTagTable{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var ResTagTableShowExtraCount = 0
 
 func (x *ShowResTagTable) ReadStream(stream edgeproto.ResTagTableApi_ShowResTagTableClient, err error) {
@@ -317,6 +325,12 @@ func InternalResTagTableDelete(t *testing.T, api edgeproto.ResTagTableApiServer,
 	ctx := log.ContextWithSpan(context.Background(), span)
 
 	DeleteResTagTableData(t, ctx, NewInternalResTagTableApi(api), testData)
+}
+
+func InternalResTagTableDeleteAll(t *testing.T, ctx context.Context, api edgeproto.ResTagTableApiServer, data []edgeproto.ResTagTable) {
+	intapi := NewInternalResTagTableApi(api)
+	log.SpanLog(ctx, log.DebugLevelInfo, "deleting all ResTagTables", "count", len(data))
+	DeleteResTagTableData(t, ctx, intapi, data)
 }
 
 func ClientResTagTableDelete(t *testing.T, api edgeproto.ResTagTableApiClient, testData []edgeproto.ResTagTable) {

--- a/test/testutil/restagtable_testutil.go
+++ b/test/testutil/restagtable_testutil.go
@@ -48,14 +48,6 @@ func (x *ShowResTagTable) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowResTagTable) ListData() []edgeproto.ResTagTable {
-	data := []edgeproto.ResTagTable{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var ResTagTableShowExtraCount = 0
 
 func (x *ShowResTagTable) ReadStream(stream edgeproto.ResTagTableApi_ShowResTagTableClient, err error) {

--- a/test/testutil/trustpolicy_testutil.go
+++ b/test/testutil/trustpolicy_testutil.go
@@ -48,14 +48,6 @@ func (x *ShowTrustPolicy) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowTrustPolicy) ListData() []edgeproto.TrustPolicy {
-	data := []edgeproto.TrustPolicy{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var TrustPolicyShowExtraCount = 0
 
 type CudStreamoutTrustPolicy struct {

--- a/test/testutil/trustpolicy_testutil.go
+++ b/test/testutil/trustpolicy_testutil.go
@@ -48,6 +48,14 @@ func (x *ShowTrustPolicy) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowTrustPolicy) ListData() []edgeproto.TrustPolicy {
+	data := []edgeproto.TrustPolicy{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var TrustPolicyShowExtraCount = 0
 
 type CudStreamoutTrustPolicy struct {
@@ -373,6 +381,12 @@ func InternalTrustPolicyDelete(t *testing.T, api edgeproto.TrustPolicyApiServer,
 	ctx := log.ContextWithSpan(context.Background(), span)
 
 	DeleteTrustPolicyData(t, ctx, NewInternalTrustPolicyApi(api), testData)
+}
+
+func InternalTrustPolicyDeleteAll(t *testing.T, ctx context.Context, api edgeproto.TrustPolicyApiServer, data []edgeproto.TrustPolicy) {
+	intapi := NewInternalTrustPolicyApi(api)
+	log.SpanLog(ctx, log.DebugLevelInfo, "deleting all TrustPolicys", "count", len(data))
+	DeleteTrustPolicyData(t, ctx, intapi, data)
 }
 
 func ClientTrustPolicyDelete(t *testing.T, api edgeproto.TrustPolicyApiClient, testData []edgeproto.TrustPolicy) {

--- a/test/testutil/trustpolicyexception_testutil.go
+++ b/test/testutil/trustpolicyexception_testutil.go
@@ -49,14 +49,6 @@ func (x *ShowTrustPolicyException) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowTrustPolicyException) ListData() []edgeproto.TrustPolicyException {
-	data := []edgeproto.TrustPolicyException{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var TrustPolicyExceptionShowExtraCount = 0
 
 func (x *ShowTrustPolicyException) ReadStream(stream edgeproto.TrustPolicyExceptionApi_ShowTrustPolicyExceptionClient, err error) {

--- a/test/testutil/trustpolicyexception_testutil.go
+++ b/test/testutil/trustpolicyexception_testutil.go
@@ -49,6 +49,14 @@ func (x *ShowTrustPolicyException) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowTrustPolicyException) ListData() []edgeproto.TrustPolicyException {
+	data := []edgeproto.TrustPolicyException{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var TrustPolicyExceptionShowExtraCount = 0
 
 func (x *ShowTrustPolicyException) ReadStream(stream edgeproto.TrustPolicyExceptionApi_ShowTrustPolicyExceptionClient, err error) {
@@ -332,6 +340,12 @@ func InternalTrustPolicyExceptionDelete(t *testing.T, api edgeproto.TrustPolicyE
 	ctx := log.ContextWithSpan(context.Background(), span)
 
 	DeleteTrustPolicyExceptionData(t, ctx, NewInternalTrustPolicyExceptionApi(api), testData)
+}
+
+func InternalTrustPolicyExceptionDeleteAll(t *testing.T, ctx context.Context, api edgeproto.TrustPolicyExceptionApiServer, data []edgeproto.TrustPolicyException) {
+	intapi := NewInternalTrustPolicyExceptionApi(api)
+	log.SpanLog(ctx, log.DebugLevelInfo, "deleting all TrustPolicyExceptions", "count", len(data))
+	DeleteTrustPolicyExceptionData(t, ctx, intapi, data)
 }
 
 func ClientTrustPolicyExceptionDelete(t *testing.T, api edgeproto.TrustPolicyExceptionApiClient, testData []edgeproto.TrustPolicyException) {

--- a/test/testutil/vmpool_testutil.go
+++ b/test/testutil/vmpool_testutil.go
@@ -49,6 +49,14 @@ func (x *ShowVMPool) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *ShowVMPool) ListData() []edgeproto.VMPool {
+	data := []edgeproto.VMPool{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var VMPoolShowExtraCount = 0
 
 func (x *ShowVMPool) ReadStream(stream edgeproto.VMPoolApi_ShowVMPoolClient, err error) {
@@ -332,6 +340,12 @@ func InternalVMPoolDelete(t *testing.T, api edgeproto.VMPoolApiServer, testData 
 	ctx := log.ContextWithSpan(context.Background(), span)
 
 	DeleteVMPoolData(t, ctx, NewInternalVMPoolApi(api), testData)
+}
+
+func InternalVMPoolDeleteAll(t *testing.T, ctx context.Context, api edgeproto.VMPoolApiServer, data []edgeproto.VMPool) {
+	intapi := NewInternalVMPoolApi(api)
+	log.SpanLog(ctx, log.DebugLevelInfo, "deleting all VMPools", "count", len(data))
+	DeleteVMPoolData(t, ctx, intapi, data)
 }
 
 func ClientVMPoolDelete(t *testing.T, api edgeproto.VMPoolApiClient, testData []edgeproto.VMPool) {

--- a/test/testutil/vmpool_testutil.go
+++ b/test/testutil/vmpool_testutil.go
@@ -49,14 +49,6 @@ func (x *ShowVMPool) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *ShowVMPool) ListData() []edgeproto.VMPool {
-	data := []edgeproto.VMPool{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var VMPoolShowExtraCount = 0
 
 func (x *ShowVMPool) ReadStream(stream edgeproto.VMPoolApi_ShowVMPoolClient, err error) {

--- a/tools/protoc-gen-test/testcud.go
+++ b/tools/protoc-gen-test/testcud.go
@@ -123,14 +123,6 @@ func (x *Show{{.Name}}) Context() context.Context {
 	return x.Ctx
 }
 
-func (x *Show{{.Name}}) ListData() []{{.Pkg}}.{{.Name}} {
-	data := []{{.Pkg}}.{{.Name}}{}
-	for _, val := range x.Data {
-		data = append(data, val)
-	}
-	return data
-}
-
 var {{.Name}}ShowExtraCount = 0
 
 {{- if .Streamout}}
@@ -1304,14 +1296,12 @@ func (t *TestCud) genE2edata(desc *generator.Descriptor) {
 	t.P()
 
 	t.P("func DeleteAll", message.Name, "Internal(t *testing.T, ctx context.Context, apis InternalCUDAPIs, in *", pkg, message.Name, ") {")
-	//t.P("func DeleteAll", message.Name, "Internal(t *testing.T, ctx context.Context, apis InternalCUDAPIs) {")
 	for ii := len(fieldInfos) - 1; ii >= 0; ii-- {
 		finfo := fieldInfos[ii]
 		if !finfo.genCUD {
 			continue
 		}
 		t.P("Internal", finfo.baseType, "DeleteAll(t, ctx, apis.Get", finfo.group.ApiName(), "(), in.", finfo.fieldName, ")")
-		//t.P("Internal", finfo.baseType, "DeleteAll(t, ctx, apis.Get", finfo.group.ApiName(), "())")
 	}
 	t.P("}")
 	t.P()

--- a/tools/protoc-gen-test/testcud.go
+++ b/tools/protoc-gen-test/testcud.go
@@ -123,6 +123,14 @@ func (x *Show{{.Name}}) Context() context.Context {
 	return x.Ctx
 }
 
+func (x *Show{{.Name}}) ListData() []{{.Pkg}}.{{.Name}} {
+	data := []{{.Pkg}}.{{.Name}}{}
+	for _, val := range x.Data {
+		data = append(data, val)
+	}
+	return data
+}
+
 var {{.Name}}ShowExtraCount = 0
 
 {{- if .Streamout}}
@@ -475,6 +483,12 @@ func Internal{{.Name}}{{.Delete}}(t *testing.T, api {{.Pkg}}.{{.Name}}ApiServer,
 	{{.Delete}}{{.Name}}Data(t, ctx, NewInternal{{.Name}}Api(api), testData)
 }
 
+func Internal{{.Name}}{{.Delete}}All(t *testing.T, ctx context.Context, api {{.Pkg}}.{{.Name}}ApiServer, data []{{.Pkg}}.{{.Name}}) {
+	intapi := NewInternal{{.Name}}Api(api)
+	log.SpanLog(ctx, log.DebugLevelInfo, "deleting all {{.Name}}s", "count", len(data))
+	{{.Delete}}{{.Name}}Data(t, ctx, intapi, data)
+}
+
 func Client{{.Name}}{{.Delete}}(t *testing.T, api {{.Pkg}}.{{.Name}}ApiClient, testData []{{.Pkg}}.{{.Name}}) {
 	span := log.StartSpan(log.DebugLevelApi, "Client{{.Name}}{{.Delete}}")
 	defer span.Finish()
@@ -609,7 +623,7 @@ func (t *TestCud) Generate(file *generator.FileDescriptor) {
 	}
 	if t.firstFile {
 		t.genDummyServer()
-		t.genClient()
+		t.genClient(file)
 		t.firstFile = false
 	}
 	gensupport.RunParseCheck(t.Generator, file)
@@ -1133,7 +1147,7 @@ func (t *TestCud) genClientInterface(service *descriptor.ServiceDescriptorProto)
 	t.P()
 }
 
-func (t *TestCud) genClient() {
+func (t *TestCud) genClient(fileDesc *generator.FileDescriptor) {
 	t.P("type ApiClient struct {")
 	t.P("Conn *grpc.ClientConn")
 	t.P("}")
@@ -1159,6 +1173,29 @@ func (t *TestCud) genClient() {
 	}
 	t.P("}")
 	t.P()
+
+	t.P("type InternalCUDAPIs interface {")
+	for _, file := range t.Generator.Request.ProtoFile {
+		if len(file.Service) == 0 {
+			continue
+		}
+		for _, service := range file.Service {
+			if gensupport.GetInternalApi(service) {
+				continue
+			}
+			if hasSupportedMethod(service) {
+				method := service.Method[0]
+				in := gensupport.GetDesc(t.Generator, method.GetInputType())
+				genCud := GetGenerateCudTest(in.DescriptorProto)
+				if genCud {
+					pkg := t.support.GetPackageName(t.Generator, in)
+					t.P("Get", service.Name, "() ", pkg, ".", service.Name, "Server")
+				}
+			}
+		}
+	}
+	t.P("}")
+	t.P()
 	t.importGrpc = true
 	t.importWrapper = true
 }
@@ -1168,6 +1205,8 @@ type e2eFieldInfo struct {
 	ref       string
 	group     *gensupport.MethodGroup
 	info      *gensupport.MethodInfo
+	baseType  string
+	genCUD    bool
 }
 
 func (t *TestCud) genE2edata(desc *generator.Descriptor) {
@@ -1192,9 +1231,11 @@ func (t *TestCud) genE2edata(desc *generator.Descriptor) {
 		for _, info := range group.MethodInfos {
 			finfo := e2eFieldInfo{
 				fieldName: generator.CamelCase(*field.Name),
+				baseType:  inType,
 				group:     group,
 				info:      info,
 				ref:       "&",
+				genCUD:    GetGenerateCudTest(fieldDesc.DescriptorProto),
 			}
 			if group.SingularData {
 				finfo.ref = ""
@@ -1261,6 +1302,21 @@ func (t *TestCud) genE2edata(desc *generator.Descriptor) {
 	}
 	t.P("}")
 	t.P()
+
+	t.P("func DeleteAll", message.Name, "Internal(t *testing.T, ctx context.Context, apis InternalCUDAPIs, in *", pkg, message.Name, ") {")
+	//t.P("func DeleteAll", message.Name, "Internal(t *testing.T, ctx context.Context, apis InternalCUDAPIs) {")
+	for ii := len(fieldInfos) - 1; ii >= 0; ii-- {
+		finfo := fieldInfos[ii]
+		if !finfo.genCUD {
+			continue
+		}
+		t.P("Internal", finfo.baseType, "DeleteAll(t, ctx, apis.Get", finfo.group.ApiName(), "(), in.", finfo.fieldName, ")")
+		//t.P("Internal", finfo.baseType, "DeleteAll(t, ctx, apis.Get", finfo.group.ApiName(), "())")
+	}
+	t.P("}")
+	t.P()
+	t.importTesting = true
+	t.importContext = true
 }
 
 func GetGenerateCud(message *descriptor.DescriptorProto) bool {


### PR DESCRIPTION
A recent upgrade function had a bug that caused a failure to delete existing objects after upgrade because a reference was missing. This change adds a delete test after the upgrade test to check that deletes will work after the upgrade is done. The intended use is to test new upgrade functions by taking a dump of an existing deployment and feeding it through the upgrade test. The deletes mimic what a user may do with existing objects.

We may want to consider more consistency checks later as well, in particular verifying refs objects data.