### PR TITLE
various k8s appinst deploy fixes

### DIFF
--- a/pkg/cloudcommon/compatibility.go
+++ b/pkg/cloudcommon/compatibility.go
@@ -39,7 +39,7 @@ const (
 
 // GetAppInstCompatibilityVersion always returns the highest compatibility version
 func GetAppInstCompatibilityVersion() uint32 {
-	return AppInstCompatibilityUniqueNameKeyConfig
+	return AppInstCompatibilityRegionScopeName
 }
 
 // ClusterInst compatibility versions, same as above for AppInsts.

--- a/pkg/controller/appinst_api_test.go
+++ b/pkg/controller/appinst_api_test.go
@@ -922,19 +922,19 @@ func testSingleKubernetesCloudlet(t *testing.T, ctx context.Context, apis *AllAp
 	}, {
 		"MT specified correct cluster",
 		0, &zoneMT, mtOrg, mtClust, notDedicatedIp,
-		"shared.singlek8smt-unittest.local." + appDnsRoot, PASS,
+		"pillimogo1-atlanticinc.singlek8smt-unittest.local." + appDnsRoot, PASS,
 	}, {
 		"MT any clust name blank org",
 		0, &zoneMT, "", "", notDedicatedIp,
-		"shared.singlek8smt-unittest.local." + appDnsRoot, PASS,
+		"pillimogo1-atlanticinc.singlek8smt-unittest.local." + appDnsRoot, PASS,
 	}, {
 		"ST specified correct cluster",
 		0, &zoneST, stOrg, stClust, notDedicatedIp,
-		"shared.singlek8sst-unittest.local." + appDnsRoot, PASS,
+		"pillimogo1-atlanticinc.singlek8sst-unittest.local." + appDnsRoot, PASS,
 	}, {
 		"ST blank clust name blank org",
 		0, &zoneST, "", "", notDedicatedIp,
-		"shared.singlek8sst-unittest.local." + appDnsRoot, PASS,
+		"pillimogo1-atlanticinc.singlek8sst-unittest.local." + appDnsRoot, PASS,
 	}, {
 		"MT blank clust name dedicated",
 		0, &zoneMT, "", "", dedicatedIp,

--- a/pkg/controller/clusterinst_api.go
+++ b/pkg/controller/clusterinst_api.go
@@ -2264,7 +2264,8 @@ func (s *ClusterInstApi) ShowClusterResourceUsage(in *edgeproto.ClusterInst, cb 
 		}
 		usage, err := s.getClusterResourceUsage(ctx, ci, flavorLookup)
 		if err != nil {
-			return err
+			log.SpanLog(ctx, log.DebugLevelApi, "failed to get cluster resource usage, skipping", "cluster", ci.Key, "err", err)
+			continue
 		}
 		if err := cb.Send(usage); err != nil {
 			return err

--- a/pkg/platform/common/vmlayer/appinst.go
+++ b/pkg/platform/common/vmlayer/appinst.go
@@ -486,7 +486,7 @@ func (v *VMPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.C
 
 		if deployment == cloudcommon.DeploymentTypeKubernetes {
 			updateCallback(edgeproto.UpdateTask, "Creating Kubernetes App")
-			err = k8smgmt.CreateAppInst(ctx, v.VMProperties.CommonPf.PlatformConfig.AccessApi, client, names, app, appInst, appFlavor)
+			err = k8smgmt.CreateAppInst(ctx, v.VMProperties.CommonPf.PlatformConfig.AccessApi, client, names, app, appInst, k8smgmt.WithAppInstNoWait())
 		} else {
 			updateCallback(edgeproto.UpdateTask, "Creating Helm App")
 
@@ -902,7 +902,7 @@ func (v *VMPlatform) UpdateAppInst(ctx context.Context, clusterInst *edgeproto.C
 
 	switch deployment := app.Deployment; deployment {
 	case cloudcommon.DeploymentTypeKubernetes:
-		return k8smgmt.UpdateAppInst(ctx, v.VMProperties.CommonPf.PlatformConfig.AccessApi, client, names, app, appInst, flavor)
+		return k8smgmt.UpdateAppInst(ctx, v.VMProperties.CommonPf.PlatformConfig.AccessApi, client, names, app, appInst)
 	case cloudcommon.DeploymentTypeHelm:
 		return k8smgmt.UpdateHelmAppInst(ctx, client, names, app, appInst)
 

--- a/pkg/platform/common/xind/xind-appinst.go
+++ b/pkg/platform/common/xind/xind-appinst.go
@@ -104,13 +104,9 @@ func (s *Xind) CreateAppInstNoPatch(ctx context.Context, clusterInst *edgeproto.
 	ctx = context.WithValue(ctx, deployvars.DeploymentReplaceVarsKey, &deploymentVars)
 
 	if DeploymentType == cloudcommon.DeploymentTypeKubernetes {
-		err = k8smgmt.CreateAppInst(ctx, nil, client, names, app, appInst, flavor)
+		err = k8smgmt.CreateAppInst(ctx, nil, client, names, app, appInst)
 		if err == nil {
-			err = k8smgmt.WaitForAppInst(ctx, client, names, app, k8smgmt.WaitRunning)
-			if err != nil {
-				undoerr := k8smgmt.DeleteAppInst(ctx, s.platformConfig.AccessApi, client, names, app, appInst)
-				log.SpanLog(ctx, log.DebugLevelInfra, "Undo CreateAppInst", "undoerr", undoerr)
-			}
+			return err
 		}
 	} else if DeploymentType == cloudcommon.DeploymentTypeHelm {
 		err = k8smgmt.CreateHelmAppInst(ctx, client, names, clusterInst, app, appInst)
@@ -218,7 +214,7 @@ func (s *Xind) UpdateAppInst(ctx context.Context, clusterInst *edgeproto.Cluster
 	ctx = context.WithValue(ctx, deployvars.DeploymentReplaceVarsKey, &deploymentVars)
 
 	if DeploymentType == cloudcommon.DeploymentTypeKubernetes {
-		return k8smgmt.UpdateAppInst(ctx, nil, client, names, app, appInst, flavor)
+		return k8smgmt.UpdateAppInst(ctx, nil, client, names, app, appInst)
 	} else if DeploymentType == cloudcommon.DeploymentTypeHelm {
 		return k8smgmt.UpdateHelmAppInst(ctx, client, names, app, appInst)
 	}

--- a/pkg/platform/k8s-baremetal/k8sbm-appinst.go
+++ b/pkg/platform/k8s-baremetal/k8sbm-appinst.go
@@ -105,7 +105,7 @@ func (k *K8sBareMetalPlatform) CreateAppInst(ctx context.Context, clusterInst *e
 
 		if deployment == cloudcommon.DeploymentTypeKubernetes {
 			updateCallback(edgeproto.UpdateTask, "Creating Kubernetes App")
-			err = k8smgmt.CreateAppInst(ctx, k.commonPf.PlatformConfig.AccessApi, client, names, app, appInst, appInstFlavor)
+			err = k8smgmt.CreateAppInst(ctx, k.commonPf.PlatformConfig.AccessApi, client, names, app, appInst, k8smgmt.WithAppInstNoWait())
 		} else {
 			updateCallback(edgeproto.UpdateTask, "Creating Helm App")
 			err = k8smgmt.CreateHelmAppInst(ctx, client, names, clusterInst, app, appInst)
@@ -266,7 +266,7 @@ func (k *K8sBareMetalPlatform) UpdateAppInst(ctx context.Context, clusterInst *e
 	if err != nil {
 		return err
 	}
-	return k8smgmt.UpdateAppInst(ctx, k.commonPf.PlatformConfig.AccessApi, client, names, app, appInst, appInstFlavor)
+	return k8smgmt.UpdateAppInst(ctx, k.commonPf.PlatformConfig.AccessApi, client, names, app, appInst)
 }
 
 func (k *K8sBareMetalPlatform) GetAppInstRuntime(ctx context.Context, clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst) (*edgeproto.AppInstRuntime, error) {

--- a/pkg/platform/localhost/localhost.go
+++ b/pkg/platform/localhost/localhost.go
@@ -171,16 +171,10 @@ func (s *Platform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 			if err != nil {
 				return err
 			}*/
-		err = k8smgmt.CreateAppInst(ctx, s.platformConfig.AccessApi, client, names, app, appInst, &edgeproto.Flavor{})
+		err = k8smgmt.CreateAppInst(ctx, s.platformConfig.AccessApi, client, names, app, appInst)
 		if err != nil {
 			return err
 		}
-		defer func() {
-			if reterr != nil {
-				k8smgmt.DeleteAppInst(ctx, s.platformConfig.AccessApi, client, names, app, appInst)
-			}
-		}()
-		return k8smgmt.WaitForAppInst(ctx, client, names, app, k8smgmt.WaitRunning)
 	case cloudcommon.DeploymentTypeHelm:
 		names, err := k8smgmt.GetKubeNames(clusterInst, app, appInst)
 		if err != nil {

--- a/pkg/workloadmgrs/k8swm/k8swm.go
+++ b/pkg/workloadmgrs/k8swm/k8swm.go
@@ -79,14 +79,10 @@ func (m *K8sWorkloadMgr) CreateAppInst(ctx context.Context, clusterInst *edgepro
 		}
 	}
 
+	updateSender.SendStatus(edgeproto.UpdateTask, "Deploying App Instance")
 	switch deployment := app.Deployment; deployment {
 	case cloudcommon.DeploymentTypeKubernetes:
-		err = k8smgmt.CreateAppInst(ctx, m.commonPf.PlatformConfig.AccessApi, client, names, app, appInst, flavor)
-		if err == nil {
-			updateSender.SendStatus(edgeproto.UpdateTask, "Waiting for AppInst to Start")
-
-			err = k8smgmt.WaitForAppInst(ctx, client, names, app, k8smgmt.WaitRunning)
-		}
+		err = k8smgmt.CreateAppInst(ctx, m.commonPf.PlatformConfig.AccessApi, client, names, app, appInst)
 	case cloudcommon.DeploymentTypeHelm:
 		err = k8smgmt.CreateHelmAppInst(ctx, client, names, clusterInst, app, appInst)
 	default:
@@ -95,7 +91,7 @@ func (m *K8sWorkloadMgr) CreateAppInst(ctx context.Context, clusterInst *edgepro
 	if err != nil {
 		return err
 	}
-	updateSender.SendStatus(edgeproto.UpdateTask, "Waiting for Load Balancer External IP")
+	updateSender.SendStatus(edgeproto.UpdateTask, "Waiting for External IPs")
 
 	// set up dns
 	getDnsAction := func(svc v1.Service) (*infracommon.DnsSvcAction, error) {
@@ -220,7 +216,7 @@ func (m *K8sWorkloadMgr) UpdateAppInst(ctx context.Context, clusterInst *edgepro
 		return err
 	}
 
-	err = k8smgmt.UpdateAppInst(ctx, m.commonPf.PlatformConfig.AccessApi, client, names, app, appInst, flavor)
+	err = k8smgmt.UpdateAppInst(ctx, m.commonPf.PlatformConfig.AccessApi, client, names, app, appInst)
 	if err == nil {
 		updateCallback(edgeproto.UpdateTask, "Waiting for AppInst to Start")
 		err = k8smgmt.WaitForAppInst(ctx, client, names, app, k8smgmt.WaitRunning)


### PR DESCRIPTION
Various fixes:
- AppInst compatibility "RegionScopedNames" which was implemented a long time ago was actually never used, because all new AppInsts were still using the previous compatibility version. This updates new AppInsts to use the new compatibility version.
- For AppInsts with ingress, we need to make sure the URI is based on the AppInst name, not a shared LB name. Otherwise, when deploying multiple AppInsts to the same cluster, the hostnames in the ingress objects for each AppInst will conflict because they are the same.
- For ClusterResourceUsage Show, if one cluster hits an error, skip it instead of failing the entire API
- k8smgmt.CheckPodsStatus is reworked. Previously, it was based on kubectl output that used the "Reason" field as the status, but the reason field is an arbitrary string, and is not reliable to expect certain strings. Because of this it sometimes failed with new types of managed clusters. It now checks fields and struct data that are not arbitrary.
- k8smgmt.createOrUpdateAppInst now has baked in undo and wait (optional). Some callers were implementing their own undo, and some had incorrectly omitted it. Most callers were calling wait inline, which is redundant. Only callers that are doing wait in parallel now specify the NoWait() option
- ingress object manifest files are now written to the cluster's manifest config dir, otherwise they end up getting pruned and deleted if another change is applied (AppInst update, or another AppInst is created).