### PR TITLE
osm final final fixes

### DIFF
--- a/pkg/k8smgmt/ingress-nginx.go
+++ b/pkg/k8smgmt/ingress-nginx.go
@@ -98,9 +98,13 @@ func InstallIngressNginx(ctx context.Context, client ssh.Client, names *KconfNam
 	for _, op := range ops {
 		op(opts)
 	}
+	// This annotation is needed for ingress to work if deploying
+	// on Azure
+	azureArgs := `--set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path"=/healthz`
+
 	// This specifies a default certificate, which should be a
 	// wildcard cert for the entire cluster/cloudlet.
-	cmd := fmt.Sprintf("helm %s upgrade --install %s %s --repo %s --namespace %s --create-namespace --version %s --set controller.extraArgs.default-ssl-certificate=%s/%s %s", names.KconfArg, IngressNginxName, IngressNginxChart, IngressNginxRepoURL, IngressNginxNamespace, IngressNginxChartVersion, IngressNginxNamespace, IngressDefaultCertSecret, strings.Join(opts.helmSetCmds, " "))
+	cmd := fmt.Sprintf("helm %s upgrade --install %s %s --repo %s --namespace %s --create-namespace --version %s --set controller.extraArgs.default-ssl-certificate=%s/%s %s %s", names.KconfArg, IngressNginxName, IngressNginxChart, IngressNginxRepoURL, IngressNginxNamespace, IngressNginxChartVersion, IngressNginxNamespace, IngressDefaultCertSecret, azureArgs, strings.Join(opts.helmSetCmds, " "))
 	log.SpanLog(ctx, log.DebugLevelInfra, "install ingress nginx", "cmd", cmd)
 	out, err := client.Output(cmd)
 	if err != nil {

--- a/pkg/platform/osmano/osmclient/osm-cluster.go
+++ b/pkg/platform/osmano/osmclient/osm-cluster.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/edgexr/edge-cloud-platform/api/edgeproto"
@@ -137,6 +138,10 @@ func (s *OSMClient) DeleteCluster(ctx context.Context, clusterName string, clust
 	}
 	id, err := s.GetClusterID(ctx, clusterName, clusterInst)
 	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			log.SpanLog(ctx, log.DebugLevelInfra, "cluster not found, skipping delete", "clusterName", clusterName)
+			return nil
+		}
 		return err
 	}
 	resp, err := client.Deletek8sCluster(ctx, id)


### PR DESCRIPTION
Hopefully the last of the OSM-related fixes:
- Ingress on Azure needs a specific annotation to work properly, see https://github.com/kubernetes/ingress-nginx/issues/9601
- Use the "description" field of the OSM App definition (OKA) to track whether the app definition needs to be updated, due to the App definition being updated or the App being deleted and recreated.
- In case of cluster delete where the underlying OSM cluster has already been deleted, do not generate an error.
