### PR TITLE
update gobuild image to 1.22.9

### DIFF
--- a/build/docker/Dockerfile.build
+++ b/build/docker/Dockerfile.build
@@ -12,7 +12,7 @@
 
 FROM ubuntu:22.04 AS build
 
-ENV GOVERS 1.21.6
+ENV GOVERS 1.22.9
 ENV PROTOCVERS 3.6.0
 
 RUN apt-get update
@@ -28,9 +28,6 @@ RUN mv bin/protoc /usr/local/bin
 RUN mv include/google /usr/local/include/
 RUN mkdir -p /root/go/bin
 RUN rm *.zip
-RUN go env
-RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-RUN mv /root/go/bin/dep /usr/local/bin/
 RUN echo export GOROOT=/usr/local >> /root/.bashrc
 RUN echo export GOPATH=/go >> /root/.bashrc
 

--- a/build/docker/Dockerfile.edge-cloud-platform
+++ b/build/docker/Dockerfile.edge-cloud-platform
@@ -14,7 +14,7 @@
 ARG REGISTRY=ghcr.io/edgexr
 ARG EDGE_CLOUD_INFRA_BASE=scratch
 
-FROM $REGISTRY/build:go1.21.6 AS build
+FROM $REGISTRY/build:go1.22.9 AS build
 
 ENV GOPATH=/go
 ENV PATH="/go/bin:${PATH}"

--- a/build/docker/Makefile
+++ b/build/docker/Makefile
@@ -16,7 +16,7 @@ build-edge-cloud-infra-base:
 publish-edge-cloud-infra-base:
 	docker push $(REGISTRY)/edge-cloud-infra-base:$(TAG)
 
-GOVERS = go1.21.6
+GOVERS = go1.22.9
 
 gobuild:
 	docker build -t edgexr/build:$(GOVERS) -f Dockerfile.build .


### PR DESCRIPTION
Update build image to 1.22, remove deprecated dep tool for build image.