### PR TITLE
osmk8s platform flavors from env vars

### DIFF
--- a/pkg/ccrm/ccrm_cloudlet.go
+++ b/pkg/ccrm/ccrm_cloudlet.go
@@ -63,6 +63,13 @@ func (s *CCRMHandler) ApplyCloudlet(in *edgeproto.Cloudlet, stream edgeproto.Clo
 			// CRM will handle it
 			return nil
 		}
+		// Delete platform from cache. This will force re-init of the platform
+		// using the new state of cloudlet (env vars, etc) pulled from etcd.
+		// Note that this also happens via Cloudlet cache update to flush
+		// from all CCRM instances, but we need to (potentially redundantly)
+		// do it here to guarantee it is flushed before CloudletChanged()
+		// function requests for it.
+		s.crmPlatforms.Delete(&in.Key)
 		return s.crmHandler.CloudletChanged(ctx, &in.Key, in, responseSender)
 	}
 

--- a/pkg/ccrm/ccrm_handler.go
+++ b/pkg/ccrm/ccrm_handler.go
@@ -143,6 +143,11 @@ func (s *CCRMHandler) InitConnectivity(client *notify.Client, kvstore objstore.K
 		edgeproto.RegisterClusterPlatformAPIServer(grpcServer, s)
 		edgeproto.RegisterAppInstPlatformAPIServer(grpcServer, s)
 	}
+
+	s.crmHandler.CloudletCache.AddUpdatedCb(func(ctx context.Context, old, new *edgeproto.Cloudlet) {
+		// force re-init of platform in case env vars, etc, changed
+		s.crmPlatforms.Delete(&new.Key)
+	})
 }
 
 func (s *CCRMHandler) Start(ctx context.Context, ctrlConn *grpc.ClientConn) {

--- a/pkg/controller/cloudlet_api.go
+++ b/pkg/controller/cloudlet_api.go
@@ -1316,6 +1316,9 @@ func (s *CloudletApi) UpdateCloudlet(in *edgeproto.Cloudlet, inCb edgeproto.Clou
 		}
 		api := edgeproto.NewCloudletPlatformAPIClient(conn)
 		cur.Fields = diffFields.Fields()
+		if crmUpdateReqd {
+			cur.Fields = append(cur.Fields, edgeproto.CloudletFieldState)
+		}
 		outStream, err := api.ApplyCloudlet(reqCtx, cur)
 		if err != nil {
 			return cloudcommon.GRPCErrorUnwrap(err)

--- a/pkg/platform/osmano/osmk8s/osmk8s-props.go
+++ b/pkg/platform/osmano/osmk8s/osmk8s-props.go
@@ -29,6 +29,7 @@ const (
 	OSM_VIM_ACCOUNT    = "OSM_VIM_ACCOUNT"
 	OSM_RESOURCE_GROUP = "OSM_RESOURCE_GROUP"
 	OSM_SKIPVERIFY     = "OSM_SKIPVERIFY"
+	OSM_FLAVORS        = "OSM_FLAVORS"
 )
 
 var AccessVarProps = map[string]*edgeproto.PropertyInfo{
@@ -61,6 +62,10 @@ var Props = map[string]*edgeproto.PropertyInfo{
 	},
 	OSM_SKIPVERIFY: {
 		Name: "Skip TLS verification on OSM URL (do not use in production), set to any value to enable",
+	},
+	OSM_FLAVORS: {
+		Name:        "List of flavors in JSON format since OSM does not provide a way to query for VIM flavors",
+		Description: `JSON formatted list of edgeproto.FlavorInfo, i.e. [{"name":"Standard_D2s_v3","vcpus":2,"ram":8192,"disk":16}]`,
 	},
 }
 

--- a/pkg/platform/osmano/osmk8s/osmk8s.go
+++ b/pkg/platform/osmano/osmk8s/osmk8s.go
@@ -68,6 +68,14 @@ func (s *Platform) GetFeatures() *edgeproto.PlatformFeatures {
 func (s *Platform) GatherCloudletInfo(ctx context.Context, info *edgeproto.CloudletInfo) error {
 	// OSM has no way to list resource limits
 	// OSM has no way to list flavors
+	flavorsJSON, ok := s.properties.GetValue(OSM_FLAVORS)
+	if ok && flavorsJSON != "" {
+		flavors := []*edgeproto.FlavorInfo{}
+		if err := json.Unmarshal([]byte(flavorsJSON), &flavors); err != nil {
+			return fmt.Errorf("failed to unmarshal %s: %s, %s", OSM_FLAVORS, flavorsJSON, err)
+		}
+		info.Flavors = flavors
+	}
 	return nil
 }
 

--- a/pkg/platform/osmano/osmk8s/osmk8s_test.go
+++ b/pkg/platform/osmano/osmk8s/osmk8s_test.go
@@ -114,3 +114,28 @@ func TestDeleteCluster(t *testing.T) {
 	err = s.RunClusterDeleteCommand(ctx, testClusterName, ci)
 	require.Nil(t, err)
 }
+
+func TestGatherCloudletInfo(t *testing.T) {
+	log.SetDebugLevel(log.DebugLevelInfra | log.DebugLevelApi)
+	log.InitTracer(nil)
+	defer log.FinishTracer()
+	ctx := log.StartTestSpan(context.Background())
+
+	s := Platform{}
+	s.properties = &infracommon.InfraProperties{
+		Properties: make(map[string]*edgeproto.PropertyInfo),
+	}
+	s.properties.SetProperties(Props)
+	s.properties.SetValue(OSM_FLAVORS, `[{"name":"Standard_D2s_v3","vcpus":2,"ram":8192,"disk":16}]`)
+
+	flavors := []*edgeproto.FlavorInfo{{
+		Name:  "Standard_D2s_v3",
+		Vcpus: 2,
+		Ram:   8192,
+		Disk:  16,
+	}}
+	info := &edgeproto.CloudletInfo{}
+	err := s.GatherCloudletInfo(ctx, info)
+	require.Nil(t, err)
+	require.Equal(t, flavors, info.Flavors)
+}


### PR DESCRIPTION
OSMano does not provide any API to query the flavors supported by the VIM. To allow us to specify per-cloudlet flavors manually, we add an env var to allow specifying the flavors as a JSON string of []edgeproto.FlavorInfo. This is a work-around until OSMano can properly tell us the real flavors.

It turns out updating env vars for an existing CCRM-based Cloudlet did not have any effect, because the env vars are set in the platform object during create, and cached from that point. The changes to resolve that are to flush the CCRM platform object cache if the cloudlet object changes.

Additionally, for changes to a flavor list set by env vars to take effect, we refresh the flavors after a cloudlet update. In general we probably need a better way to keep the flavor list in sync in case the flavors change, but luckily infra flavors do not typically change very frequently.