### PR TITLE
managed cluster provider support cluster updates

### DIFF
--- a/api/edgeproto/alertpolicy.pb.go
+++ b/api/edgeproto/alertpolicy.pb.go
@@ -987,6 +987,10 @@ var UpdateAlertPolicyFieldsMap = NewFieldMap(map[string]struct{}{
 })
 
 func (m *AlertPolicy) ValidateUpdateFields() error {
+	return m.ValidateUpdateFieldsCustom(UpdateAlertPolicyFieldsMap)
+}
+
+func (m *AlertPolicy) ValidateUpdateFieldsCustom(allowedFields *FieldMap) error {
 	if m.Fields == nil {
 		return fmt.Errorf("nothing specified to update")
 	}
@@ -996,7 +1000,7 @@ func (m *AlertPolicy) ValidateUpdateFields() error {
 		if m.IsKeyField(field) {
 			continue
 		}
-		if !UpdateAlertPolicyFieldsMap.Has(field) {
+		if !allowedFields.Has(field) {
 			if _, ok := AlertPolicyAllFieldsStringMap[field]; !ok {
 				continue
 			}

--- a/api/edgeproto/app.pb.go
+++ b/api/edgeproto/app.pb.go
@@ -3754,6 +3754,10 @@ var UpdateAppFieldsMap = NewFieldMap(map[string]struct{}{
 })
 
 func (m *App) ValidateUpdateFields() error {
+	return m.ValidateUpdateFieldsCustom(UpdateAppFieldsMap)
+}
+
+func (m *App) ValidateUpdateFieldsCustom(allowedFields *FieldMap) error {
 	if m.Fields == nil {
 		return fmt.Errorf("nothing specified to update")
 	}
@@ -3763,7 +3767,7 @@ func (m *App) ValidateUpdateFields() error {
 		if m.IsKeyField(field) {
 			continue
 		}
-		if !UpdateAppFieldsMap.Has(field) {
+		if !allowedFields.Has(field) {
 			if _, ok := AppAllFieldsStringMap[field]; !ok {
 				continue
 			}

--- a/api/edgeproto/appinst.pb.go
+++ b/api/edgeproto/appinst.pb.go
@@ -5004,6 +5004,10 @@ var UpdateAppInstFieldsMap = NewFieldMap(map[string]struct{}{
 })
 
 func (m *AppInst) ValidateUpdateFields() error {
+	return m.ValidateUpdateFieldsCustom(UpdateAppInstFieldsMap)
+}
+
+func (m *AppInst) ValidateUpdateFieldsCustom(allowedFields *FieldMap) error {
 	if m.Fields == nil {
 		return fmt.Errorf("nothing specified to update")
 	}
@@ -5013,7 +5017,7 @@ func (m *AppInst) ValidateUpdateFields() error {
 		if m.IsKeyField(field) {
 			continue
 		}
-		if !UpdateAppInstFieldsMap.Has(field) {
+		if !allowedFields.Has(field) {
 			if _, ok := AppInstAllFieldsStringMap[field]; !ok {
 				continue
 			}

--- a/api/edgeproto/autoprovpolicy.pb.go
+++ b/api/edgeproto/autoprovpolicy.pb.go
@@ -1217,6 +1217,10 @@ var UpdateAutoProvPolicyFieldsMap = NewFieldMap(map[string]struct{}{
 })
 
 func (m *AutoProvPolicy) ValidateUpdateFields() error {
+	return m.ValidateUpdateFieldsCustom(UpdateAutoProvPolicyFieldsMap)
+}
+
+func (m *AutoProvPolicy) ValidateUpdateFieldsCustom(allowedFields *FieldMap) error {
 	if m.Fields == nil {
 		return fmt.Errorf("nothing specified to update")
 	}
@@ -1226,7 +1230,7 @@ func (m *AutoProvPolicy) ValidateUpdateFields() error {
 		if m.IsKeyField(field) {
 			continue
 		}
-		if !UpdateAutoProvPolicyFieldsMap.Has(field) {
+		if !allowedFields.Has(field) {
 			if _, ok := AutoProvPolicyAllFieldsStringMap[field]; !ok {
 				continue
 			}

--- a/api/edgeproto/autoscalepolicy.pb.go
+++ b/api/edgeproto/autoscalepolicy.pb.go
@@ -877,6 +877,10 @@ var UpdateAutoScalePolicyFieldsMap = NewFieldMap(map[string]struct{}{
 })
 
 func (m *AutoScalePolicy) ValidateUpdateFields() error {
+	return m.ValidateUpdateFieldsCustom(UpdateAutoScalePolicyFieldsMap)
+}
+
+func (m *AutoScalePolicy) ValidateUpdateFieldsCustom(allowedFields *FieldMap) error {
 	if m.Fields == nil {
 		return fmt.Errorf("nothing specified to update")
 	}
@@ -886,7 +890,7 @@ func (m *AutoScalePolicy) ValidateUpdateFields() error {
 		if m.IsKeyField(field) {
 			continue
 		}
-		if !UpdateAutoScalePolicyFieldsMap.Has(field) {
+		if !allowedFields.Has(field) {
 			if _, ok := AutoScalePolicyAllFieldsStringMap[field]; !ok {
 				continue
 			}

--- a/api/edgeproto/cloudlet.pb.go
+++ b/api/edgeproto/cloudlet.pb.go
@@ -10062,6 +10062,10 @@ var UpdateGPUDriverFieldsMap = NewFieldMap(map[string]struct{}{
 })
 
 func (m *GPUDriver) ValidateUpdateFields() error {
+	return m.ValidateUpdateFieldsCustom(UpdateGPUDriverFieldsMap)
+}
+
+func (m *GPUDriver) ValidateUpdateFieldsCustom(allowedFields *FieldMap) error {
 	if m.Fields == nil {
 		return fmt.Errorf("nothing specified to update")
 	}
@@ -10071,7 +10075,7 @@ func (m *GPUDriver) ValidateUpdateFields() error {
 		if m.IsKeyField(field) {
 			continue
 		}
-		if !UpdateGPUDriverFieldsMap.Has(field) {
+		if !allowedFields.Has(field) {
 			if _, ok := GPUDriverAllFieldsStringMap[field]; !ok {
 				continue
 			}
@@ -12594,6 +12598,10 @@ var UpdateCloudletFieldsMap = NewFieldMap(map[string]struct{}{
 })
 
 func (m *Cloudlet) ValidateUpdateFields() error {
+	return m.ValidateUpdateFieldsCustom(UpdateCloudletFieldsMap)
+}
+
+func (m *Cloudlet) ValidateUpdateFieldsCustom(allowedFields *FieldMap) error {
 	if m.Fields == nil {
 		return fmt.Errorf("nothing specified to update")
 	}
@@ -12603,7 +12611,7 @@ func (m *Cloudlet) ValidateUpdateFields() error {
 		if m.IsKeyField(field) {
 			continue
 		}
-		if !UpdateCloudletFieldsMap.Has(field) {
+		if !allowedFields.Has(field) {
 			if _, ok := CloudletAllFieldsStringMap[field]; !ok {
 				continue
 			}

--- a/api/edgeproto/cloudletnode.pb.go
+++ b/api/edgeproto/cloudletnode.pb.go
@@ -956,6 +956,10 @@ var UpdateCloudletNodeFieldsMap = NewFieldMap(map[string]struct{}{
 })
 
 func (m *CloudletNode) ValidateUpdateFields() error {
+	return m.ValidateUpdateFieldsCustom(UpdateCloudletNodeFieldsMap)
+}
+
+func (m *CloudletNode) ValidateUpdateFieldsCustom(allowedFields *FieldMap) error {
 	if m.Fields == nil {
 		return fmt.Errorf("nothing specified to update")
 	}
@@ -965,7 +969,7 @@ func (m *CloudletNode) ValidateUpdateFields() error {
 		if m.IsKeyField(field) {
 			continue
 		}
-		if !UpdateCloudletNodeFieldsMap.Has(field) {
+		if !allowedFields.Has(field) {
 			if _, ok := CloudletNodeAllFieldsStringMap[field]; !ok {
 				continue
 			}

--- a/api/edgeproto/clusterinst.pb.go
+++ b/api/edgeproto/clusterinst.pb.go
@@ -3328,6 +3328,10 @@ var UpdateClusterInstFieldsMap = NewFieldMap(map[string]struct{}{
 })
 
 func (m *ClusterInst) ValidateUpdateFields() error {
+	return m.ValidateUpdateFieldsCustom(UpdateClusterInstFieldsMap)
+}
+
+func (m *ClusterInst) ValidateUpdateFieldsCustom(allowedFields *FieldMap) error {
 	if m.Fields == nil {
 		return fmt.Errorf("nothing specified to update")
 	}
@@ -3337,7 +3341,7 @@ func (m *ClusterInst) ValidateUpdateFields() error {
 		if m.IsKeyField(field) {
 			continue
 		}
-		if !UpdateClusterInstFieldsMap.Has(field) {
+		if !allowedFields.Has(field) {
 			if _, ok := ClusterInstAllFieldsStringMap[field]; !ok {
 				continue
 			}

--- a/api/edgeproto/flavor.pb.go
+++ b/api/edgeproto/flavor.pb.go
@@ -871,6 +871,10 @@ var UpdateFlavorFieldsMap = NewFieldMap(map[string]struct{}{
 })
 
 func (m *Flavor) ValidateUpdateFields() error {
+	return m.ValidateUpdateFieldsCustom(UpdateFlavorFieldsMap)
+}
+
+func (m *Flavor) ValidateUpdateFieldsCustom(allowedFields *FieldMap) error {
 	if m.Fields == nil {
 		return fmt.Errorf("nothing specified to update")
 	}
@@ -880,7 +884,7 @@ func (m *Flavor) ValidateUpdateFields() error {
 		if m.IsKeyField(field) {
 			continue
 		}
-		if !UpdateFlavorFieldsMap.Has(field) {
+		if !allowedFields.Has(field) {
 			if _, ok := FlavorAllFieldsStringMap[field]; !ok {
 				continue
 			}

--- a/api/edgeproto/network.pb.go
+++ b/api/edgeproto/network.pb.go
@@ -1038,6 +1038,10 @@ var UpdateNetworkFieldsMap = NewFieldMap(map[string]struct{}{
 })
 
 func (m *Network) ValidateUpdateFields() error {
+	return m.ValidateUpdateFieldsCustom(UpdateNetworkFieldsMap)
+}
+
+func (m *Network) ValidateUpdateFieldsCustom(allowedFields *FieldMap) error {
 	if m.Fields == nil {
 		return fmt.Errorf("nothing specified to update")
 	}
@@ -1047,7 +1051,7 @@ func (m *Network) ValidateUpdateFields() error {
 		if m.IsKeyField(field) {
 			continue
 		}
-		if !UpdateNetworkFieldsMap.Has(field) {
+		if !allowedFields.Has(field) {
 			if _, ok := NetworkAllFieldsStringMap[field]; !ok {
 				continue
 			}

--- a/api/edgeproto/restagtable.pb.go
+++ b/api/edgeproto/restagtable.pb.go
@@ -963,6 +963,10 @@ var UpdateResTagTableFieldsMap = NewFieldMap(map[string]struct{}{
 })
 
 func (m *ResTagTable) ValidateUpdateFields() error {
+	return m.ValidateUpdateFieldsCustom(UpdateResTagTableFieldsMap)
+}
+
+func (m *ResTagTable) ValidateUpdateFieldsCustom(allowedFields *FieldMap) error {
 	if m.Fields == nil {
 		return fmt.Errorf("nothing specified to update")
 	}
@@ -972,7 +976,7 @@ func (m *ResTagTable) ValidateUpdateFields() error {
 		if m.IsKeyField(field) {
 			continue
 		}
-		if !UpdateResTagTableFieldsMap.Has(field) {
+		if !allowedFields.Has(field) {
 			if _, ok := ResTagTableAllFieldsStringMap[field]; !ok {
 				continue
 			}

--- a/api/edgeproto/settings.pb.go
+++ b/api/edgeproto/settings.pb.go
@@ -1393,6 +1393,10 @@ var UpdateSettingsFieldsMap = NewFieldMap(map[string]struct{}{
 })
 
 func (m *Settings) ValidateUpdateFields() error {
+	return m.ValidateUpdateFieldsCustom(UpdateSettingsFieldsMap)
+}
+
+func (m *Settings) ValidateUpdateFieldsCustom(allowedFields *FieldMap) error {
 	if m.Fields == nil {
 		return fmt.Errorf("nothing specified to update")
 	}
@@ -1402,7 +1406,7 @@ func (m *Settings) ValidateUpdateFields() error {
 		if m.IsKeyField(field) {
 			continue
 		}
-		if !UpdateSettingsFieldsMap.Has(field) {
+		if !allowedFields.Has(field) {
 			if _, ok := SettingsAllFieldsStringMap[field]; !ok {
 				continue
 			}

--- a/api/edgeproto/trustpolicy.pb.go
+++ b/api/edgeproto/trustpolicy.pb.go
@@ -772,6 +772,10 @@ var UpdateTrustPolicyFieldsMap = NewFieldMap(map[string]struct{}{
 })
 
 func (m *TrustPolicy) ValidateUpdateFields() error {
+	return m.ValidateUpdateFieldsCustom(UpdateTrustPolicyFieldsMap)
+}
+
+func (m *TrustPolicy) ValidateUpdateFieldsCustom(allowedFields *FieldMap) error {
 	if m.Fields == nil {
 		return fmt.Errorf("nothing specified to update")
 	}
@@ -781,7 +785,7 @@ func (m *TrustPolicy) ValidateUpdateFields() error {
 		if m.IsKeyField(field) {
 			continue
 		}
-		if !UpdateTrustPolicyFieldsMap.Has(field) {
+		if !allowedFields.Has(field) {
 			if _, ok := TrustPolicyAllFieldsStringMap[field]; !ok {
 				continue
 			}

--- a/api/edgeproto/trustpolicyexception.pb.go
+++ b/api/edgeproto/trustpolicyexception.pb.go
@@ -1162,6 +1162,10 @@ var UpdateTrustPolicyExceptionFieldsMap = NewFieldMap(map[string]struct{}{
 })
 
 func (m *TrustPolicyException) ValidateUpdateFields() error {
+	return m.ValidateUpdateFieldsCustom(UpdateTrustPolicyExceptionFieldsMap)
+}
+
+func (m *TrustPolicyException) ValidateUpdateFieldsCustom(allowedFields *FieldMap) error {
 	if m.Fields == nil {
 		return fmt.Errorf("nothing specified to update")
 	}
@@ -1171,7 +1175,7 @@ func (m *TrustPolicyException) ValidateUpdateFields() error {
 		if m.IsKeyField(field) {
 			continue
 		}
-		if !UpdateTrustPolicyExceptionFieldsMap.Has(field) {
+		if !allowedFields.Has(field) {
 			if _, ok := TrustPolicyExceptionAllFieldsStringMap[field]; !ok {
 				continue
 			}

--- a/api/edgeproto/vmpool.pb.go
+++ b/api/edgeproto/vmpool.pb.go
@@ -1935,6 +1935,10 @@ var UpdateVMPoolFieldsMap = NewFieldMap(map[string]struct{}{
 })
 
 func (m *VMPool) ValidateUpdateFields() error {
+	return m.ValidateUpdateFieldsCustom(UpdateVMPoolFieldsMap)
+}
+
+func (m *VMPool) ValidateUpdateFieldsCustom(allowedFields *FieldMap) error {
 	if m.Fields == nil {
 		return fmt.Errorf("nothing specified to update")
 	}
@@ -1944,7 +1948,7 @@ func (m *VMPool) ValidateUpdateFields() error {
 		if m.IsKeyField(field) {
 			continue
 		}
-		if !UpdateVMPoolFieldsMap.Has(field) {
+		if !allowedFields.Has(field) {
 			if _, ok := VMPoolAllFieldsStringMap[field]; !ok {
 				continue
 			}

--- a/api/edgeproto/zone.pb.go
+++ b/api/edgeproto/zone.pb.go
@@ -826,6 +826,10 @@ var UpdateZoneFieldsMap = NewFieldMap(map[string]struct{}{
 })
 
 func (m *Zone) ValidateUpdateFields() error {
+	return m.ValidateUpdateFieldsCustom(UpdateZoneFieldsMap)
+}
+
+func (m *Zone) ValidateUpdateFieldsCustom(allowedFields *FieldMap) error {
 	if m.Fields == nil {
 		return fmt.Errorf("nothing specified to update")
 	}
@@ -835,7 +839,7 @@ func (m *Zone) ValidateUpdateFields() error {
 		if m.IsKeyField(field) {
 			continue
 		}
-		if !UpdateZoneFieldsMap.Has(field) {
+		if !allowedFields.Has(field) {
 			if _, ok := ZoneAllFieldsStringMap[field]; !ok {
 				continue
 			}

--- a/api/edgeproto/zonepool.pb.go
+++ b/api/edgeproto/zonepool.pb.go
@@ -1014,6 +1014,10 @@ var UpdateZonePoolFieldsMap = NewFieldMap(map[string]struct{}{
 })
 
 func (m *ZonePool) ValidateUpdateFields() error {
+	return m.ValidateUpdateFieldsCustom(UpdateZonePoolFieldsMap)
+}
+
+func (m *ZonePool) ValidateUpdateFieldsCustom(allowedFields *FieldMap) error {
 	if m.Fields == nil {
 		return fmt.Errorf("nothing specified to update")
 	}
@@ -1023,7 +1027,7 @@ func (m *ZonePool) ValidateUpdateFields() error {
 		if m.IsKeyField(field) {
 			continue
 		}
-		if !UpdateZonePoolFieldsMap.Has(field) {
+		if !allowedFields.Has(field) {
 			if _, ok := ZonePoolAllFieldsStringMap[field]; !ok {
 				continue
 			}

--- a/pkg/platform/aws/aws-eks/aws-eks.go
+++ b/pkg/platform/aws/aws-eks/aws-eks.go
@@ -17,6 +17,7 @@ package awseks
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -89,6 +90,10 @@ func (a *AwsEksPlatform) RunClusterCreateCommand(ctx context.Context, clusterNam
 		return nil, fmt.Errorf("Create eks cluster failed: %s - %v", string(out), err)
 	}
 	return nil, nil
+}
+
+func (s *AwsEksPlatform) RunClusterUpdateCommand(ctx context.Context, clusterName string, clusterInst *edgeproto.ClusterInst) (map[string]string, error) {
+	return nil, errors.New("update cluster instance not implemented")
 }
 
 // RunClusterDeleteCommand removes the kubernetes cluster on AWS

--- a/pkg/platform/common/managedk8s/mk8s-provider.go
+++ b/pkg/platform/common/managedk8s/mk8s-provider.go
@@ -44,6 +44,9 @@ type ManagedK8sProvider interface {
 	CreateClusterPrerequisites(ctx context.Context, clusterName string) error
 	// RunClusterCreateCommand creates the specified cluster, returning any infra annotations to add to the cluster.
 	RunClusterCreateCommand(ctx context.Context, clusterName string, clusterInst *edgeproto.ClusterInst) (map[string]string, error)
+	// RunClusterUpdateCommand updates the specified cluster, returning any infra annotations to add to the cluster.
+	// Check clusterInst.Fields to see which fields are updated.
+	RunClusterUpdateCommand(ctx context.Context, clusterName string, clusterInst *edgeproto.ClusterInst) (map[string]string, error)
 	RunClusterDeleteCommand(ctx context.Context, clusterName string, clusterInst *edgeproto.ClusterInst) error
 	GetClusterAddonInfo(ctx context.Context, clusterName string, clusterInst *edgeproto.ClusterInst) (*k8smgmt.ClusterAddonInfo, error)
 	InitApiAccessProperties(ctx context.Context, accessApi platform.AccessApi, vars map[string]string) error

--- a/pkg/platform/gcp/gcp-gke.go
+++ b/pkg/platform/gcp/gcp-gke.go
@@ -16,6 +16,7 @@ package gcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -64,6 +65,10 @@ func (g *GCPPlatform) RunClusterCreateCommand(ctx context.Context, clusterName s
 		return nil, fmt.Errorf("Error in cluster create: %s - %v", string(out), err)
 	}
 	return nil, nil
+}
+
+func (s *GCPPlatform) RunClusterUpdateCommand(ctx context.Context, clusterName string, clusterInst *edgeproto.ClusterInst) (map[string]string, error) {
+	return nil, errors.New("update cluster instance not implemented")
 }
 
 // RunClusterDeleteCommand removes kubernetes cluster on gcloud

--- a/pkg/platform/osmano/osmapi/SOL005.yaml
+++ b/pkg/platform/osmano/osmapi/SOL005.yaml
@@ -11479,6 +11479,8 @@ components:
           type: string
         resource_group:
           type: string
+        bootstrap:
+          type: boolean
         infra_controller_profiles:
           type: array
           items:

--- a/pkg/platform/osmano/osmapi/osm-generated.go
+++ b/pkg/platform/osmano/osmapi/osm-generated.go
@@ -323,6 +323,7 @@ type CloneKsu struct {
 // CreateClusterInfo defines model for CreateClusterInfo.
 type CreateClusterInfo struct {
 	AppProfiles             *[]string `json:"app_profiles,omitempty"`
+	Bootstrap               *bool     `json:"bootstrap,omitempty"`
 	Description             *string   `json:"description,omitempty"`
 	InfraConfigProfiles     *[]string `json:"infra_config_profiles,omitempty"`
 	InfraControllerProfiles *[]string `json:"infra_controller_profiles,omitempty"`

--- a/tools/protoc-gen-gomex/mex.go
+++ b/tools/protoc-gen-gomex/mex.go
@@ -1383,6 +1383,10 @@ type cudTemplateArgs struct {
 
 var fieldsValTemplate = `
 func (m *{{.Name}}) ValidateUpdateFields() error {
+	return m.ValidateUpdateFieldsCustom(Update{{.Name}}FieldsMap)
+}
+
+func (m *{{.Name}}) ValidateUpdateFieldsCustom(allowedFields *FieldMap) error {
 	if m.Fields == nil {
 		return fmt.Errorf("nothing specified to update")
 	}
@@ -1392,7 +1396,7 @@ func (m *{{.Name}}) ValidateUpdateFields() error {
 		if m.IsKeyField(field) {
 			continue
 		}
-		if !Update{{.Name}}FieldsMap.Has(field) {
+		if !allowedFields.Has(field) {
 			if _, ok := {{.Name}}AllFieldsStringMap[field]; !ok {
 				continue
 			}


### PR DESCRIPTION
This allows platforms based on the mk8s-provider (managed kubernetes provider) to support cluster updates.

Specifically this is used for scaling cluster node pools for Azure and OSM.