### PR TITLE
fix issue with k8s ingress getting wrong service

### DIFF
--- a/pkg/k8smgmt/appinst.go
+++ b/pkg/k8smgmt/appinst.go
@@ -209,6 +209,10 @@ func WaitForAppInst(ctx context.Context, client ssh.Client, names *KubeNames, ap
 			if done {
 				break
 			}
+			if err := ctx.Err(); err != nil {
+				log.SpanLog(ctx, log.DebugLevelInfra, "context error, aboring wait for appinst", "app", app.Key, "err", err)
+				return err
+			}
 			elapsed := time.Since(start)
 			if elapsed >= (maxWait) {
 				// for now we will return no errors when we time out.  In future we will use some other state or status


### PR DESCRIPTION
When deploying an ingress, we search for the service to route to. For non multi-tenant AppInsts, we search all namespaces, because it could be a helm chart or k8s operator deploying services to various namespaces (although more likely it's just our simple app deploying to the default namespace).

A bug was hit where the search for a service matched the ingress-nginx-controller service, which listens on port 80 (the AppInst also used port 80), and so the AppInst's ingress targeted the wrong service. To fix, for now we avoid the system and ingress-nginx namespaces when searching for matching services.

Additionally, I saw an issue where the AppInst create command had timed out, but the CCRM process was still polling for the AppInst status. We now properly check if the context has been cancelled.