### PR TITLE
Update AppInstInfo to keep it in sync with AppInst

### DIFF
--- a/pkg/controller/appinst_api.go
+++ b/pkg/controller/appinst_api.go
@@ -2547,7 +2547,7 @@ func (s *AppInstApi) updateURI(key *edgeproto.AppInstKey, cloudlet *edgeproto.Cl
 		}
 
 		// Store previous URI, so we can update this with CCRM
-		log.SpanLog(ctx, log.DebugLevelApi, "Updating AppInst URI", "old FQDN", appInst.Uri, "new", getAppInstFQDN(&appInst, cloudlet))
+		log.SpanLog(ctx, log.DebugLevelApi, "Updating AppInst URI", "old FQDN", appInst.Uri, "new", newURI)
 		appInst.AddAnnotation(cloudcommon.AnnotationPreviousDNSName, appInst.Uri)
 		appInst.Uri = newURI
 		appInst.UpdatedAt = dme.TimeToTimestamp(time.Now())

--- a/pkg/crmutil/controller-data.go
+++ b/pkg/crmutil/controller-data.go
@@ -384,6 +384,11 @@ func (cd *CRMHandler) appInstDNSChanged(ctx context.Context, pf platform.Platfor
 		return err
 	}
 	log.SpanLog(ctx, log.DebugLevelInfra, "AppInstDNSChanged done", "key", new.Key, "old dns", oldURI, "new dns", new.Uri)
+	sender.SendUpdate(func(info *edgeproto.AppInstInfo) error {
+		info.Fields = []string{edgeproto.AppInstInfoFieldUri}
+		info.Uri = new.Uri
+		return nil
+	})
 	sender.SendState(edgeproto.TrackedState_READY)
 	return nil
 }
@@ -419,7 +424,7 @@ func (cd *CRMHandler) AppInstChanged(ctx context.Context, target *edgeproto.Clou
 	// Special case for dns update
 	if dnsUpdate {
 		_ = cd.appInstDNSChanged(ctx, pf, &app, oldURI, new, sender)
-		return
+		return nu, nil
 	}
 
 	trackChange := app.Deployment == cloudcommon.DeploymentTypeVM || platform.TrackK8sAppInst(ctx, &app, pf.GetFeatures())


### PR DESCRIPTION
### Issues Fixed

https://github.com/edgexr/edge-cloud-platform/issues/433

### Description

When we update appinst uri on the crm side, we didn't update appinst info, so when appinst info gets refreshed from crm, the dns entry gets overwritten in etcd.
Added an explicit update to appinst info as part of the uri update handler.
Also fixed couple other minor issues.