### PR TITLE
support ingress lb hostname and aws tag

### DIFF
--- a/pkg/k8smgmt/ingress-nginx.go
+++ b/pkg/k8smgmt/ingress-nginx.go
@@ -102,7 +102,9 @@ func InstallIngressNginx(ctx context.Context, client ssh.Client, names *KconfNam
 	}
 	// This annotation is needed for ingress to work if deploying
 	// on Azure
-	azureArgs := `--set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path"=/healthz`
+	extraArgs := `--set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path"=/healthz`
+	// AWS annotation for LB to get external IP
+	extraArgs += ` --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-scheme"=internet-facing`
 	if os.Getenv("E2ETEST_TLS") != "" {
 		// for e2e tests, change the status update interval from 60s
 		// default to 2s, this avoids a 60s wait for the external IP check.
@@ -111,7 +113,7 @@ func InstallIngressNginx(ctx context.Context, client ssh.Client, names *KconfNam
 
 	// This specifies a default certificate, which should be a
 	// wildcard cert for the entire cluster/cloudlet.
-	cmd := fmt.Sprintf("helm %s upgrade --install %s %s --repo %s --namespace %s --create-namespace --version %s --set controller.extraArgs.default-ssl-certificate=%s/%s %s %s", names.KconfArg, IngressNginxName, IngressNginxChart, IngressNginxRepoURL, IngressNginxNamespace, IngressNginxChartVersion, IngressNginxNamespace, IngressDefaultCertSecret, azureArgs, strings.Join(opts.helmSetCmds, " "))
+	cmd := fmt.Sprintf("helm %s upgrade --install %s %s --repo %s --namespace %s --create-namespace --version %s --set controller.extraArgs.default-ssl-certificate=%s/%s %s %s", names.KconfArg, IngressNginxName, IngressNginxChart, IngressNginxRepoURL, IngressNginxNamespace, IngressNginxChartVersion, IngressNginxNamespace, IngressDefaultCertSecret, extraArgs, strings.Join(opts.helmSetCmds, " "))
 	log.SpanLog(ctx, log.DebugLevelInfra, "install ingress nginx", "cmd", cmd)
 	out, err := client.Output(cmd)
 	if err != nil {

--- a/pkg/k8smgmt/ingress.go
+++ b/pkg/k8smgmt/ingress.go
@@ -213,7 +213,7 @@ func GetIngresses(ctx context.Context, client ssh.Client, names *KconfNames, ops
 	return data.Items, nil
 }
 
-func GetIngressExternalIP(ctx context.Context, client ssh.Client, names *KubeNames, name string) (string, error) {
+func GetIngressExternalIP(ctx context.Context, client ssh.Client, names *KubeNames, name string) (string, string, error) {
 	log.SpanLog(ctx, log.DebugLevelInfra, "get ingress IP", "kconf", names.KconfName)
 	for i := 0; i < IngressExternalIPRetries; i++ {
 		ingress := &networkingv1.Ingress{}
@@ -224,14 +224,17 @@ func GetIngressExternalIP(ctx context.Context, client ssh.Client, names *KubeNam
 				time.Sleep(IngressExternalIPRetry)
 				continue
 			}
-			return "", err
+			return "", "", err
 		}
 		if len(ingress.Status.LoadBalancer.Ingress) > 0 {
-			if ingress.Status.LoadBalancer.Ingress[0].IP != "" {
-				return ingress.Status.LoadBalancer.Ingress[0].IP, nil
+			ingressStatus := ingress.Status.LoadBalancer.Ingress[0]
+			ip := ingressStatus.IP
+			hostname := ingressStatus.Hostname
+			if ip != "" || hostname != "" {
+				return ip, hostname, nil
 			}
 		}
 		time.Sleep(IngressExternalIPRetry)
 	}
-	return "", fmt.Errorf("unable to get external IP for ingress %s", name)
+	return "", "", fmt.Errorf("unable to get external IP for ingress %s", name)
 }

--- a/pkg/k8spm/k8spm.go
+++ b/pkg/k8spm/k8spm.go
@@ -154,12 +154,15 @@ func (m *K8sPlatformMgr) CreateAppInst(ctx context.Context, clusterInst *edgepro
 		// set the IP address on the ingress object, so the operator
 		// will need to specify the IP address for the ingress.
 		ip, found := m.commonPf.Properties.GetValue(cloudcommon.IngressIPV4)
+		var hostname string
 		if !found || ip == "" {
-			ip, err = k8smgmt.GetIngressExternalIP(ctx, client, names, ingress.ObjectMeta.Name)
+			ip, hostname, err = k8smgmt.GetIngressExternalIP(ctx, client, names, ingress.ObjectMeta.Name)
 			if err != nil {
 				return err
 			}
-			ip = m.commonPf.GetMappedExternalIP(ip)
+			if ip != "" {
+				ip = m.commonPf.GetMappedExternalIP(ip)
+			}
 		}
 		// register DNS for ingress
 		// note that we do not register DNS based on the presence of
@@ -168,9 +171,10 @@ func (m *K8sPlatformMgr) CreateAppInst(ctx context.Context, clusterInst *edgepro
 		// won't be using our host names.
 		action := infracommon.DnsSvcAction{
 			ExternalIP: ip,
+			Hostname:   hostname,
 		}
 		fqdns := m.getFQDNs(appInst, names)
-		log.SpanLog(ctx, log.DebugLevelInfra, "registering ingress DNS", "ip", action.ExternalIP, "fqdns", fqdns)
+		log.SpanLog(ctx, log.DebugLevelInfra, "registering ingress DNS", "ip", action.ExternalIP, "hostname", action.Hostname, "fqdns", fqdns)
 		for _, fqdn := range fqdns {
 			if err := m.commonPf.AddDNS(ctx, fqdn, &action); err != nil {
 				return err


### PR DESCRIPTION
Ingress was missing support for external address set as hostname instead of IP. Also add AWS tag required for external access to load balancer.