### PR TITLE
Add Flavor label

### DIFF
--- a/pkg/k8smgmt/cluster.go
+++ b/pkg/k8smgmt/cluster.go
@@ -531,3 +531,14 @@ func WaitNodesReady(ctx context.Context, client ssh.Client, clusterInst *edgepro
 	log.SpanLog(ctx, log.DebugLevelInfra, "wait nodes ready timed out", "cluster", clusterInst.Key)
 	return fmt.Errorf("timed out waiting for %s nodes to be ready", clusterInst.Key.GetKeyString())
 }
+
+// SetNodeLabels Create a function to set node labels
+func SetNodeLabels(ctx context.Context, client ssh.Client, kconfArg string, nodeName string, labelKey string, labelVal string) error {
+	cmd := fmt.Sprintf("kubectl %s label node %s %s=%s --overwrite", kconfArg, nodeName, labelKey, labelVal)
+	log.SpanLog(ctx, log.DebugLevelInfra, "k8smgmt set node labels", "node", nodeName, "labelKey", labelKey, "labelVal", labelVal, "cmd", cmd)
+	out, err := client.Output(cmd)
+	if err != nil {
+		return fmt.Errorf("failed to set node labels, %s, %s, %v", cmd, out, err)
+	}
+	return nil
+}


### PR DESCRIPTION
* Adds flavor label to each node
* Fixes fetching of master node using `node-role.kubernetes.io/control-plane` label

Description:

This Merge request is a good to have feature and adds a label related to flavor which can be used for further monitoring and observability. 
