### PR TITLE
restore k8s appinst manifest on delete

### DIFF
--- a/pkg/k8smgmt/appinst.go
+++ b/pkg/k8smgmt/appinst.go
@@ -449,7 +449,10 @@ func UpdateAppInst(ctx context.Context, accessApi platform.AccessApi, client ssh
 	return WaitForAppInst(ctx, client, names, app, WaitRunning)
 }
 
-func DeleteAppInst(ctx context.Context, client ssh.Client, names *KubeNames, app *edgeproto.App, appInst *edgeproto.AppInst) error {
+func DeleteAppInst(ctx context.Context, accessApi platform.AccessApi, client ssh.Client, names *KubeNames, app *edgeproto.App, appInst *edgeproto.AppInst) error {
+	if err := WriteDeploymentManifestToFile(ctx, accessApi, client, names, app, appInst); err != nil {
+		return err
+	}
 	configDir := getConfigDirName(names)
 	configName := getConfigFileName(names, appInst)
 	file := configDir + "/" + configName

--- a/pkg/platform/common/managedk8s/mk8s-appinst.go
+++ b/pkg/platform/common/managedk8s/mk8s-appinst.go
@@ -116,7 +116,7 @@ func (m *ManagedK8sPlatform) DeleteAppInst(ctx context.Context, clusterInst *edg
 
 	switch deployment := app.Deployment; deployment {
 	case cloudcommon.DeploymentTypeKubernetes:
-		err = k8smgmt.DeleteAppInst(ctx, client, names, app, appInst)
+		err = k8smgmt.DeleteAppInst(ctx, m.CommonPf.PlatformConfig.AccessApi, client, names, app, appInst)
 	default:
 		err = fmt.Errorf("unsupported deployment type %s", deployment)
 	}

--- a/pkg/platform/common/vmlayer/appinst.go
+++ b/pkg/platform/common/vmlayer/appinst.go
@@ -709,9 +709,9 @@ func (v *VMPlatform) cleanupAppInstInternal(ctx context.Context, clusterInst *ed
 				log.SpanLog(ctx, log.DebugLevelInfra, "cannot clean up DNS entries", "name", names.AppName, "rootlb", rootLBName, "error", err)
 			}
 		}
-
+		accessApi := v.VMProperties.CommonPf.PlatformConfig.AccessApi
 		if deployment == cloudcommon.DeploymentTypeKubernetes {
-			return k8smgmt.DeleteAppInst(ctx, client, names, app, appInst)
+			return k8smgmt.DeleteAppInst(ctx, accessApi, client, names, app, appInst)
 		} else {
 			return k8smgmt.DeleteHelmAppInst(ctx, client, names, clusterInst)
 		}

--- a/pkg/platform/common/xind/xind-appinst.go
+++ b/pkg/platform/common/xind/xind-appinst.go
@@ -108,7 +108,7 @@ func (s *Xind) CreateAppInstNoPatch(ctx context.Context, clusterInst *edgeproto.
 		if err == nil {
 			err = k8smgmt.WaitForAppInst(ctx, client, names, app, k8smgmt.WaitRunning)
 			if err != nil {
-				undoerr := k8smgmt.DeleteAppInst(ctx, client, names, app, appInst)
+				undoerr := k8smgmt.DeleteAppInst(ctx, s.platformConfig.AccessApi, client, names, app, appInst)
 				log.SpanLog(ctx, log.DebugLevelInfra, "Undo CreateAppInst", "undoerr", undoerr)
 			}
 		}
@@ -168,7 +168,7 @@ func (s *Xind) DeleteAppInst(ctx context.Context, clusterInst *edgeproto.Cluster
 	}
 
 	if DeploymentType == cloudcommon.DeploymentTypeKubernetes {
-		err = k8smgmt.DeleteAppInst(ctx, client, names, app, appInst)
+		err = k8smgmt.DeleteAppInst(ctx, s.platformConfig.AccessApi, client, names, app, appInst)
 	} else if DeploymentType == cloudcommon.DeploymentTypeHelm {
 		err = k8smgmt.DeleteHelmAppInst(ctx, client, names, clusterInst)
 	} else {

--- a/pkg/platform/k8s-baremetal/k8sbm-appinst.go
+++ b/pkg/platform/k8s-baremetal/k8sbm-appinst.go
@@ -232,7 +232,7 @@ func (k *K8sBareMetalPlatform) DeleteAppInst(ctx context.Context, clusterInst *e
 		}
 
 		if deployment == cloudcommon.DeploymentTypeKubernetes {
-			err = k8smgmt.DeleteAppInst(ctx, client, names, app, appInst)
+			err = k8smgmt.DeleteAppInst(ctx, k.commonPf.PlatformConfig.AccessApi, client, names, app, appInst)
 		} else {
 			err = k8smgmt.DeleteHelmAppInst(ctx, client, names, clusterInst)
 		}

--- a/pkg/platform/k8s-operator/k8sop-appinst.go
+++ b/pkg/platform/k8s-operator/k8sop-appinst.go
@@ -114,7 +114,7 @@ func (s *K8sOperator) DeleteAppInst(ctx context.Context, clusterInst *edgeproto.
 
 	switch deployment := app.Deployment; deployment {
 	case cloudcommon.DeploymentTypeKubernetes:
-		err = k8smgmt.DeleteAppInst(ctx, client, names, app, appInst)
+		err = k8smgmt.DeleteAppInst(ctx, s.CommonPf.PlatformConfig.AccessApi, client, names, app, appInst)
 	default:
 		err = fmt.Errorf("unsupported deployment type %s", deployment)
 	}

--- a/pkg/platform/localhost/localhost.go
+++ b/pkg/platform/localhost/localhost.go
@@ -177,7 +177,7 @@ func (s *Platform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 		}
 		defer func() {
 			if reterr != nil {
-				k8smgmt.DeleteAppInst(ctx, client, names, app, appInst)
+				k8smgmt.DeleteAppInst(ctx, s.platformConfig.AccessApi, client, names, app, appInst)
 			}
 		}()
 		return k8smgmt.WaitForAppInst(ctx, client, names, app, k8smgmt.WaitRunning)
@@ -211,7 +211,7 @@ func (s *Platform) DeleteAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 		}
 		proxy := s.getAppInstProxy(clusterInst, appInst)
 		proxy.StopLocal()
-		return k8smgmt.DeleteAppInst(ctx, client, names, app, appInst)
+		return k8smgmt.DeleteAppInst(ctx, s.platformConfig.AccessApi, client, names, app, appInst)
 	case cloudcommon.DeploymentTypeHelm:
 		names, err := k8smgmt.GetKubeNames(clusterInst, app, appInst)
 		if err != nil {


### PR DESCRIPTION
When using the CCRM, a restart/upgrade of the CCRM service will cause any locally stored k8s manifests to be lost. For CRMs these remain after restart.

Because these are needed for delete, on delete we re-write the manifest to ensure that it is present in case it was lost.