### PR TITLE
Fix pod labels issue in kube-state-metrics

### DIFF
--- a/pkg/cluster-svc/cluster-svc.go
+++ b/pkg/cluster-svc/cluster-svc.go
@@ -91,6 +91,9 @@ defaultRules:
     prometheus: true
     prometheusOperator: true
     time: true
+kube-state-metrics:
+  extraArgs:
+    - --metric-labels-allowlist=pods=[*]
 grafana:
   enabled: false
 alertmanager:


### PR DESCRIPTION
### Issues Fixed

`kube-state-metrics` pod, which is responsible for exporting `kube_pod_labels` metric is not including pod labels as attributes while exporting metrics.

### Description

### Root Cause: 

kube-state-metrics v2.x has a breaking change which stopped these label attributes from getting attached to `kube_pod_labels` metric.

### Fix
`--metric-labels-allowlist` is an argument to `kube-state-metrics` container which takes in configuration for which labels to be allowed for including into `kube_pod_labels` metric as attributes.
