### PR TITLE
fix clusterinst reservation handling for multiple appinsts

### DIFF
--- a/pkg/controller/appinst_api.go
+++ b/pkg/controller/appinst_api.go
@@ -1879,7 +1879,7 @@ func (s *AppInstApi) deleteAppInstInternal(cctx *CallContext, in *edgeproto.AppI
 		if cloudletRefsChanged {
 			s.all.cloudletRefsApi.store.STMPut(stm, &cloudletRefs)
 		}
-		if clusterInstReqd && clusterInst.ReservedBy != "" && clusterInst.ReservedBy == in.Key.Organization {
+		if clusterInstReqd && clusterInst.ReservedBy != "" && clusterInst.ReservedBy == in.Key.Organization && s.all.clusterRefsApi.canReleaseReservation(stm, in) {
 			clusterInst.ReservedBy = ""
 			clusterInst.ReservationEndedAt = dme.TimeToTimestamp(time.Now())
 			s.all.clusterInstApi.store.STMPut(stm, &clusterInst)

--- a/pkg/controller/clusterinst_api_test.go
+++ b/pkg/controller/clusterinst_api_test.go
@@ -376,6 +376,11 @@ func testReservableClusterInst(t *testing.T, ctx context.Context, api *testutil.
 	// Make sure above changes have not affected ReservedBy setting
 	checkReservedBy(t, ctx, api, &cinst.Key, appinst.Key.Organization)
 
+	// Delete second AppInst should not clear reservation
+	err = apis.appInstApi.DeleteAppInst(&appinst3, streamOut)
+	require.Nil(t, err, "delete AppInst on reservable ClusterInst")
+	checkReservedBy(t, ctx, api, &cinst.Key, appinst.Key.Organization)
+
 	// Deleting AppInst should removed ReservedBy
 	err = apis.appInstApi.DeleteAppInst(&appinst, streamOut)
 	require.Nil(t, err, "delete AppInst")
@@ -388,8 +393,6 @@ func testReservableClusterInst(t *testing.T, ctx context.Context, api *testutil.
 
 	// Delete AppInst
 	err = apis.appInstApi.DeleteAppInst(&appinst2, streamOut)
-	require.Nil(t, err, "delete AppInst on reservable ClusterInst")
-	err = apis.appInstApi.DeleteAppInst(&appinst3, streamOut)
 	require.Nil(t, err, "delete AppInst on reservable ClusterInst")
 	checkReservedBy(t, ctx, api, &cinst.Key, "")
 


### PR DESCRIPTION
We recently made changes to allow AppInst deployments to target an existing reservable ClusterInst if already owned by the same organization, and scale that clusterinst up to fit the second AppInst. This fixes a bug where deleting the second AppInst would clear the reservation, even though the first AppInst was still present.
