### PR TITLE
appinst zone check, k8smgmt pod check fix

### DIFF
--- a/pkg/controller/appinst_zone.go
+++ b/pkg/controller/appinst_zone.go
@@ -63,6 +63,11 @@ func (s *AppInstApi) getPotentialCloudlets(ctx context.Context, cctx *CallContex
 		if in.ZoneKey.Name == "" {
 			return nil, errors.New("zone not specified")
 		}
+		// check if zone exists
+		zoneBuf := edgeproto.Zone{}
+		if !s.all.zoneApi.cache.Get(&in.ZoneKey, &zoneBuf) {
+			return nil, in.ZoneKey.NotFoundError()
+		}
 		potentialCloudletKeys = s.all.cloudletApi.cache.CloudletsForZone(&in.ZoneKey)
 		if len(potentialCloudletKeys) == 0 {
 			return nil, errors.New("no available edge sites in zone " + in.ZoneKey.Name)


### PR DESCRIPTION
Two minor fixes:
- During appinst create, if the specified zone does not exist, we used to return a confusing error, "no cloudlets available for zone". Now we return "zone not found".
- When checking pod status, newer versions of kubernetes return the "No resources found" error in a way that now matches the pod state regexp. This caused the code to erroneously try to parse the error message as a pod state string. Instead I've moved the error check up before the pod state regexp match to avoid this issue.