### PR TITLE
show redacted cloudlet access vars

### DIFF
--- a/pkg/controller/cloudlet_api.go
+++ b/pkg/controller/cloudlet_api.go
@@ -40,6 +40,8 @@ import (
 	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
+const RedactedAccessVarValue = "***"
+
 type CloudletApi struct {
 	all                   *AllApis
 	sync                  *regiondata.Sync
@@ -462,7 +464,7 @@ func (s *CloudletApi) createCloudletInternal(cctx *CallContext, in *edgeproto.Cl
 	accessVars := make(map[string]string)
 	if in.AccessVars != nil {
 		accessVars = in.AccessVars
-		in.AccessVars = nil
+		in.AccessVars = redactAccessVars(accessVars)
 	}
 
 	kafkaDetails := node.KafkaCreds{}
@@ -1001,7 +1003,7 @@ func (s *CloudletApi) UpdateCloudlet(in *edgeproto.Cloudlet, inCb edgeproto.Clou
 	accessVars := make(map[string]string)
 	if fmap.HasOrHasChild(edgeproto.CloudletFieldAccessVars) {
 		accessVars = in.AccessVars
-		in.AccessVars = nil
+		in.AccessVars = redactAccessVars(accessVars)
 	}
 
 	singleKubernetesClusterOwnerSet := fmap.Has(edgeproto.CloudletFieldSingleKubernetesClusterOwner)
@@ -2874,4 +2876,12 @@ func (s *CloudletApi) ChangeCloudletDNS(key *edgeproto.CloudletKey, inCb edgepro
 	}
 	cb.Send(&edgeproto.Result{Message: "DNS Migration complete"})
 	return nil
+}
+
+func redactAccessVars(accessVars map[string]string) map[string]string {
+	vars := map[string]string{}
+	for k := range accessVars {
+		vars[k] = RedactedAccessVarValue
+	}
+	return vars
 }


### PR DESCRIPTION
Rather than completely hiding accessvars set during Cloudlet create/update, this retains the keys so that users can see which access vars they've set.