### PR TITLE
infra prop for ingress controller present

### DIFF
--- a/build/docker/Dockerfile.alpine-wget
+++ b/build/docker/Dockerfile.alpine-wget
@@ -1,0 +1,5 @@
+
+FROM alpine
+
+USER root
+RUN apk add --no-cache wget

--- a/build/docker/Makefile
+++ b/build/docker/Makefile
@@ -25,6 +25,11 @@ gobuild:
 gobuild-publish:
 	docker push $(REGISTRY)/build:$(GOVERS)
 
+alpine-wget:
+	docker build -t edgexr/alpine-wget:$(VERSION) -f Dockerfile.alpine-wget .
+	docker tag edgexr/alpine-wget:$(VERSION) $(REGISTRY)/alpine-wget:$(VERSION)
+	docker push $(REGISTRY)/alpine-wget:$(VERSION)
+
 # Image to be used for services that don't need infra-specific clients
 # Ideally this should be a non-debug version, but using debug for
 # now to include shell.

--- a/pkg/accessvars/accessvars.go
+++ b/pkg/accessvars/accessvars.go
@@ -93,9 +93,9 @@ func DeleteCloudletAccessVars(ctx context.Context, region string, cloudlet *edge
 	return vault.DeleteData(vaultConfig, path)
 }
 
