### PR TITLE
more informational messages for appinst deploy algorithms

### DIFF
--- a/pkg/cloudcommon/names.go
+++ b/pkg/cloudcommon/names.go
@@ -266,6 +266,7 @@ const (
 	AnnotationBadUpgrade55Name        = "bad-upgrade55-name"
 	AnnotationPreviousDNSName         = "previous-dns-name"
 	AnnotationFedPartnerAppProviderID = "fed-partner-app-provider-id"
+	AnnotationKubernetesVersion       = "kubernetes-version"
 )
 
 var InstanceUp = "UP"

--- a/pkg/controller/appinst_api_test.go
+++ b/pkg/controller/appinst_api_test.go
@@ -902,7 +902,7 @@ func testSingleKubernetesCloudlet(t *testing.T, ctx context.Context, apis *AllAp
 	}{{
 		"MT non-serverless app",
 		3, &zoneMT, "", "", notDedicatedIp, "",
-		"no available cloudlet sites to create a new cluster",
+		"no resources available for deployment",
 	}, {
 		"MT bad cluster org",
 		0, &zoneMT, "foo", mtClust, notDedicatedIp, "",
@@ -1434,7 +1434,7 @@ func testAppInstPotentialCloudlets(t *testing.T, ctx context.Context, apis *AllA
 	}
 	err = apis.appInstApi.CreateAppInst(ai, testutil.NewCudStreamoutAppInst(ctx))
 	require.NotNil(t, err)
-	require.Equal(t, "no available cloudlet sites to create a new cluster", err.Error())
+	require.Equal(t, "no resources available for deployment", err.Error())
 }
 
 func testAppInstScaleSpec(t *testing.T, ctx context.Context, apis *AllApis) {
@@ -1829,7 +1829,7 @@ func TestNBIUseCase(t *testing.T) {
 	// scenario 4: rejection
 	_, err = deployApp("scenario4", appIDs[3], zoneA.ObjId)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "no available cloudlet sites to create a new cluster")
+	require.Contains(t, err.Error(), "no resources available for deployment")
 
 	// scanario 5: delete ai3, check that ai5 deploy fails
 	// due to kubernetes version mismatch
@@ -1856,7 +1856,7 @@ func TestNBIUseCase(t *testing.T) {
 	// deploy app
 	_, err = deployApp("scenario5", appIDs[4], zoneA.ObjId)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "no available cloudlet sites to create a new cluster")
+	require.Contains(t, err.Error(), "no resources available for deployment")
 	// redeploy ai3 should work
 	_, err = deployApp("scenario5.1", appIDs[2], zoneA.ObjId)
 	require.Nil(t, err)

--- a/pkg/controller/cloudletinfo_api.go
+++ b/pkg/controller/cloudletinfo_api.go
@@ -156,7 +156,7 @@ func (s *CloudletInfoApi) UpdateFields(ctx context.Context, in *edgeproto.Cloudl
 	}
 	if fmap.HasOrHasChild(edgeproto.CloudletInfoFieldNodePools) && features != nil && features.IsSingleKubernetesCluster {
 		// copy node pool resource info to single cluster
-		s.all.clusterInstApi.updateCloudletSingleClusterResources(ctx, &cloudlet.Key, cloudlet.SingleKubernetesClusterOwner, in.NodePools)
+		s.all.clusterInstApi.updateCloudletSingleClusterResources(ctx, &cloudlet.Key, cloudlet.SingleKubernetesClusterOwner, in.NodePools, in.Properties)
 	}
 
 	newState := edgeproto.TrackedState_TRACKED_STATE_UNKNOWN

--- a/pkg/controller/potential_cloudlet.go
+++ b/pkg/controller/potential_cloudlet.go
@@ -43,6 +43,7 @@ type potentialInstCloudlet struct {
 // from developers.
 type SkipReason string
 
+// cloudlet skip reasons
 const (
 	NoSkipReason                SkipReason = ""
 	SiteUnavailable                        = "site is unavailable"
@@ -66,11 +67,33 @@ const (
 	NoSupportMultipleNodePools             = "site does not support multiple node pools"
 )
 
+// cluster skip reasons
+const (
+	ClusterMissing              SkipReason = "cluster missing"
+	DeploymentMismatch                     = "deployment type mismatch"
+	AppNotServerless                       = "app is not serverless"
+	ClusterReserved                        = "cluster reserved"
+	ClusterOwned                           = "cluster owned by another tenant"
+	SidecarAppMustTargetCluster            = "sidecar app must target cluster"
+	NoDynamicPlacement                     = "cluster has dynamic placement disabled"
+	K8SVersionFail                         = "k8s version not supported"
+	ClusterNoIPV6                          = "cluster does not support IPV6"
+	NoAppDuplicates                        = "instance of App already present"
+	StandaloneConflict                     = "standalone App conflict"
+	ClusterNoResources                     = "not enough resources"
+)
+
 type SkipReasons map[SkipReason]struct{}
 
 func (s SkipReasons) add(reason SkipReason) {
 	if reason != NoSkipReason {
 		s[reason] = struct{}{}
+	}
+}
+
+func (s SkipReasons) addAll(reasons SkipReasons) {
+	for reason := range reasons {
+		s.add(reason)
 	}
 }
 

--- a/pkg/platform/k8ssite/k8ssite.go
+++ b/pkg/platform/k8ssite/k8ssite.go
@@ -133,6 +133,15 @@ func (s *K8sSite) GatherCloudletInfo(ctx context.Context, info *edgeproto.Cloudl
 	if err != nil {
 		return err
 	}
+	clusterVersion, err := k8smgmt.GetClusterVersion(ctx, s.getClient(), kconfNames.KconfArg)
+	if err != nil {
+		return err
+	}
+	if info.Properties == nil {
+		info.Properties = make(map[string]string)
+	}
+	info.Properties[cloudcommon.AnnotationKubernetesVersion] = clusterVersion
+
 	// set total resource limits based on sum of all nodes
 	vcpus := edgeproto.Udec64{}
 	ram := edgeproto.Udec64{}


### PR DESCRIPTION
This provides more transparency as to why some cloudlets or clusters may not be able to be used when looking for a way to deploy an AppInst. We provide messages regarding the potential cloudlets and reasons that some may be skipped. Messages are intended to be generic rather than specific, as we are not supposed to expose the cloudlet-specific information to the user.

An example:
```
message: Found 3 potential cloudlets for deployment
message: Found 0 potential clusters for deployment, some skipped because instance of App already present
message: No existing cluster available
message: Creating new auto-cluster named reservable0-1aa80307 to deploy AppInst
```
Failure case (no existing available and no resources to create a new one):
```
message: Found 1 potential cloudlets for deployment
message: Found 0 potential clusters for deployment, some skipped because k8s version not supported
message: No existing cluster available
Error: No resources available for deployment
```

Also an unrelated change: for k8ssite platforms, figure out the version of the underlying kubernetes cluster.