### PR TITLE
nbi scaffolding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,9 @@ addlicense:
 		-ignore pkg/platform/common/vmlayer/TestSetupIptablesRulesForRootLB-expected.sh \
 		-ignore pkg/proxy/test-envoy-config-expected.yaml \
 		-ignore pkg/proxy/test-envoy-sds-expected.yaml \
+		-ignore api/nbi/openapi/Edge-Application-Management.yaml \
+		-ignore api/nbi/openapi/Edge-Application-Management-official.yaml \
+		-ignore api/nbi/generated.go \
 		.
 
 lint:

--- a/api/nbi/config.yaml
+++ b/api/nbi/config.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 EdgeXR, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 package: nbi
 generate:
   echo-server: true

--- a/api/nbi/nbi-generated.go
+++ b/api/nbi/nbi-generated.go
@@ -173,13 +173,13 @@ type AdditionalStorage = []struct {
 // AppId A globally unique identifier associated with the application.
 // Edge Cloud Platform generates this identifier when the
 // Application is submitted.
-type AppId = openapi_types.UUID
+type AppId = string
 
 // AppInstanceId A globally unique identifier associated with a running
 // instance of an application.
 // Edge Cloud Platform generates this identifier when the
 // instantiation in the Edge Cloud Zone is successful.
-type AppInstanceId = openapi_types.UUID
+type AppInstanceId = string
 
 // AppInstanceInfo Information about the application instance.
 type AppInstanceInfo struct {
@@ -442,7 +442,7 @@ type EdgeCloudZone struct {
 
 // EdgeCloudZoneId Unique identifier created by the Edge Cloud Platform to identify an
 // Edge Cloud Zone within an Edge Cloud.
-type EdgeCloudZoneId = openapi_types.UUID
+type EdgeCloudZoneId = string
 
 // EdgeCloudZoneName Human readable name of the geographical zone of
 // the Edge Cloud. Defined by the Edge Cloud Provider.
@@ -547,7 +547,7 @@ type K8sNetworkingAdditionalNetworksInterfaceType string
 
 // KubernetesClusterRef A global unique identifier associated with a Kubernetes cluster
 // infrastructure.
-type KubernetesClusterRef = openapi_types.UUID
+type KubernetesClusterRef = string
 
 // KubernetesResources Definition of Kubernetes Cluster Infrastructure.
 type KubernetesResources struct {

--- a/api/nbi/openapi/Edge-Application-Management.yaml
+++ b/api/nbi/openapi/Edge-Application-Management.yaml
@@ -654,7 +654,6 @@ components:
 
     AppId:
       type: string
-      format: uuid
       description: |
         A globally unique identifier associated with the application.
         Edge Cloud Platform generates this identifier when the
@@ -662,7 +661,6 @@ components:
 
     AppInstanceId:
       type: string
-      format: uuid
       description: |
         A globally unique identifier associated with a running
         instance of an application.
@@ -910,7 +908,6 @@ components:
 
     EdgeCloudZoneId:
       type: string
-      format: uuid
       description: |
         Unique identifier created by the Edge Cloud Platform to identify an
         Edge Cloud Zone within an Edge Cloud.
@@ -1094,8 +1091,6 @@ components:
         A global unique identifier associated with a Kubernetes cluster
         infrastructure.
       type: string
-      format: uuid
-      example: "642f6105-7015-4af1-a4d1-e1ecb8437abc"
 
     KubernetesResources:
       description: Definition of Kubernetes Cluster Infrastructure.

--- a/api/nbi/openapi/patches/04-rm-uuid-format.patch
+++ b/api/nbi/openapi/patches/04-rm-uuid-format.patch
@@ -1,0 +1,35 @@
+--- Edge-Application-Management.yaml.last	2024-09-20 17:18:32.307516180 -0700
++++ Edge-Application-Management.yaml	2024-09-20 17:19:12.998769047 -0700
+@@ -654,7 +654,6 @@
+ 
+     AppId:
+       type: string
+-      format: uuid
+       description: |
+         A globally unique identifier associated with the application.
+         Edge Cloud Platform generates this identifier when the
+@@ -662,7 +661,6 @@
+ 
+     AppInstanceId:
+       type: string
+-      format: uuid
+       description: |
+         A globally unique identifier associated with a running
+         instance of an application.
+@@ -910,7 +908,6 @@
+ 
+     EdgeCloudZoneId:
+       type: string
+-      format: uuid
+       description: |
+         Unique identifier created by the Edge Cloud Platform to identify an
+         Edge Cloud Zone within an Edge Cloud.
+@@ -1094,8 +1091,6 @@
+         A global unique identifier associated with a Kubernetes cluster
+         infrastructure.
+       type: string
+-      format: uuid
+-      example: "642f6105-7015-4af1-a4d1-e1ecb8437abc"
+ 
+     KubernetesResources:
+       description: Definition of Kubernetes Cluster Infrastructure.

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/cloudflare/cloudflare-go v0.13.4 // indirect
 	github.com/codeskyblue/go-sh v0.0.0-20170112005953-b097669b1569
-	github.com/creack/pty v1.1.11
+	github.com/creack/pty v1.1.18
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/daviddengcn/go-colortext v0.0.0-20171126034257-17e75f6184bc
 	github.com/go-openapi/errors v0.20.3
@@ -167,7 +167,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect
 	github.com/moby/sys/sequential v0.5.0 // indirect
-	github.com/moby/term v0.0.0-20221105221325-4eb28fa6025c // indirect
+	github.com/moby/term v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
@@ -210,7 +210,7 @@ require (
 	google.golang.org/protobuf v1.32.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	gotest.tools/v3 v3.0.3 // indirect
+	gotest.tools/v3 v3.5.0 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
 	k8s.io/utils v0.0.0-20230220204549-a5ecb0141aa5 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
-github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -437,8 +437,8 @@ github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkV
 github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/sys/sequential v0.5.0 h1:OPvI35Lzn9K04PBbCLW0g4LcFAJgHsvXsRyewg5lXtc=
 github.com/moby/sys/sequential v0.5.0/go.mod h1:tH2cOOs5V9MlPiXcQzRC+eEyab644PWKGRYaaV5ZZlo=
-github.com/moby/term v0.0.0-20221105221325-4eb28fa6025c h1:RC8WMpjonrBfyAh6VN/POIPtYD5tRAq0qMqCRjQNK+g=
-github.com/moby/term v0.0.0-20221105221325-4eb28fa6025c/go.mod h1:9OcmHNQQUTbk4XCffrLgN1NEKc2mh5u++biHVrvHsSU=
+github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
+github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -797,7 +797,6 @@ golang.org/x/tools v0.0.0-20190416151739-9c9e1878f421/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190420181800-aa740d480789/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190531172133-b3315ee88b7d/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
-golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -894,8 +893,8 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
-gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
+gotest.tools/v3 v3.5.0 h1:Ljk6PdHdOhAb5aDMWXjDLMMhph+BpztA4v1QdqEW2eY=
+gotest.tools/v3 v3.5.0/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.26.2 h1:dM3cinp3PGB6asOySalOZxEG4CZ0IAdJsrYZXE/ovGQ=

--- a/pkg/cloudcommon/names.go
+++ b/pkg/cloudcommon/names.go
@@ -224,6 +224,8 @@ var CustomMetric = "custom-metric"
 var VmRegPath = "/storage/v1/artifacts"
 var VmRegPullPath = "/storage/v1/pull"
 var VmRegHeaderMD5 = "X-Checksum-Md5"
+var ControllerEdgeprotoRESTPath = "/edgeproto/v1"
+var NBIRootPath = "/edge-application-management/vwip"
 
 // Map used to identify which metrics should go to persistent_metrics db. Value represents the measurement creation status
 var EdgeEventsMetrics = map[string]struct{}{

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -548,7 +548,7 @@ func startServices() error {
 	if err != nil {
 		return fmt.Errorf("Failed to create grpc gateway, %v", err)
 	}
-	mux.Handle("/edgeproto/v1/", gw)
+	mux.Handle(cloudcommon.ControllerEdgeprotoRESTPath, gw)
 	// Suppress contant stream of TLS error logs due to LB health check. There is discussion in the community
 	//to get rid of some of these logs, but as of now this a the way around it.   We could miss other logs here but
 	// the excessive error logs are drowning out everthing else.
@@ -560,8 +560,9 @@ func startServices() error {
 	e.Use(log.EchoTraceHandler, log.EchoAuditLogger)
 	e.HideBanner = true
 	nbiHandler := nbi.NewStrictHandler(nbiApis, []nbi.StrictMiddlewareFunc{})
-	nbi.RegisterHandlersWithBaseURL(e, nbiHandler, "/edge-application-management/vwip")
-	mux.Handle("/edge-application-management/vwip/", e)
+	nbi.RegisterHandlersWithBaseURL(e, nbiHandler, cloudcommon.NBIRootPath)
+	// note that the trailing / is needed to do sub-path matching
+	mux.Handle(cloudcommon.NBIRootPath+"/", e)
 
 	httpServer := &http.Server{
 		Addr:      *httpAddr,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/api/nbi"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon/node"
 	influxq "github.com/edgexr/edge-cloud-platform/pkg/influxq_client"
@@ -50,6 +51,7 @@ import (
 	"github.com/go-redis/redis/v8"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/labstack/echo/v4"
 	yaml "github.com/mobiledgex/yaml/v2"
 	"google.golang.org/grpc"
 )
@@ -65,12 +67,11 @@ var apiAddr = flag.String("apiAddr", "127.0.0.1:55001", "API listener address")
 // external API Addr is registered with etcd so other controllers can connect
 // directly to this controller.
 var externalApiAddr = flag.String("externalApiAddr", "", "External API listener address if behind proxy/LB. Defaults to apiAddr")
-var httpAddr = flag.String("httpAddr", "127.0.0.1:8091", "HTTP listener address")
+var httpAddr = flag.String("httpAddr", "127.0.0.1:8901", "HTTP listener address")
 var notifyAddr = flag.String("notifyAddr", "127.0.0.1:50001", "Notify listener address")
 var notifyRootAddrs = flag.String("notifyRootAddrs", "", "Comma separated list of notifyroots")
 var notifyParentAddrs = flag.String("notifyParentAddrs", "", "Comma separated list of notify parents")
 var accessApiAddr = flag.String("accessApiAddr", "127.0.0.1:41001", "listener address for external services with access key")
-
 var edgeTurnAddr = flag.String("edgeTurnAddr", "127.0.0.1:6080", "Address to EdgeTurn Server")
 var edgeTurnProxyAddr = flag.String("edgeTurnProxyAddr", "127.0.0.1:8443", "Address to EdgeTurn Server")
 var debugLevels = flag.String("d", "", fmt.Sprintf("comma separated list of %v", log.DebugLevelStrings))
@@ -547,12 +548,20 @@ func startServices() error {
 	if err != nil {
 		return fmt.Errorf("Failed to create grpc gateway, %v", err)
 	}
-	mux.Handle("/", gw)
+	mux.Handle("/edgeproto/v1/", gw)
 	// Suppress contant stream of TLS error logs due to LB health check. There is discussion in the community
 	//to get rid of some of these logs, but as of now this a the way around it.   We could miss other logs here but
 	// the excessive error logs are drowning out everthing else.
 	var nullLogger baselog.Logger
 	nullLogger.SetOutput(io.Discard)
+
+	nbiApis := NewNBIAPI(allApis)
+	e := echo.New()
+	e.Use(log.EchoTraceHandler, log.EchoAuditLogger)
+	e.HideBanner = true
+	nbiHandler := nbi.NewStrictHandler(nbiApis, []nbi.StrictMiddlewareFunc{})
+	nbi.RegisterHandlersWithBaseURL(e, nbiHandler, "/edge-application-management/vwip")
+	mux.Handle("/edge-application-management/vwip/", e)
 
 	httpServer := &http.Server{
 		Addr:      *httpAddr,

--- a/pkg/controller/nbi_api.go
+++ b/pkg/controller/nbi_api.go
@@ -1,0 +1,87 @@
+// Copyright 2024 EdgeXR, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"net/http"
+	"slices"
+
+	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/api/nbi"
+	"github.com/edgexr/edge-cloud-platform/pkg/nbiconvert"
+	"github.com/labstack/echo/v4"
+)
+
+// NBIAPI implements nbi.ServerInterface
+type NBIAPI struct {
+	allApis *AllApis
+}
+
+func NewNBIAPI(allApis *AllApis) *NBIAPI {
+	return &NBIAPI{
+		allApis: allApis,
+	}
+}
+
+func (s *NBIAPI) GetApps(ctx context.Context, request nbi.GetAppsRequestObject) (nbi.GetAppsResponseObject, error) {
+	return nil, echo.NewHTTPError(http.StatusNotImplemented, "Not implemented yet")
+}
+
+func (s *NBIAPI) SubmitApp(ctx context.Context, request nbi.SubmitAppRequestObject) (nbi.SubmitAppResponseObject, error) {
+	return nil, echo.NewHTTPError(http.StatusNotImplemented, "Not implemented yet")
+}
+
+func (s *NBIAPI) DeleteApp(ctx context.Context, request nbi.DeleteAppRequestObject) (nbi.DeleteAppResponseObject, error) {
+	return nil, echo.NewHTTPError(http.StatusNotImplemented, "Not implemented yet")
+}
+
+func (s *NBIAPI) GetApp(ctx context.Context, request nbi.GetAppRequestObject) (nbi.GetAppResponseObject, error) {
+	return nil, echo.NewHTTPError(http.StatusNotImplemented, "Not implemented yet")
+}
+
+func (s *NBIAPI) GetAppInstance(ctx context.Context, request nbi.GetAppInstanceRequestObject) (nbi.GetAppInstanceResponseObject, error) {
+	return nil, echo.NewHTTPError(http.StatusNotImplemented, "Not implemented yet")
+}
+
+func (s *NBIAPI) CreateAppInstance(ctx context.Context, request nbi.CreateAppInstanceRequestObject) (nbi.CreateAppInstanceResponseObject, error) {
+	return nil, echo.NewHTTPError(http.StatusNotImplemented, "Not implemented yet")
+}
+
+func (s *NBIAPI) DeleteAppInstance(ctx context.Context, request nbi.DeleteAppInstanceRequestObject) (nbi.DeleteAppInstanceResponseObject, error) {
+	return nil, echo.NewHTTPError(http.StatusNotImplemented, "Not implemented yet")
+}
+
+func (s *NBIAPI) GetEdgeCloudZones(ctx context.Context, request nbi.GetEdgeCloudZonesRequestObject) (nbi.GetEdgeCloudZonesResponseObject, error) {
+	filter := &edgeproto.Zone{}
+	resp := nbi.GetEdgeCloudZones200JSONResponse{}
+	err := s.allApis.zoneApi.cache.Show(filter, func(obj *edgeproto.Zone) error {
+		resp.Body = append(resp.Body, *nbiconvert.NBIZone(obj, *region))
+		return nil
+	})
+	if err != nil {
+		return nil, echoShowErr("zone", err)
+	}
+	slices.SortStableFunc(resp.Body, nbiconvert.ZoneSort)
+	return nbi.GetEdgeCloudZonesResponseObject(&resp), nil
+}
+
+func echoShowErr(objType string, err error) error {
+	return &echo.HTTPError{
+		Code:     http.StatusInternalServerError,
+		Message:  "failed to get " + objType + " information",
+		Internal: err,
+	}
+}

--- a/pkg/nbiconvert/nbiconvert_zone.go
+++ b/pkg/nbiconvert/nbiconvert_zone.go
@@ -1,0 +1,39 @@
+// Copyright 2024 EdgeXR, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package nbiconvert provides conversion functions between
+// NBI structs and edgeproto structs
+package nbiconvert
+
+import (
+	"strings"
+
+	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/api/nbi"
+)
+
+func NBIZone(in *edgeproto.Zone, region string) *nbi.EdgeCloudZone {
+	zone := nbi.EdgeCloudZone{}
+	zone.EdgeCloudProvider = in.Key.Organization
+	zone.EdgeCloudRegion = &region
+	zone.EdgeCloudZoneId = in.ObjId
+	zone.EdgeCloudZoneName = in.Key.Name
+	return &zone
+}
+
+func ZoneSort(a, b nbi.EdgeCloudZone) int {
+	akey := a.EdgeCloudProvider + a.EdgeCloudZoneName
+	bkey := b.EdgeCloudProvider + b.EdgeCloudZoneName
+	return strings.Compare(akey, bkey)
+}

--- a/pkg/nbictl/nbictl_apply.go
+++ b/pkg/nbictl/nbictl_apply.go
@@ -12,6 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config=config.yaml openapi/Edge-Application-Management.yaml
+package nbictl
 
-package nbi
+import (
+	"context"
+
+	"github.com/edgexr/edge-cloud-platform/api/nbi"
+)
+
+func ApplyAll(ctx context.Context, client *nbi.ClientWithResponses, data *ApplyData) []APIErr {
+	return nil
+}

--- a/pkg/nbictl/nbictl_data.go
+++ b/pkg/nbictl/nbictl_data.go
@@ -1,0 +1,75 @@
+// Copyright 2024 EdgeXR, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package nbictl provides client functions for accessing the NBI
+// (north bound interface)
+package nbictl
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+
+	"github.com/edgexr/edge-cloud-platform/api/nbi"
+)
+
+type AppInst struct {
+	AppID    nbi.AppId    `json:"appid"`
+	AppZones nbi.AppZones `json:"appzones"`
+}
+
+type ApplyData struct {
+	Apps     []nbi.AppManifest `json:"apps,omitempty"`
+	AppInsts []AppInst         `json:"appinsts,omitempty"`
+}
+
+type GetData struct {
+	Apps     []nbi.AppManifest     `json:"apps,omitempty"`
+	AppInsts []nbi.AppInstanceInfo `json:"appinsts,omitempty"`
+	Zones    []nbi.EdgeCloudZone   `json:"zones,omitempty"`
+}
+
+type APIErr struct {
+	Desc   string
+	Status int
+	Err    error
+}
+
+func getURL(addr string) string {
+	return addr + "/edge-application-management/vwip"
+}
+
+func BasicClient(addr, bearerToken string, skipVerify bool) (*nbi.ClientWithResponses, error) {
+	url := getURL(addr)
+	customize := func(client *nbi.Client) error {
+		if skipVerify {
+			client.Client = &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{
+						InsecureSkipVerify: true,
+					},
+				},
+			}
+		}
+		if bearerToken != "" {
+			addToken := func(ctx context.Context, req *http.Request) error {
+				req.Header.Add("Authorization", "Bearer "+bearerToken)
+				return nil
+			}
+			client.RequestEditors = append(client.RequestEditors, addToken)
+		}
+		return nil
+	}
+	return nbi.NewClientWithResponses(url, customize)
+}

--- a/pkg/nbictl/nbictl_data.go
+++ b/pkg/nbictl/nbictl_data.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"github.com/edgexr/edge-cloud-platform/api/nbi"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 )
 
 type AppInst struct {
@@ -47,7 +48,7 @@ type APIErr struct {
 }
 
 func getURL(addr string) string {
-	return addr + "/edge-application-management/vwip"
+	return addr + cloudcommon.NBIRootPath
 }
 
 func BasicClient(addr, bearerToken string, skipVerify bool) (*nbi.ClientWithResponses, error) {

--- a/pkg/nbictl/nbictl_get.go
+++ b/pkg/nbictl/nbictl_get.go
@@ -1,0 +1,95 @@
+// Copyright 2024 EdgeXR, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nbictl
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/edgexr/edge-cloud-platform/api/nbi"
+)
+
+func GetAll(ctx context.Context, client *nbi.ClientWithResponses) (*GetData, []APIErr) {
+	data := &GetData{}
+	apiErrors := []APIErr{}
+
+	// get apps
+	apps, apierr := GetApps(ctx, client)
+	if apierr != nil {
+		apiErrors = append(apiErrors, *apierr)
+	} else {
+		data.Apps = apps
+	}
+
+	// get app instances
+	appinsts, apierr := GetAppInsts(ctx, client)
+	if apierr != nil {
+		apiErrors = append(apiErrors, *apierr)
+	} else {
+		data.AppInsts = appinsts
+	}
+
+	// get zones
+	zones, apierr := GetZones(ctx, client)
+	if apierr != nil {
+		apiErrors = append(apiErrors, *apierr)
+	} else {
+		data.Zones = zones
+	}
+
+	return data, apiErrors
+}
+
+func GetApps(ctx context.Context, client *nbi.ClientWithResponses) ([]nbi.AppManifest, *APIErr) {
+	resp, err := client.GetAppsWithResponse(ctx, &nbi.GetAppsParams{})
+	status := resp.StatusCode()
+	if err != nil || status != http.StatusOK {
+		return nil, &APIErr{
+			Desc:   "getapps",
+			Status: status,
+			Err:    err,
+		}
+	}
+	return *resp.JSON200, nil
+}
+
+func GetAppInsts(ctx context.Context, client *nbi.ClientWithResponses) ([]nbi.AppInstanceInfo, *APIErr) {
+	resp, err := client.GetAppInstanceWithResponse(ctx, &nbi.GetAppInstanceParams{})
+	status := resp.StatusCode()
+	if err != nil || status != http.StatusOK {
+		return nil, &APIErr{
+			Desc:   "getappinstances",
+			Status: status,
+			Err:    err,
+		}
+	}
+	return *resp.JSON200.AppInstaceInfo, nil
+}
+
+func GetZones(ctx context.Context, client *nbi.ClientWithResponses) ([]nbi.EdgeCloudZone, *APIErr) {
+	resp, err := client.GetEdgeCloudZonesWithResponse(ctx, &nbi.GetEdgeCloudZonesParams{})
+	status := 0
+	if resp != nil {
+		status = resp.StatusCode()
+	}
+	if err != nil || status != http.StatusOK {
+		return nil, &APIErr{
+			Desc:   "getzones",
+			Status: status,
+			Err:    err,
+		}
+	}
+	return *resp.JSON200, nil
+}


### PR DESCRIPTION
This adds some scaffolding around how to handle NBI APIs.

We add an echo server to the controller on the existing HTTP API endpoint, shared with the grpc-gateway APIs which aren't actually being used by anything.

We add the `NBIAPIs` object in the controller which will be the handler for all NBI APIs. Currently only the `GET edge-cloud-zones` API is implemented as a test to ensure the basic communication is working. Other APIs will be implemented in later PRs, as implementing everything all at once will be a lot of changes.

We add the `nbictl` library which allows for CLI and e2e test clients to leverage common client code.

We add the `nbiconvert` library which will handle conversion between NBI structs and edgeproto structs.