-func ValidateAccessVars(accessVars map[string]string, props map[string]*edgeproto.PropertyInfo) error {
+func ValidatePropVars(vars map[string]string, props map[string]*edgeproto.PropertyInfo, varType string) error {
 	invalid := []string{}
-	for key := range accessVars {
+	for key := range vars {
 		if _, ok := props[key]; !ok {
 			invalid = append(invalid, key)
 		}
@@ -107,19 +107,19 @@ func ValidateAccessVars(accessVars map[string]string, props map[string]*edgeprot
 		}
 		sort.Strings(invalid)
 		sort.Strings(validVars)
-		return fmt.Errorf("Invalid access vars %s, valid vars are %s", strings.Join(invalid, ", "), strings.Join(validVars, ", "))
+		return fmt.Errorf("Invalid %s vars %s, valid vars are %s", varType, strings.Join(invalid, ", "), strings.Join(validVars, ", "))
 	}
 	notFound := []string{}
 	for key, prop := range props {
 		if prop.Mandatory {
-			if _, found := accessVars[key]; !found {
+			if _, found := vars[key]; !found {
 				notFound = append(notFound, key)
 			}
 		}
 	}
 	if len(notFound) > 0 {
 		sort.Strings(notFound)
-		return fmt.Errorf("Missing required access vars %s", strings.Join(notFound, ", "))
+		return fmt.Errorf("Missing required %s vars %s", varType, strings.Join(notFound, ", "))
 	}
 	return nil
 }

--- a/pkg/accessvars/accessvars_test.go
+++ b/pkg/accessvars/accessvars_test.go
@@ -77,7 +77,7 @@ func TestValidateAccessVars(t *testing.T) {
 		}, "Invalid access vars",
 	}}
 	for _, test := range tests {
-		err := ValidateAccessVars(test.vars, props)
+		err := ValidatePropVars(test.vars, props, "access")
 		if test.expErr == "" {
 			require.Nil(t, err, test.desc)
 		} else {

--- a/pkg/cloudcommon/cloudlet-props.go
+++ b/pkg/cloudcommon/cloudlet-props.go
@@ -22,8 +22,9 @@ import (
 )
 
 const (
-	IngressHTTPPort  = "INGRESS_HTTP_PORT"
-	IngressHTTPSPort = "INGRESS_HTTPS_PORT"
+	IngressHTTPPort          = "INGRESS_HTTP_PORT"
+	IngressHTTPSPort         = "INGRESS_HTTPS_PORT"
+	IngressControllerPresent = "INGRESS_CONTROLLER_PRESENT"
 )
 
 var IngressHTTPPortProp = &edgeproto.PropertyInfo{
@@ -34,6 +35,11 @@ var IngressHTTPPortProp = &edgeproto.PropertyInfo{
 var IngressHTTPSPortProp = &edgeproto.PropertyInfo{
 	Name:        "Ingress HTTPS Port",
 	Description: "Port number to override the default port 443 for HTTPS ports with TLS using ingress objects in Kubernetes clusters, typically used when a NAT fronts the ingress",
+}
+
+var IngressControllerPresentProp = &edgeproto.PropertyInfo{
+	Name:        "Ingress Controller is Present",
+	Description: "Pre-existing clusters or clusters deployed by cluster manager come with the ingress controller already installed",
 }
 
 func ValidateProps(vars map[string]string) error {

--- a/pkg/controller/cloudlet_api.go
+++ b/pkg/controller/cloudlet_api.go
@@ -536,7 +536,7 @@ func (s *CloudletApi) createCloudletInternal(cctx *CallContext, in *edgeproto.Cl
 	}()
 
 	if len(accessVars) > 0 {
-		err = accessvars.ValidateAccessVars(accessVars, features.AccessVars)
+		err = accessvars.ValidatePropVars(accessVars, features.AccessVars, "access")
 		if err != nil {
 			return err
 		}
@@ -546,6 +546,12 @@ func (s *CloudletApi) createCloudletInternal(cctx *CallContext, in *edgeproto.Cl
 		}
 		// NOTE: If accessvars is successfully stored then do not delete it on cleanup
 		//       as it can be shared amongst other cloudlets
+	}
+	if len(in.EnvVar) > 0 {
+		err = accessvars.ValidatePropVars(in.EnvVar, features.Properties, "env")
+		if err != nil {
+			return err
+		}
 	}
 
 	vmPool := edgeproto.VMPool{}

--- a/pkg/platform/common/managedk8s/mk8s-cluster.go
+++ b/pkg/platform/common/managedk8s/mk8s-cluster.go
@@ -75,9 +75,12 @@ func (m *ManagedK8sPlatform) CreateClusterInst(ctx context.Context, clusterInst 
 		CommerialCerts: m.CommonPf.PlatformConfig.CommercialCerts,
 		InitCluster:    true,
 	}
-	err = k8smgmt.SetupIngressNginx(ctx, client, names.GetKConfNames(), m.CommonPf.PlatformConfig.CloudletKey, m.CommonPf.PlatformConfig.ProxyCertsCache, wildcardName, refreshOpts, updateCallback, addonInfo.IngressNginxOps...)
-	if err != nil {
-		return nil, err
+	hasIngressController, ok := m.CommonPf.Properties.GetValue(cloudcommon.IngressControllerPresent)
+	if !ok || hasIngressController == "" {
+		err = k8smgmt.SetupIngressNginx(ctx, client, names.GetKConfNames(), m.CommonPf.PlatformConfig.CloudletKey, m.CommonPf.PlatformConfig.ProxyCertsCache, wildcardName, refreshOpts, updateCallback, addonInfo.IngressNginxOps...)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return infraAnnotations, err
 }

--- a/pkg/platform/common/managedk8s/mk8s-provider.go
+++ b/pkg/platform/common/managedk8s/mk8s-provider.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/k8smgmt"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform"
@@ -103,6 +104,10 @@ func (m *ManagedK8sPlatform) GetFeatures() *edgeproto.PlatformFeatures {
 	features := m.Provider.GetFeatures()
 	features.RequiresCrmOffEdge = true
 	features.UsesIngress = true
+	if features.Properties == nil {
+		features.Properties = make(map[string]*edgeproto.PropertyInfo)
+	}
+	features.Properties[cloudcommon.IngressControllerPresent] = cloudcommon.IngressControllerPresentProp
 	return features
 }
 

--- a/pkg/platform/fake/fake.go
+++ b/pkg/platform/fake/fake.go
@@ -102,6 +102,22 @@ var fakeProps = map[string]*edgeproto.PropertyInfo{
 		Description: "[]edgeproto.FlavorInfo as JSON string",
 		Mandatory:   false,
 	},
+	"FAKE_RAM_MAX": {
+		Name: "Fake RAM max",
+	},
+	"FAKE_VCPUS_MAX": {
+		Name: "Fake VCPUs max",
+	},
+	"FAKE_DISK_MAX": {
+		Name: "Fake VCPUs max",
+	},
+	"foo": {
+		Name: "foo",
+	},
+	"FAKE_PLATFORM_APPINST_CREATE_FAIL": {
+		Name:        "fake platform appinst create fail",
+		Description: "for e2e tests, make appinst create fail",
+	},
 }
 
 var AccessVarProps = map[string]*edgeproto.PropertyInfo{

--- a/pkg/platform/k8ssite/k8ssite-cloudlet.go
+++ b/pkg/platform/k8ssite/k8ssite-cloudlet.go
@@ -20,6 +20,7 @@ import (
 
 	dme "github.com/edgexr/edge-cloud-platform/api/distributed_match_engine"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/k8smgmt"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform"
@@ -67,9 +68,12 @@ func (s *K8sSite) CreateCloudlet(ctx context.Context, cloudlet *edgeproto.Cloudl
 		CommerialCerts: s.CommonPf.PlatformConfig.CommercialCerts,
 		InitCluster:    true,
 	}
-	err = k8smgmt.SetupIngressNginx(ctx, client, kconfNames, &cloudlet.Key, pfInitConfig.ProxyCertsCache, wildcardName, refreshOpts, updateCallback)
-	if err != nil {
-		return false, err
+	hasIngressController, ok := s.CommonPf.Properties.GetValue(cloudcommon.IngressControllerPresent)
+	if !ok || hasIngressController == "" {
+		err = k8smgmt.SetupIngressNginx(ctx, client, kconfNames, &cloudlet.Key, pfInitConfig.ProxyCertsCache, wildcardName, refreshOpts, updateCallback)
+		if err != nil {
+			return false, err
+		}
 	}
 	return false, nil
 }

--- a/pkg/platform/k8ssite/k8ssite-props.go
+++ b/pkg/platform/k8ssite/k8ssite-props.go
@@ -36,9 +36,10 @@ var AccessVarProps = map[string]*edgeproto.PropertyInfo{
 }
 
 var Props = map[string]*edgeproto.PropertyInfo{
-	infracommon.ExternalIPMap:    infracommon.ExternalIPMapProp,
-	cloudcommon.IngressHTTPPort:  cloudcommon.IngressHTTPPortProp,
-	cloudcommon.IngressHTTPSPort: cloudcommon.IngressHTTPSPortProp,
+	infracommon.ExternalIPMap:            infracommon.ExternalIPMapProp,
+	cloudcommon.IngressHTTPPort:          cloudcommon.IngressHTTPPortProp,
+	cloudcommon.IngressHTTPSPort:         cloudcommon.IngressHTTPSPortProp,
+	cloudcommon.IngressControllerPresent: cloudcommon.IngressControllerPresentProp,
 }
 
 func (s *K8sSite) InitApiAccessProperties(ctx context.Context, accessApi platform.AccessApi, vars map[string]string) error {

--- a/pkg/platform/k8ssite/k8ssite.go
+++ b/pkg/platform/k8ssite/k8ssite.go
@@ -81,11 +81,12 @@ func (s *K8sSite) InitCommon(ctx context.Context, platformConfig *platform.Platf
 		return err
 	}
 
-	if err := s.CommonPf.InitInfraCommon(ctx, platformConfig, map[string]*edgeproto.PropertyInfo{}); err != nil {
+	features := s.GetFeatures()
+	if err := s.CommonPf.InitInfraCommon(ctx, platformConfig, features.Properties); err != nil {
 		log.SpanLog(ctx, log.DebugLevelInfra, "InitInfraCommon failed", "err")
 		return err
 	}
-	s.K8sWorkloadMgr.Init(s, s.GetFeatures(), &s.CommonPf)
+	s.K8sWorkloadMgr.Init(s, features, &s.CommonPf)
 	return nil
 }
 

--- a/test/testutil/test_data.go
+++ b/test/testutil/test_data.go
@@ -433,7 +433,19 @@ func PlatformFeaturesData() []edgeproto.PlatformFeatures {
 				Name:        "API Key",
 				Description: "API Key for authentication",
 				Secret:      true,
-			}}
+			},
+		}
+		features[ii].Properties = map[string]*edgeproto.PropertyInfo{
+			"FAKE_RAM_MAX": {
+				Name: "Fake RAM Max",
+			},
+			"FAKE_VCPUS_MAX": {
+				Name: "Fake VCPUs Max",
+			},
+			"FLAVORS": {
+				Name: "Flavors",
+			},
+		}
 	}
 	return features
 }


### PR DESCRIPTION
Add common infra property to control whether or not to install ingress-nginx. Some clusters (rke2) may be given to us with the ingress controller already present.

Added a dockerfile for an image with a proper wget installed that handles proxies (the default wget in alpine does not).

I also added checks on Cloudlet.EnvVars to match checks on Cloudlet.AccessVars. This validates the env vars are spelled properly and actually supported.