### PR TITLE
fix reservable autocluster cleanup on undo

### DIFF
--- a/api/edgeproto/cloudlet.pb.go
+++ b/api/edgeproto/cloudlet.pb.go
@@ -13,6 +13,7 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/objstore"
 	"github.com/edgexr/edge-cloud-platform/pkg/util"
 	_ "github.com/edgexr/edge-cloud-platform/tools/protogen"
+	"github.com/go-redis/redis/v8"
 	_ "github.com/gogo/googleapis/google/api"
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
@@ -17979,7 +17980,7 @@ func (s *CloudletInfoPrintUpdater) Update(obj *CloudletInfo) error {
 	return nil
 }
 
-func WaitForCloudletInfo(ctx context.Context, key *CloudletKey, store CloudletInfoStore, targetState distributed_match_engine.CloudletState, transitionStates map[distributed_match_engine.CloudletState]struct{}, errorState distributed_match_engine.CloudletState, successMsg string, send func(*Result) error, opts ...WaitStateOps) error {
+func WaitForCloudletInfo(ctx context.Context, key *CloudletKey, store CloudletInfoStore, targetState distributed_match_engine.CloudletState, transitionStates map[distributed_match_engine.CloudletState]struct{}, errorState distributed_match_engine.CloudletState, successMsg string, send func(*Result) error, crmMsgCh <-chan *redis.Message) error {
 	var lastMsgCnt int
 	var err error
 
@@ -18006,20 +18007,14 @@ func WaitForCloudletInfo(ctx context.Context, key *CloudletKey, store CloudletIn
 		return nil
 	}
 
-	var wSpec WaitStateSpec
-	for _, op := range opts {
-		if err := op(&wSpec); err != nil {
-			return err
-		}
-	}
-
-	if wSpec.CrmMsgCh == nil {
-		return nil
+	if crmMsgCh == nil {
+		log.SpanLog(ctx, log.DebugLevelApi, "wait for CloudletInfo func missing crmMsgCh", "key", key)
+		return fmt.Errorf("wait for CloudletInfo missing redis message channel")
 	}
 
 	for {
 		select {
-		case chObj := <-wSpec.CrmMsgCh:
+		case chObj := <-crmMsgCh:
 			if chObj == nil {
 				// Since msg chan is a receive-only chan, it will return nil if
 				// connection to redis server is disrupted. But the object might

--- a/api/edgeproto/objs.go
+++ b/api/edgeproto/objs.go
@@ -28,7 +28,6 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/objstore"
 	"github.com/edgexr/edge-cloud-platform/pkg/util"
-	"github.com/go-redis/redis/v8"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	context "golang.org/x/net/context"
@@ -60,19 +59,6 @@ var ReservedPlatformPorts = map[string]string{
 	"tcp:20800": "Kubernetes master join server",
 	"udp:53":    "dns udp",
 	"tcp:53":    "dns tcp",
-}
-
-type WaitStateSpec struct {
-	CrmMsgCh <-chan *redis.Message
-}
-
-type WaitStateOps func(wSpec *WaitStateSpec) error
-
-func WithCrmMsgCh(crmCh <-chan *redis.Message) WaitStateOps {
-	return func(wSpec *WaitStateSpec) error {
-		wSpec.CrmMsgCh = crmCh
-		return nil
-	}
 }
 
 // sort each slice by key

--- a/pkg/controller/appinst_api_test.go
+++ b/pkg/controller/appinst_api_test.go
@@ -180,9 +180,6 @@ func TestAppInstApi(t *testing.T) {
 		// Verify that on error, undo deleted the appInst object from etcd
 		show := testutil.ShowAppInst{}
 		show.Init()
-		err = apis.appInstApi.ShowAppInst(&obj, &show)
-		require.Nil(t, err, "show app inst data")
-		require.Equal(t, 0, len(show.Data))
 		require.Equal(t, 0, apis.appInstApi.cache.GetCount())
 		require.Equal(t, curClusterInstCount, apis.clusterInstApi.cache.GetCount())
 		// Since appinst creation failed, object is deleted from etcd, stream obj should also be deleted

--- a/pkg/controller/appinst_api_test.go
+++ b/pkg/controller/appinst_api_test.go
@@ -135,6 +135,8 @@ func TestAppInstApi(t *testing.T) {
 		require.NotNil(t, err, "Create app inst without apps/cloudlets")
 		// Verify stream AppInst fails
 		GetAppInstStreamMsgs(t, ctx, &obj.Key, apis, Fail)
+		require.Equal(t, 0, apis.appInstApi.cache.GetCount())
+		require.Equal(t, 0, apis.clusterInstApi.cache.GetCount())
 	}
 
 	// create supporting data
@@ -153,6 +155,7 @@ func TestAppInstApi(t *testing.T) {
 	clusterInstCnt := len(apis.clusterInstApi.cache.Objs)
 	require.Equal(t, len(testutil.ClusterInstData())+testutil.GetDefaultClusterCount(), clusterInstCnt)
 
+	curClusterInstCount := apis.clusterInstApi.cache.GetCount()
 	// Set responder to fail. This should clean up the object after
 	// the fake crm returns a failure. If it doesn't, the next test to
 	// create all the app insts will fail.
@@ -180,6 +183,8 @@ func TestAppInstApi(t *testing.T) {
 		err = apis.appInstApi.ShowAppInst(&obj, &show)
 		require.Nil(t, err, "show app inst data")
 		require.Equal(t, 0, len(show.Data))
+		require.Equal(t, 0, apis.appInstApi.cache.GetCount())
+		require.Equal(t, curClusterInstCount, apis.clusterInstApi.cache.GetCount())
 		// Since appinst creation failed, object is deleted from etcd, stream obj should also be deleted
 		GetAppInstStreamMsgs(t, ctx, &obj.Key, apis, Fail)
 	}

--- a/pkg/controller/cloudlet_api.go
+++ b/pkg/controller/cloudlet_api.go
@@ -730,7 +730,7 @@ func (s *CloudletApi) createCloudletInternal(cctx *CallContext, in *edgeproto.Cl
 			cb.Send(&edgeproto.Result{Message: reterr.Error()})
 			cb.Send(&edgeproto.Result{Message: "Deleting Cloudlet due to failures"})
 			log.SpanLog(ctx, log.DebugLevelInfo, "deleting cloudlet due to failures")
-			undoErr := s.deleteCloudletInternal(cctx.WithUndo(), in, cb, cloudletResourcesCreated)
+			undoErr := s.deleteCloudletInternal(cctx.WithUndo().WithStream(sendObj), in, cb, cloudletResourcesCreated)
 			if undoErr != nil {
 				log.SpanLog(ctx, log.DebugLevelInfo, "Undo create Cloudlet", "undoErr", undoErr)
 			}
@@ -813,8 +813,7 @@ func (s *CloudletApi) createCloudletInternal(cctx *CallContext, in *edgeproto.Cl
 			reqCtx, &in.Key, s.all.cloudletInfoApi.store,
 			dme.CloudletState_CLOUDLET_STATE_READY,
 			CreateCloudletTransitions, dme.CloudletState_CLOUDLET_STATE_ERRORS,
-			successMsg, cb.Send,
-			edgeproto.WithCrmMsgCh(sendObj.crmMsgCh))
+			successMsg, cb.Send, sendObj.crmMsgCh)
 		if err != nil {
 			return err
 		}
@@ -1311,8 +1310,7 @@ func (s *CloudletApi) UpdateCloudlet(in *edgeproto.Cloudlet, inCb edgeproto.Clou
 			reqCtx, &in.Key, s.all.cloudletInfoApi.store,
 			dme.CloudletState_CLOUDLET_STATE_READY,
 			UpdateCloudletTransitions, dme.CloudletState_CLOUDLET_STATE_ERRORS,
-			successMsg, cb.Send,
-			edgeproto.WithCrmMsgCh(sendObj.crmMsgCh))
+			successMsg, cb.Send, sendObj.crmMsgCh)
 		return err
 	} else if crmUpdateReqd && !ignoreCRM(cctx) {
 		conn, err := services.platformServiceConnCache.GetConn(ctx, features.NodeType)
@@ -2837,8 +2835,7 @@ func (s *CloudletApi) ChangeCloudletDNS(key *edgeproto.CloudletKey, inCb edgepro
 				reqCtx, key, s.all.cloudletInfoApi.store,
 				dme.CloudletState_CLOUDLET_STATE_READY,
 				UpdateCloudletTransitions, dme.CloudletState_CLOUDLET_STATE_ERRORS,
-				successMsg, cb.Send,
-				edgeproto.WithCrmMsgCh(sendObj.crmMsgCh))
+				successMsg, cb.Send, sendObj.crmMsgCh)
 			if err != nil {
 				// revert the fqdn back to the original state
 				undoErr := s.sync.ApplySTMWait(ctx, func(stm concurrency.STM) error {

--- a/pkg/controller/stream_api.go
+++ b/pkg/controller/stream_api.go
@@ -355,11 +355,12 @@ func (s *StreamObjApi) startStream(ctx context.Context, cctx *CallContext, strea
 		fn(&streamOps)
 	}
 
-	// If this is an undo, then caller has already performed
-	// the same operation, so reuse the existing callback
+	// If stream already exists in the context, resuse it.
+	// This can happen in the case of undo.
 	if ss := cctx.GetStreamSend(streamKey); ss != nil {
 		// make a copy so we know not to terminate the stream
-		// during stopStream, as the caller will terminate it.
+		// during stopStream, as the function that originally
+		// created the stream will terminate it.
 		return ss.Copy(), nil
 	}
 
@@ -502,7 +503,8 @@ func (s *StreamObjApi) stopStream(ctx context.Context, cctx *CallContext, stream
 	id := streamSendObj.id
 	log.SpanLog(ctx, log.DebugLevelApi, "stop stream", "key", streamKey, "cctx", cctx, "modRev", modRev, "id", id, "err", objErr, "invalid", streamSendObj.invalid, "cleanup", cleanupStream, "iscopy", streamSendObj.isCopy)
 
-	// If this is a copy, then caller will terminate the stream.
+	// If this is a copy, then the original creator will terminate
+	// the stream.
 	if streamSendObj.isCopy {
 		return nil
 	}

--- a/pkg/controller/vmpool_api.go
+++ b/pkg/controller/vmpool_api.go
@@ -359,7 +359,7 @@ func (s *VMPoolApi) updateVMPoolInternal(cctx *CallContext, ctx context.Context,
 		err = edgeproto.WaitForVMPoolInfo(reqCtx, key, s.store, edgeproto.TrackedState_READY,
 			UpdateVMPoolTransitions, edgeproto.TrackedState_UPDATE_ERROR,
 			"Updated VM Pool Successfully", nil,
-			edgeproto.WithCrmMsgCh(sendObj.crmMsgCh))
+			sendObj.crmMsgCh)
 	} else {
 		// VMPool not supported for CCRM
 		return fmt.Errorf("vm pool not supported off edge-site")


### PR DESCRIPTION
Testing found an issue with the cleanup of a reservable autocluster created during CreateAppInst, if the AppInst create failed. The problem was that the AppInst API finished before the cluster was fully deleted. This caused subsequent tests to fail.

The problem stemmed from the streamObj handling. When the AppInst create fails, it sets the undo flag on the context and calls deleteClusterInstInternal. The undo flag triggers streamStart() to try to reuse the existing stream, but this process did not carry over the crmMsgCh. Without the crmMsgCh, the call to WaitForCloudletInfo in deleteClusterInstInternal returns early, instead of waiting until the clusterinst is deleted.

Using the Undo flag is tricky, because in this case, the stream is technically not resuable by deleteClusterInstInternal, because we are actually undoing the AppInst create. The stream used by createClusterInstInternal to create the autocluster was already finished, and the only stream present is the AppInst stream. So, we now track streams by their streamKey on the CallContext. This allows stream reuse to trigger off the presence of the stream to reuse, rather than the undo flag.

Because crmMsgCh is not really optional to the WaitFor funcs (there's no point in calling it if the channel is nil), I've made it a required parameter instead of optional.