### PR TITLE
Osmk8s: cluster get-creds fixes

### DIFF
--- a/pkg/controller/cloudletinfo_api.go
+++ b/pkg/controller/cloudletinfo_api.go
@@ -208,7 +208,7 @@ func (s *CloudletInfoApi) UpdateFields(ctx context.Context, in *edgeproto.Cloudl
 			newCloudlet.ContainerVersion = in.ContainerVersion
 			updateObj = true
 		}
-		if newCloudlet.Key.FederatedOrganization == "" && len(newCloudlet.InfraFlavors) != len(in.Flavors) {
+		if newCloudlet.Key.FederatedOrganization == "" && fmap.HasOrHasChild(edgeproto.CloudletInfoFieldFlavors) {
 			// Copy CloudletInfo.Flavors to Cloudlet.InfraFlavors so
 			// that developers can see and use cloudlet-specific
 			// flavors. Don't do this for federated cloudlets

--- a/pkg/k8smgmt/kubenames.go
+++ b/pkg/k8smgmt/kubenames.go
@@ -300,6 +300,7 @@ func EnsureNamespace(ctx context.Context, client ssh.Client, names *KconfNames, 
 	cmd := fmt.Sprintf("kubectl %s create ns %s --dry-run=client -o yaml | kubectl %s apply -f -", names.KconfArg, namespace, names.KconfArg)
 	out, err := client.Output(cmd)
 	if err != nil {
+		log.SpanLog(ctx, log.DebugLevelInfra, "failed to ensure namespace", "name", namespace, "cmd", cmd, "out", out, "err", err)
 		return fmt.Errorf("failed to create namespace %s: %s, %s", namespace, out, err)
 	}
 	return nil

--- a/pkg/platform/osmano/osmk8s/osmk8s_test.go
+++ b/pkg/platform/osmano/osmk8s/osmk8s_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/edgexr/edge-cloud-platform/pkg/k8smgmt"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 	"github.com/edgexr/edge-cloud-platform/pkg/platform/common/infracommon"
-	"github.com/edgexr/edge-cloud-platform/pkg/platform/pc"
 	"github.com/test-go/testify/require"
 )
 
@@ -93,10 +92,6 @@ func TestCreateCluster(t *testing.T) {
 	err = os.WriteFile(names.KconfName, creds, 0644)
 	require.Nil(t, err)
 	fmt.Println("wrote kubeconfig to " + names.KconfName)
-
-	client := &pc.LocalClient{}
-	err = k8smgmt.EnsureNamespace(ctx, client, nn.GetKConfNames(), k8smgmt.IngressNginxNamespace)
-	require.Nil(t, err)
 }
 
 func TestGetCredentials(t *testing.T) {
@@ -118,10 +113,6 @@ func TestGetCredentials(t *testing.T) {
 	err = os.WriteFile(names.KconfName, creds, 0644)
 	require.Nil(t, err)
 	fmt.Println("wrote kubeconfig to " + names.KconfName)
-
-	client := &pc.LocalClient{}
-	err = k8smgmt.EnsureNamespace(ctx, client, nn.GetKConfNames(), k8smgmt.IngressNginxNamespace)
-	require.Nil(t, err)
 }
 
 func TestScaleCluster(t *testing.T) {


### PR DESCRIPTION
Fix how OSM K8s cluster credentials are retrieved. Apparently, the client must run two API calls to get credentials.

Also a fix for updating cloudlet flavors, where the updated flavors were not being updated to the cloudlet object if the new flavors were the same number as the old flavors.