### PR TITLE
namespace labels platform property

### DIFF
--- a/pkg/k8smgmt/ingress-nginx.go
+++ b/pkg/k8smgmt/ingress-nginx.go
@@ -142,9 +142,9 @@ func InstallIngressNginx(ctx context.Context, client ssh.Client, names *KconfNam
 // SetupIngressNginx is a convenience function that creates the
 // namespace, creates the default certificate, and installs the
 // ingress-nginx controller.
-func SetupIngressNginx(ctx context.Context, client ssh.Client, names *KconfNames, cloudletKey *edgeproto.CloudletKey, certsCache *certscache.ProxyCertsCache, wildcardName string, refreshOpts RefreshCertsOpts, updateCallback edgeproto.CacheUpdateCallback, ops ...IngressNginxOp) error {
+func SetupIngressNginx(ctx context.Context, client ssh.Client, names *KconfNames, cloudletKey *edgeproto.CloudletKey, certsCache *certscache.ProxyCertsCache, wildcardName string, refreshOpts RefreshCertsOpts, namespaceLabels map[string]string, updateCallback edgeproto.CacheUpdateCallback, ops ...IngressNginxOp) error {
 	// set up namespace so we can write the default cert
-	err := EnsureNamespace(ctx, client, names, IngressNginxNamespace)
+	err := EnsureNamespace(ctx, client, names, IngressNginxNamespace, namespaceLabels)
 	if err != nil {
 		return err
 	}

--- a/pkg/k8spm/k8spm.go
+++ b/pkg/k8spm/k8spm.go
@@ -73,11 +73,17 @@ func (m *K8sPlatformMgr) CreateAppInst(ctx context.Context, clusterInst *edgepro
 	}
 	features := m.features
 
-	updateSender.SendStatus(edgeproto.UpdateTask, "Creating Registry Secret")
-	err = k8smgmt.CreateAllNamespaces(ctx, client, names)
+	nsLabels, err := m.commonPf.Properties.GetJSONMapValue(cloudcommon.NamespaceLabels)
 	if err != nil {
 		return err
 	}
+
+	updateSender.SendStatus(edgeproto.UpdateTask, "Creating Namespaces")
+	err = k8smgmt.CreateAllNamespaces(ctx, client, names, nsLabels)
+	if err != nil {
+		return err
+	}
+	updateSender.SendStatus(edgeproto.UpdateTask, "Creating Registry Secret")
 	for _, imagePath := range names.ImagePaths {
 		err = infracommon.CreateDockerRegistrySecret(ctx, client, k8smgmt.GetKconfName(clusterInst), imagePath, m.commonPf.PlatformConfig.AccessApi, names, nil)
 		if err != nil {

--- a/pkg/platform/common/infracommon/common-props.go
+++ b/pkg/platform/common/infracommon/common-props.go
@@ -24,6 +24,7 @@ import (
 
 	sh "github.com/codeskyblue/go-sh"
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
+	"github.com/edgexr/edge-cloud-platform/pkg/cloudcommon"
 	"github.com/edgexr/edge-cloud-platform/pkg/log"
 )
 
@@ -116,6 +117,16 @@ func (p *InfraProperties) GetValue(key string) (string, bool) {
 		return out.Value, ok
 	}
 	return "", false
+}
+
+func (p *InfraProperties) GetJSONMapValue(key string) (map[string]string, error) {
+	p.Mux.Lock()
+	defer p.Mux.Unlock()
+	val := ""
+	if out, ok := p.Properties[key]; ok {
+		val = out.Value
+	}
+	return cloudcommon.ParseJSONMapValue(val)
 }
 
 func (p *InfraProperties) SetValue(key, value string) {

--- a/pkg/platform/common/managedk8s/mk8s-cluster.go
+++ b/pkg/platform/common/managedk8s/mk8s-cluster.go
@@ -81,7 +81,11 @@ func (m *ManagedK8sPlatform) CreateClusterInst(ctx context.Context, clusterInst 
 	}
 	hasIngressController, ok := m.CommonPf.Properties.GetValue(cloudcommon.IngressControllerPresent)
 	if !ok || hasIngressController == "" {
-		err = k8smgmt.SetupIngressNginx(ctx, client, names.GetKConfNames(), m.CommonPf.PlatformConfig.CloudletKey, m.CommonPf.PlatformConfig.ProxyCertsCache, wildcardName, refreshOpts, updateCallback, addonInfo.IngressNginxOps...)
+		nsLabels, err := m.CommonPf.Properties.GetJSONMapValue(cloudcommon.NamespaceLabels)
+		if err != nil {
+			return nil, err
+		}
+		err = k8smgmt.SetupIngressNginx(ctx, client, names.GetKConfNames(), m.CommonPf.PlatformConfig.CloudletKey, m.CommonPf.PlatformConfig.ProxyCertsCache, wildcardName, refreshOpts, nsLabels, updateCallback, addonInfo.IngressNginxOps...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/platform/common/managedk8s/mk8s-provider.go
+++ b/pkg/platform/common/managedk8s/mk8s-provider.go
@@ -120,6 +120,7 @@ func (m *ManagedK8sPlatform) GetFeatures() *edgeproto.PlatformFeatures {
 	}
 	features.Properties[cloudcommon.IngressControllerPresent] = cloudcommon.IngressControllerPresentProp
 	features.Properties[cloudcommon.WorkloadManager] = cloudcommon.WorkloadManagerProp
+	features.Properties[cloudcommon.NamespaceLabels] = cloudcommon.NamespaceLabelsProp
 	return features
 }
 

--- a/pkg/platform/common/vmlayer/appinst.go
+++ b/pkg/platform/common/vmlayer/appinst.go
@@ -454,7 +454,8 @@ func (v *VMPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.C
 		if err != nil {
 			return err
 		}
-		err = k8smgmt.CreateAllNamespaces(ctx, client, names)
+		nsLabels := map[string]string{}
+		err = k8smgmt.CreateAllNamespaces(ctx, client, names, nsLabels)
 		if err != nil {
 			return err
 		}
@@ -889,7 +890,8 @@ func (v *VMPlatform) UpdateAppInst(ctx context.Context, clusterInst *edgeproto.C
 			if err != nil {
 				return err
 			}
-			err = k8smgmt.CreateAllNamespaces(ctx, client, names)
+			nsLabels := map[string]string{}
+			err = k8smgmt.CreateAllNamespaces(ctx, client, names, nsLabels)
 			if err != nil {
 				return err
 			}

--- a/pkg/platform/k8s-baremetal/k8sbm-appinst.go
+++ b/pkg/platform/k8s-baremetal/k8sbm-appinst.go
@@ -72,7 +72,8 @@ func (k *K8sBareMetalPlatform) CreateAppInst(ctx context.Context, clusterInst *e
 
 		updateCallback(edgeproto.UpdateTask, "Setting up registry secret")
 		for _, imagePath := range names.ImagePaths {
-			err = k8smgmt.CreateAllNamespaces(ctx, client, names)
+			nsLabels := map[string]string{}
+			err = k8smgmt.CreateAllNamespaces(ctx, client, names, nsLabels)
 			if err != nil {
 				return err
 			}

--- a/pkg/platform/k8ssite/k8ssite-cloudlet.go
+++ b/pkg/platform/k8ssite/k8ssite-cloudlet.go
@@ -70,7 +70,11 @@ func (s *K8sSite) CreateCloudlet(ctx context.Context, cloudlet *edgeproto.Cloudl
 	}
 	hasIngressController, ok := s.CommonPf.Properties.GetValue(cloudcommon.IngressControllerPresent)
 	if !ok || hasIngressController == "" {
-		err = k8smgmt.SetupIngressNginx(ctx, client, kconfNames, &cloudlet.Key, pfInitConfig.ProxyCertsCache, wildcardName, refreshOpts, updateCallback)
+		nsLabels, err := s.CommonPf.Properties.GetJSONMapValue(cloudcommon.NamespaceLabels)
+		if err != nil {
+			return false, err
+		}
+		err = k8smgmt.SetupIngressNginx(ctx, client, kconfNames, &cloudlet.Key, pfInitConfig.ProxyCertsCache, wildcardName, refreshOpts, nsLabels, updateCallback)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/platform/k8ssite/k8ssite-props.go
+++ b/pkg/platform/k8ssite/k8ssite-props.go
@@ -40,6 +40,7 @@ var Props = map[string]*edgeproto.PropertyInfo{
 	cloudcommon.IngressHTTPPort:          cloudcommon.IngressHTTPPortProp,
 	cloudcommon.IngressHTTPSPort:         cloudcommon.IngressHTTPSPortProp,
 	cloudcommon.IngressControllerPresent: cloudcommon.IngressControllerPresentProp,
+	cloudcommon.NamespaceLabels:          cloudcommon.NamespaceLabelsProp,
 }
 
 func (s *K8sSite) InitApiAccessProperties(ctx context.Context, accessApi platform.AccessApi, vars map[string]string) error {


### PR DESCRIPTION
This adds a namespace labels platform property, to allow certain platforms to be configured to add labels to dynamically created namespaces. For example, a k8ssite build using a rancher rke2 comes with default security policies that restrict running as root. For applications that cannot run as non-root, or do not have security contexts to set them to run as non-root, adding annotations to the namespace allows those namespaces to bypass those restrictions. Eventually we should allow users to specify security contexts per AppInst as another way to handle the security policies (see #425).

Here's an example via mcctl using a k3d cluster:
```
export KC=$(k3d kubeconfig get testcluster)
export NSLABELS='{"pod-security.kubernetes.io/audit": "privileged",
  "pod-security.kubernetes.io/enforce": "privileged",
  "pod-security.kubernetes.io/enforce-version": "latest",
  "pod-security.kubernetes.io/warn": "privileged"}'
mcctl --skipverify --addr=https://localhost:9900 cloudlet create region=local \
  cloudlet=k3d cloudletorg=dmuus location.latitude=40 location.longitude=50 \
  zone=k3d numdynamicips=20 platformtype=k8ssite "accessvars=KUBECONFIG=$KC" \
  "envvar=NAMESPACE_LABELS=${NSLABELS}" \
  singlekubernetesclusterowner=AcmeAppCo
```

Result:
```
> kubectl get ns ingress-nginx -o yaml
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{},"creationTimestamp":null,"name":"ingress-nginx"},"spec":{},"status":{}}
  creationTimestamp: "2025-01-30T22:31:04Z"
  labels:
    kubernetes.io/metadata.name: ingress-nginx
    pod-security.kubernetes.io/audit: privileged
    pod-security.kubernetes.io/enforce: privileged
    pod-security.kubernetes.io/enforce-version: latest
    pod-security.kubernetes.io/warn: privileged
  name: ingress-nginx
  resourceVersion: "505"
  uid: e21f0e1b-ecbe-4947-9aff-35d90f8998d8
spec:
  finalizers:
  - kubernetes
status:
  phase: Active
```