### PR TITLE
potential cloudlet skip if not enough resources

### DIFF
--- a/pkg/controller/appinst_api_test.go
+++ b/pkg/controller/appinst_api_test.go
@@ -1385,6 +1385,7 @@ func testAppInstPotentialCloudlets(t *testing.T, ctx context.Context, apis *AllA
 			CpuPool: &edgeproto.NodePoolResources{
 				TotalVcpus:  *edgeproto.NewUdec64(uint64(6-ii), 0),
 				TotalMemory: uint64(1024 * (6 - ii)),
+				TotalDisk:   2,
 				Topology: edgeproto.NodePoolTopology{
 					MinNodeVcpus:     1,
 					MinNodeMemory:    1024,
@@ -1433,7 +1434,7 @@ func testAppInstPotentialCloudlets(t *testing.T, ctx context.Context, apis *AllA
 	}
 	err = apis.appInstApi.CreateAppInst(ai, testutil.NewCudStreamoutAppInst(ctx))
 	require.NotNil(t, err)
-	require.Equal(t, "not enough resources available: required RAM is 86016MB but only 66560MB out of 81920MB is available, required vCPUs is 84 but only 5 out of 20 is available", err.Error())
+	require.Equal(t, "no available cloudlet sites to create a new cluster", err.Error())
 }
 
 func testAppInstScaleSpec(t *testing.T, ctx context.Context, apis *AllApis) {
@@ -1828,7 +1829,7 @@ func TestNBIUseCase(t *testing.T) {
 	// scenario 4: rejection
 	_, err = deployApp("scenario4", appIDs[3], zoneA.ObjId)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "not enough resources available: required vCPUs is 2 but only 0")
+	require.Contains(t, err.Error(), "no available cloudlet sites to create a new cluster")
 
 	// scanario 5: delete ai3, check that ai5 deploy fails
 	// due to kubernetes version mismatch
@@ -1855,7 +1856,7 @@ func TestNBIUseCase(t *testing.T) {
 	// deploy app
 	_, err = deployApp("scenario5", appIDs[4], zoneA.ObjId)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "not enough resources available: required vCPUs is 2 but only 0")
+	require.Contains(t, err.Error(), "no available cloudlet sites to create a new cluster")
 	// redeploy ai3 should work
 	_, err = deployApp("scenario5.1", appIDs[2], zoneA.ObjId)
 	require.Nil(t, err)

--- a/pkg/controller/clusterinst_api.go
+++ b/pkg/controller/clusterinst_api.go
@@ -937,8 +937,8 @@ func (s *ClusterInstApi) createClusterInstInternal(cctx *CallContext, in *edgepr
 		break
 	}
 	if err != nil {
-		// no valid cloudlets found, return last resource error
-		return err
+		// if we get here, then all sites had resourceFailures.
+		return fmt.Errorf("not enough resources available to create the cluster")
 	}
 
 	sendObj, err := s.startClusterInstStream(ctx, cctx, streamCb, modRev)


### PR DESCRIPTION
For AppInst creates, if no existing cluster was found, we picked the first potential cloudlet from the list, sorted by resource score (i.e. with the most resources available). However, this didn't actually check if the specific resources needed were available. A cloudlet can have a high resource score if other resources are abundant, but if there aren't enough vcpus, the cluster can't be created.

We now check that cloudlets can fit the desired auto cluster instance.